### PR TITLE
issue #196 issue #195 fixed issues and tests

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -189,7 +189,6 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
                 cacheLoaderObserver.begin();
                 loaded = cacheLoader.load(k);
                 cacheLoaderObserver.end(CacheLoaderOutcome.SUCCESS);
-                getObserver.end(loaded != null ? GetOutcome.HIT_WITH_LOADER : GetOutcome.MISS_WITH_LOADER);
               }
             } catch (Exception e) {
               cacheLoaderObserver.end(CacheLoaderOutcome.FAILURE);
@@ -205,14 +204,10 @@ public class Ehcache<K, V> implements Cache<K, V>, StandaloneCache<K, V>, Persis
       
       // Check for expiry first
       if (valueHolder == null) {
-        if (cacheLoader == null) {
-          getObserver.end(GetOutcome.MISS_NO_LOADER);
-        }
+        getObserver.end(cacheLoader == null ? GetOutcome.MISS_NO_LOADER : GetOutcome.MISS_WITH_LOADER);
         return null;
       } else {
-        if (cacheLoader == null) {
-          getObserver.end(GetOutcome.HIT_NO_LOADER);
-        }
+        getObserver.end(cacheLoader == null ? GetOutcome.HIT_NO_LOADER : GetOutcome.HIT_WITH_LOADER);
         return valueHolder.value();
       }
     } catch (CacheAccessException e) {

--- a/core/src/test/java/org/ehcache/EhcacheBasicGetTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicGetTest.java
@@ -199,8 +199,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.store).computeIfAbsent(eq("key"), getAnyFunction());
     verify(this.cacheLoader).load(eq("key"));
     verify(this.spiedResilienceStrategy).getFailure(eq("key"), isNull(String.class), any(CacheAccessException.class));
-    validateStats(ehcache,
-        EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER, CacheOperationOutcomes.GetOutcome.FAILURE));   // TODO: Confirm correctness - Issue #195
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.FAILURE));
     validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.CacheLoaderOutcome.SUCCESS));
   }
 
@@ -225,8 +224,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.store).computeIfAbsent(eq("key"), getAnyFunction());
     verify(this.cacheLoader).load(eq("key"));
     verify(this.spiedResilienceStrategy).getFailure(eq("key"), eq("value"), any(CacheAccessException.class));
-    validateStats(ehcache,
-        EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER, CacheOperationOutcomes.GetOutcome.FAILURE));    // TODO: Confirm correctness - Issue #195
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.FAILURE));
     validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.CacheLoaderOutcome.SUCCESS));
   }
 
@@ -303,7 +301,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoader, never()).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.GetOutcome.class));    // TODO: Confirm correctness - Issue #196
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoaderOutcome.class));
   }
 
@@ -328,7 +326,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoader, never()).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.GetOutcome.class));    // TODO: Confirm correctness - Issue #196
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoaderOutcome.class));
   }
 
@@ -353,7 +351,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoader, never()).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.GetOutcome.class));    // TODO: Confirm correctness - Issue #196
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoaderOutcome.class));
   }
 
@@ -402,8 +400,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.store).computeIfAbsent(eq("key"), getAnyFunction());
     verify(this.cacheLoader).load(eq("key"));
     verify(this.spiedResilienceStrategy).getFailure(eq("key"), isNull(String.class), any(CacheAccessException.class));
-    validateStats(ehcache,
-        EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER, CacheOperationOutcomes.GetOutcome.FAILURE));   // TODO: Confirm correctness - Issue #195
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.FAILURE));
     validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.CacheLoaderOutcome.SUCCESS));
   }
 
@@ -429,8 +426,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.store).computeIfAbsent(eq("key"), getAnyFunction());
     verify(this.cacheLoader).load(eq("key"));
     verify(this.spiedResilienceStrategy).getFailure(eq("key"), eq("value"), any(CacheAccessException.class));
-    validateStats(ehcache,
-        EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER, CacheOperationOutcomes.GetOutcome.FAILURE));    // TODO: Confirm correctness - Issue #195
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.FAILURE));
     validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.CacheLoaderOutcome.SUCCESS));
   }
 


### PR DESCRIPTION
Having the get() Function handling the statistics counting for GetOutcome results is problematic because the Function is (should be) agnostic of the logic of the get() function, thus resulting in faulty counting behaviours.
By moving the GetOutcome counting back to the get() method, the counting is now handled correctly according to the result of the get() method.
