### PR TITLE
Issue #241 - Resolve jaxb plugin dependencies issue

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-buildscript {
-  repositories { jcenter() }
-  dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.1.1'
-  }
+plugins {
+  id 'java'
+  id 'maven'
+  id 'com.github.johnrengelman.shadow' version '1.2.0'
 }
-
-apply plugin: 'java'
-apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'maven'
 
 def projectsToInclude = [':api', ':core', ':impl', ':jmx', ':107', ':xml']
 

--- a/xml/build.gradle
+++ b/xml/build.gradle
@@ -14,23 +14,9 @@
  * limitations under the License.
  */
 
-buildscript {
-  repositories {
-    jcenter()
-    mavenCentral()
-    // added for gradle-jaxb-plugin:1.3.5.tc
-    maven { url "http://repo.terracotta.org/maven2" }
-
-    // XXX: This should be removed, but needed until org.gradle.jacobo:gradle-xsd-wsdl-slurping:1.1.1 reappears on bintray/maven-central    
-    maven { url "http://repo.springsource.org/libs-milestone" }
-  }
-
-  dependencies {
-    classpath 'org.gradle.jacobo.plugins:gradle-jaxb-plugin:1.3.5.tc'
-  }
+plugins {
+    id 'com.github.jacobono.jaxb' version '1.3.5'
 }
-
-apply plugin: 'com.github.jacobono.jaxb'
 
 dependencies {
   compile project(':api'), project(':core'), project(':impl')


### PR DESCRIPTION
* Bump to freshly released 1.3.5 for jaxb plugin
* Adapt to new plugin declaration syntax in Gradle 2.1
* Bump shadow plugin version to 1.2.0