### PR TITLE
Issue #245 Ignore keys returned from CacheLoader.loadAll

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107Cache.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107Cache.java
@@ -130,11 +130,16 @@ class Eh107Cache<K, V> implements Cache<K, V> {
     }
 
     try {
-      jsr107Cache.loadAll(keys, replaceExistingValues, new Function<Iterable<? extends K>, Map<? super K, ? extends V>>() {
+      jsr107Cache.loadAll(keys, replaceExistingValues, new Function<Iterable<? extends K>, Map<K, V>>() {
         @Override
-        public Map<? super K, ? extends V> apply(Iterable<? extends K> keys) {
+        public Map<K, V> apply(Iterable<? extends K> keys) {
           try {
-            return cacheLoaderWriter.loadAll(keys);
+            Map<? super K, ? extends V> loadResult = cacheLoaderWriter.loadAll(keys);
+            HashMap<K, V> resultMap = new HashMap<K, V>();
+            for (K key : keys) {
+              resultMap.put(key, loadResult.get(key));
+            }
+            return resultMap;
           } catch (Exception e) {
             final CacheLoaderException cle;
             if (e instanceof CacheLoaderException) {

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/CacheLoaderWriter.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/CacheLoaderWriter.java
@@ -49,9 +49,10 @@ public interface CacheLoaderWriter<K, V> {
   /**
    * Loads the values to be associated with the keys in the {@link org.ehcache.Cache} using this
    * {@link CacheLoaderWriter} instance. The returned {@link java.util.Map} should contain
-   * {@code null} mapped keys for values that couldn't be found. Only keys passed in the
-   * <code>loadAll</code> method will be mapped.
-   * Any other mapping will be ignored
+   * {@code null} mapped keys for values that couldn't be found.
+   * <br/>
+   * The mapping that will be installed in the cache is the {@code key} as found in the input parameter {@code keys}
+   * mapped to the result of {@code loadAllResult.get(key)}. Any other mapping will be ignored.
    *
    * @param keys the keys that will be mapped to the values returned in the map
    * @return the {@link java.util.Map} of values for each key passed in, where no mapping means no value to map.

--- a/core/src/main/java/org/ehcache/Jsr107Cache.java
+++ b/core/src/main/java/org/ehcache/Jsr107Cache.java
@@ -39,5 +39,5 @@ public interface Jsr107Cache<K, V> {
       NullaryFunction<Boolean> replaceEqual, final NullaryFunction<Boolean> invokeWriter,
       final NullaryFunction<Boolean> withStatsAndEvents);
   
-  void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<? super K, ? extends V>> function);
+  void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<K, V>> function);
 }


### PR DESCRIPTION
Clarifies/Fixes the way results returned from `CacheLoader.loadAll` are processed.