### PR TITLE
make compute methods return sane/expected values

### DIFF
--- a/core/src/main/java/org/ehcache/spi/cache/Store.java
+++ b/core/src/main/java/org/ehcache/spi/cache/Store.java
@@ -235,7 +235,7 @@ public interface Store<K, V> {
    *        with the key and existing value (or null if no entry exists) as parameters. The function should
    *        return the desired new value for the entry or null to remove the entry. If the method throws
    *        an unchecked exception the Store will not be modified (the caller will receive the exception)
-   * @return the new value associated with the key or null if none
+   * @return the old value associated with the key or null if none
    * @throws ClassCastException If the specified key is not of the correct type ({@code K}) or if the
    *         function returns a value that is not of type ({@code V})
    * @throws CacheAccessException
@@ -267,7 +267,7 @@ public interface Store<K, V> {
    *        with the key and existing value as parameters. The function should
    *        return the desired new value for the entry or null to remove the entry. If the method throws
    *        an unchecked exception the Store will not be modified (the caller will receive the exception)
-   * @return the new value associated with the key or null if none
+   * @return the old value associated with the key or null if none
    * @throws ClassCastException If the specified key is not of the correct type ({@code K}) or if the
    *         function returns a value that is not of type ({@code V})
    * @throws CacheAccessException

--- a/impl/src/test/java/org/ehcache/internal/store/OnHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/OnHeapStoreTest.java
@@ -313,7 +313,7 @@ public class OnHeapStoreTest {
   public void testCompute() throws Exception {
     OnHeapStore<String, String> store = newStore();
 
-    store.compute("key", new BiFunction<String, String, String>() {
+    ValueHolder<String> prev = store.compute("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         assertThat(mappedKey, equalTo("key"));
@@ -322,6 +322,7 @@ public class OnHeapStoreTest {
       }
     });
 
+    assertThat(prev, nullValue());
     assertThat(store.get("key").value(), equalTo("value"));
   }
 
@@ -329,22 +330,24 @@ public class OnHeapStoreTest {
   public void testComputeNull() throws Exception {
     OnHeapStore<String, String> store = newStore();
 
-    store.compute("key", new BiFunction<String, String, String>() {
+    ValueHolder<String> prev = store.compute("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         return null;
       }
     });
+    assertThat(prev, nullValue());
     assertThat(store.get("key"), nullValue());
 
     store.put("key", "value");
     assertThat(store.get("key").value(), equalTo("value"));
-    store.compute("key", new BiFunction<String, String, String>() {
+    prev = store.compute("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         return null;
       }
     });
+    assertThat(prev.value(), equalTo("value"));
     assertThat(store.get("key"), nullValue());
   }
 
@@ -372,7 +375,7 @@ public class OnHeapStoreTest {
     OnHeapStore<String, String> store = newStore();
 
     store.put("key", "value");
-    store.compute("key", new BiFunction<String, String, String>() {
+    ValueHolder<String> prev = store.compute("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         assertThat(mappedKey, equalTo("key"));
@@ -381,6 +384,7 @@ public class OnHeapStoreTest {
       }
     });
 
+    assertThat(prev.value(), equalTo("value"));
     assertThat(store.get("key").value(), equalTo("value2"));
   }
 
@@ -391,7 +395,7 @@ public class OnHeapStoreTest {
         Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS)));
     store.put("key", "value");
     timeSource.advanceTime(1);
-    store.compute("key", new BiFunction<String, String, String>() {
+    ValueHolder<String> prev = store.compute("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         assertThat(mappedKey, equalTo("key"));
@@ -400,6 +404,7 @@ public class OnHeapStoreTest {
       }
     });
 
+    assertThat(prev, nullValue());
     assertThat(store.get("key").value(), equalTo("value2"));
   }
 
@@ -407,7 +412,7 @@ public class OnHeapStoreTest {
   public void testComputeIfAbsent() throws Exception {
     OnHeapStore<String, String> store = newStore();
 
-    store.computeIfAbsent("key", new Function<String, String>() {
+    ValueHolder<String> newValue = store.computeIfAbsent("key", new Function<String, String>() {
       @Override
       public String apply(String mappedKey) {
         assertThat(mappedKey, equalTo("key"));
@@ -415,6 +420,7 @@ public class OnHeapStoreTest {
       }
     });
 
+    assertThat(newValue.value(), equalTo("value"));
     assertThat(store.get("key").value(), equalTo("value"));
   }
 
@@ -437,13 +443,14 @@ public class OnHeapStoreTest {
   public void testComputeIfAbsentReturnNull() throws Exception {
     OnHeapStore<String, String> store = newStore();
 
-    store.computeIfAbsent("key", new Function<String, String>() {
+    ValueHolder<String> newValue = store.computeIfAbsent("key", new Function<String, String>() {
       @Override
       public String apply(String mappedKey) {
         return null;
       }
     });
 
+    assertThat(newValue, nullValue());
     assertThat(store.get("key"), nullValue());
   }
 
@@ -474,7 +481,7 @@ public class OnHeapStoreTest {
     store.put("key", "value");
     timeSource.advanceTime(1);
 
-    store.computeIfAbsent("key", new Function<String, String>() {
+    ValueHolder<String> newValue = store.computeIfAbsent("key", new Function<String, String>() {
       @Override
       public String apply(String mappedKey) {
         assertThat(mappedKey, equalTo("key"));
@@ -482,6 +489,7 @@ public class OnHeapStoreTest {
       }
     });
 
+    assertThat(newValue.value(), equalTo("value2"));
     assertThat(store.get("key").value(), equalTo("value2"));
   }
 
@@ -544,7 +552,7 @@ public class OnHeapStoreTest {
     OnHeapStore<String, String> store = newStore();
 
     store.put("key", "value");
-    store.computeIfPresent("key", new BiFunction<String, String, String>() {
+    ValueHolder<String> prev = store.computeIfPresent("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         assertThat(mappedKey, equalTo("key"));
@@ -553,6 +561,7 @@ public class OnHeapStoreTest {
       }
     });
 
+    assertThat(prev.value(), equalTo("value"));
     assertThat(store.get("key").value(), equalTo("value2"));
   }
 
@@ -573,13 +582,14 @@ public class OnHeapStoreTest {
     OnHeapStore<String, String> store = newStore();
 
     store.put("key", "value");
-    store.computeIfPresent("key", new BiFunction<String, String, String>() {
+    ValueHolder<String> prev = store.computeIfPresent("key", new BiFunction<String, String, String>() {
       @Override
       public String apply(String mappedKey, String mappedValue) {
         return null;
       }
     });
 
+    assertThat(prev.value(), equalTo("value"));
     assertThat(store.get("key"), nullValue());
   }
 
@@ -618,7 +628,7 @@ public class OnHeapStoreTest {
         throw new AssertionError();
       }
     });
-
+    
     assertThat(store.get("key"), nullValue());
   }
 


### PR DESCRIPTION
At least one bit of code (Ehcache.putIfAbsent()) was using the contract of one of these methods expecting the old value. 

Still not quite sure what Store.computeIfAbsent() should return? Perhaps void? 
