### PR TITLE
Issue #184 - Correct behavior of repeated Iterator.remove() calls

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -1136,7 +1136,11 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
     @Override
     public void remove() {
       statusTransitioner.checkAvailable();
+      if (current == null) {
+        throw new IllegalStateException("No current element");
+      }
       Ehcache.this.remove(current.getKey(), current.getValue().value());
+      current = null;
     }
   }
 


### PR DESCRIPTION
This change addresses both repeated calls to remove() and remove() called before next().
