### PR TITLE
Issue #114 State transition to MAINTENANCE fixes

### DIFF
--- a/core/src/main/java/org/ehcache/StatusTransitioner.java
+++ b/core/src/main/java/org/ehcache/StatusTransitioner.java
@@ -46,7 +46,7 @@ final class StatusTransitioner {
 
   void checkAvailable() {
     final Status status = currentStatus();
-    if(status == Status.MAINTENANCE && Thread.currentThread() == maintenanceLease) {
+    if(status == Status.MAINTENANCE && Thread.currentThread() != maintenanceLease) {
       throw new IllegalStateException("State is " + status + ", yet you don't own it!");
     } else if(status == Status.UNINITIALIZED) {
       throw new IllegalStateException("State is " + status);
@@ -55,10 +55,10 @@ final class StatusTransitioner {
 
   void checkMaintenance() {
     final Status status = currentStatus();
-    if(status != Status.MAINTENANCE) {
-      throw new IllegalStateException("State is " + status);
-    } else if(Thread.currentThread() != maintenanceLease) {
+    if(status == Status.MAINTENANCE && Thread.currentThread() != maintenanceLease) {
       throw new IllegalStateException("State is " + status + ", yet you don't own it!");
+    } else if (status != Status.MAINTENANCE) {
+      throw new IllegalStateException("State is " + status);
     }
   }
 

--- a/core/src/test/java/org/ehcache/StatusTransitionerTest.java
+++ b/core/src/test/java/org/ehcache/StatusTransitionerTest.java
@@ -113,4 +113,26 @@ public class StatusTransitionerTest {
     transitioner.close();
   }
 
+  @Test
+  public void testCheckAvailableAccountsForThreadLease() throws InterruptedException {
+    final StatusTransitioner transitioner = new StatusTransitioner();
+    transitioner.maintenance().succeeded();
+    transitioner.checkAvailable();
+    Thread thread = new Thread() {
+      @Override
+      public void run() {
+        try {
+          transitioner.checkAvailable();
+          fail();
+        } catch (IllegalStateException e) {
+          assertThat(e.getMessage().contains(Status.MAINTENANCE.name()), is(true));
+          assertThat(e.getMessage().contains("own"), is(true));
+        }
+      }
+    };
+    thread.start();
+    thread.join();
+    transitioner.close();
+  }
+
 }


### PR DESCRIPTION
There were three issues in the `StatusTransitioner`:
- It was throwing `IllegalStateException` on `checkMaintenance` when you actually owned the lease
- It was throwing `IllegalStateException` on `checkAvailable` when you actually owned the lease
- When in `MAINTENANCE` it would transition to `UNINITIALIZE` on `close()`, prior to checking if you owned the lease
