### PR TITLE
Cache.remove(K) should always invoke the CacheWriter (even if no entry exists in the cache)

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -254,7 +254,7 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
     });
 
     try {
-      store.computeIfPresent(key, remappingFunction);
+      store.compute(key, remappingFunction);
       removeObserver.end(RemoveOutcome.SUCCESS);
     } catch (CacheAccessException e) {
       removeObserver.end(RemoveOutcome.FAILURE);

--- a/core/src/test/java/org/ehcache/EhcacheWriterLoaderTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheWriterLoaderTest.java
@@ -135,7 +135,7 @@ public class EhcacheWriterLoaderTest {
   
   @Test
   public void testRemove() throws Exception {
-    when(store.computeIfPresent(any(Number.class), anyBiFunction())).thenAnswer(new Answer<Object>() {
+    when(store.compute(any(Number.class), anyBiFunction())).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         BiFunction<Number, String, String> function = asBiFunction(invocation);
@@ -149,7 +149,7 @@ public class EhcacheWriterLoaderTest {
 
   @Test
   public void testRemoveThrowsOnCompute() throws Exception {
-    when(store.computeIfPresent(any(Number.class), anyBiFunction())).thenThrow(new CacheAccessException("boom"));
+    when(store.compute(any(Number.class), anyBiFunction())).thenThrow(new CacheAccessException("boom"));
     cache.remove(1);
     verify(store).remove(1);
     verify(cache.getCacheWriter()).delete(1);
@@ -157,7 +157,7 @@ public class EhcacheWriterLoaderTest {
   
   @Test(expected=CacheWriterException.class)
   public void testRemoveThrowsOnWrite() throws Exception {
-    when(store.computeIfPresent(any(Number.class), anyBiFunction())).thenAnswer(new Answer<Object>() {
+    when(store.compute(any(Number.class), anyBiFunction())).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         BiFunction<Number, String, String> function = asBiFunction(invocation);


### PR DESCRIPTION
In the words of christall:
"absence of a cache entry should not be used to veto a write"
