### PR TITLE
Issue #1 Maven publishing using maven plugin

### DIFF
--- a/107/gradle.properties
+++ b/107/gradle.properties
@@ -1,0 +1,2 @@
+subPomName = Ehcache 3 JSR-107 module
+subPomDesc = The JSR-107 compatibility module of Ehcache 3

--- a/api/gradle.properties
+++ b/api/gradle.properties
@@ -1,0 +1,2 @@
+subPomName = Ehcache 3 API module
+subPomDesc = The API module of Ehcache 3

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 subprojects {
   apply plugin: 'java'
-  apply plugin: 'maven-publish'
+  apply plugin: 'maven'
+  apply plugin: 'signing'
 
   group = 'org.ehcache.modules'
   version = '3.0.0-SNAPSHOT'
+
+  ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 
   archivesBaseName = "ehcache-${project.name}"
 
@@ -26,32 +29,79 @@ subprojects {
             'Built-JDK': System.getProperty('java.version'),
             'Build-Time': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
     )
-    archiveName = "ehcache-${baseName}-${version}.${extension}"
   }
 
   task sourceJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allJava
+    classifier = 'sources'
   }
 
   task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
+    classifier = 'javadoc'
   }
 
-  publishing {
-    publications {
-      mavenJava(MavenPublication) {
+  artifacts {
+    archives jar
 
-        artifactId archivesBaseName
+    archives javadocJar
+    archives sourceJar
+  }
 
-        from components.java
+  signing {
+    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives")}
+    sign configurations.archives
+  }
 
-        artifact sourceJar {
-          classifier 'sources'
+  def pomFiller = {
+    name project.subPomName
+    description project.subPomDesc
+    url 'http://ehcache.org'
+    organization {
+      name 'Terraccotta'
+      url 'http://terracotta.org'
+    }
+    issueManagement {
+      system 'Github'
+      url 'https://github.com/ehcache/ehcache3/issues'
+    }
+    scm {
+      url 'https://github.com/ehcache/ehcache3'
+      connection 'scm:git:https://github.com/ehcache/ehcache3.git'
+      developerConnection 'scm:git:git@github.com:ehcache/ehcache3.git'
+    }
+    licenses {
+      license {
+        name 'The Apache Software License, Version 2.0'
+        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        distribution 'repo'
+      }
+    }
+  }
+
+  install {
+    repositories.mavenInstaller {
+      pom.project pomFiller
+    }
+  }
+
+  uploadArchives {
+    repositories {
+      mavenDeployer {
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment)}
+
+        if (isReleaseVersion) {
+          repository(id: 'sonatype-nexus-staging', url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+            authentication(userName: sonatypeUser, password: sonatypePwd)
+          }
+        } else {
+          repository(id: 'sonatype-nexus-snapshot', url: 'https://oss.sonatype.org/content/repositories/snapshots') {
+            authentication(userName: sonatypeUser, password: sonatypePwd)
+          }
         }
 
-        artifact javadocJar {
-          classifier 'javadoc'
-        }
+        pom.project pomFiller
+
       }
     }
   }

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,0 +1,2 @@
+subPomName = Ehcache 3 Core module
+subPomDesc = The Core module of Ehcache 3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+sonatypeUser = OVERRIDE_ME
+sonatypePwd = OVERRIDE_ME

--- a/impl/gradle.properties
+++ b/impl/gradle.properties
@@ -1,0 +1,2 @@
+subPomName = Ehcache 3 Implementation module
+subPomDesc = The implementation module of Ehcache 3


### PR DESCRIPTION
- Replace maven-publish plugin with maven plugin as signing does not seem to be supported in the former
  - `gradlew install` is back for local maven deploy
  - Publishing to sonatype requires `sonatypeUser` and `sonatypePwd` to be overidden on command line or in `~/.gradle/gradle.properties`
- Resolves #11
- Fixed missing property issue
