### PR TITLE
Some small fixes (certainly can go after alpha) 

### DIFF
--- a/107/src/main/java/org/ehcache/EhcacheHackAccessor.java
+++ b/107/src/main/java/org/ehcache/EhcacheHackAccessor.java
@@ -34,5 +34,9 @@ public final class EhcacheHackAccessor {
   public static <K, V> CacheWriter<? super K, ? super V> getCacheWriter(Ehcache<K, V> ehcache) {
     return ehcache.getCacheWriter();
   }
+  
+  public static <K, V> Jsr107Cache<K, V> getJsr107Cache(Ehcache<K, V> ehcache) {
+    return ehcache.getJsr107Cache();
+  }
 
 }

--- a/107/src/main/java/org/ehcache/jsr107/CacheResources.java
+++ b/107/src/main/java/org/ehcache/jsr107/CacheResources.java
@@ -30,7 +30,6 @@ import javax.cache.configuration.Factory;
 import javax.cache.event.CacheEntryEventFilter;
 import javax.cache.event.CacheEntryListener;
 
-import org.ehcache.config.CacheConfiguration;
 import org.ehcache.jsr107.EventListenerAdaptors.EventListenerAdaptor;
 import org.ehcache.spi.loader.CacheLoader;
 import org.ehcache.spi.writer.CacheWriter;
@@ -41,7 +40,7 @@ import org.ehcache.spi.writer.CacheWriter;
 class CacheResources<K, V> {
 
   private final Eh107Expiry<K, V> expiryPolicy;
-  private final CacheLoader<K, V> cacheLoader;
+  private final CacheLoader<? super K, ? extends V> cacheLoader;
   private final CacheWriter<? super K, ? super V> cacheWriter;
   private final Map<CacheEntryListenerConfiguration<K, V>, ListenerResources<K, V>> listenerResources = new ConcurrentHashMap<CacheEntryListenerConfiguration<K, V>, ListenerResources<K, V>>();
   private final AtomicBoolean closed = new AtomicBoolean();
@@ -71,7 +70,7 @@ class CacheResources<K, V> {
 
   CacheResources(String cacheName, CacheLoader<? super K, ? extends V> cacheLoader, CacheWriter<? super K, ? super V> cacheWriter, Eh107Expiry<K, V> expiry) {
     this.cacheName = cacheName;
-    this.cacheLoader = (CacheLoader<K, V>)cacheLoader;
+    this.cacheLoader = cacheLoader;
     this.cacheWriter = cacheWriter;
     this.expiryPolicy = expiry;
   }
@@ -90,7 +89,7 @@ class CacheResources<K, V> {
     return expiryPolicy;
   }
 
-  CacheLoader<K, V> getCacheLoader() {
+  CacheLoader<? super K, ? extends V> getCacheLoader() {
     return cacheLoader;
   }
 

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
@@ -30,7 +30,6 @@ import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.Configuration;
-import javax.cache.configuration.MutableConfiguration;
 import javax.cache.spi.CachingProvider;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
@@ -40,7 +39,6 @@ import org.ehcache.Ehcache;
 import org.ehcache.EhcacheHackAccessor;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.CacheConfigurationBuilder;
-import org.ehcache.internal.serialization.JavaSerializationProvider;
 import org.ehcache.internal.store.service.OnHeapStoreServiceConfig;
 import org.ehcache.spi.loader.CacheLoader;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -218,7 +216,7 @@ class Eh107CacheManager implements CacheManager {
     // This code is a little weird. In particular that it doesn't
     // complain if you have config.isReadThrough() true and a null
     // loader -- see https://github.com/jsr107/jsr107tck/issues/59
-    CacheLoader<K, V> cacheLoader = cacheResources.getCacheLoader();
+    CacheLoader<? super K, ? extends V> cacheLoader = cacheResources.getCacheLoader();
     if (cacheLoader != null && jsr107Config.isReadThrough()) {
       cacheLoaderFactory.registerJsr107Loader(cacheName, cacheLoader);
     }

--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -1099,7 +1099,7 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
 
   private final class Jsr107CacheImpl implements Jsr107Cache<K, V> {
     @Override
-    public void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+    public void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<? super K, ? extends V>> loadFunction) {
       if (replaceExistingValues) {
         loadAllReplace(keys, loadFunction);
       } else {
@@ -1112,7 +1112,7 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
       return Ehcache.this.getAllInternal(keys, false);
     }
 
-    private void loadAllAbsent(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+    private void loadAllAbsent(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<? super K, ? extends V>> loadFunction) {
       try {
         store.bulkComputeIfAbsent(keys, new Function<Iterable<? extends K>, Iterable<? extends Map.Entry<? extends K, ? extends V>>>() {
           @Override
@@ -1125,9 +1125,9 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
       }
     }
 
-    Map<K, V> cacheLoaderLoadAllForKeys(Iterable<? extends K> keys, Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+    Map<K, V> cacheLoaderLoadAllForKeys(Iterable<? extends K> keys, Function<Iterable<? extends K>, Map<? super K, ? extends V>> loadFunction) {
       try {
-        Map<K, V> loaded = loadFunction.apply(keys);
+        Map<? super K, ? extends V> loaded = loadFunction.apply(keys);
         
         // put into a new map since we can't assume the 107 cache loader returns things ordered, or necessarily with all the desired keys
         Map<K, V> rv = new LinkedHashMap<K, V>();
@@ -1140,7 +1140,7 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
       }
     }
 
-    private void loadAllReplace(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+    private void loadAllReplace(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<? super K, ? extends V>> loadFunction) {
       try {
         store.bulkCompute(keys, new Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>>() {
           @Override

--- a/core/src/main/java/org/ehcache/Jsr107Cache.java
+++ b/core/src/main/java/org/ehcache/Jsr107Cache.java
@@ -39,5 +39,5 @@ public interface Jsr107Cache<K, V> {
       NullaryFunction<Boolean> replaceEqual, final NullaryFunction<Boolean> invokeWriter,
       final NullaryFunction<Boolean> withStatsAndEvents);
   
-  void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<K, V>> loadFunction);
+  void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<? super K, ? extends V>> function);
 }


### PR DESCRIPTION
- Use hack accessor for getting jsr107 interface (instead of reflection)
- clean up (I think) generics on CacheLoader from 107
