### PR TITLE
Allowing caches to override types in XML Template. 

### DIFF
--- a/107/src/test/java/org/ehcache/jsr107/Eh107CacheTypeTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/Eh107CacheTypeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.jsr107;
+
+import org.junit.Test;
+
+import javax.cache.Caching;
+import javax.cache.configuration.Configuration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.spi.CachingProvider;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class Eh107CacheTypeTest {
+
+  @Test
+  public void testCompileTimeTypeSafety() throws Exception {
+    CachingProvider provider = Caching.getCachingProvider();
+    javax.cache.CacheManager cacheManager =
+        provider.getCacheManager(this.getClass().getResource("/ehcache-107-types.xml").toURI(), getClass().getClassLoader());
+    MutableConfiguration<Long, String> cache1Conf = new MutableConfiguration<Long, String>();
+    javax.cache.Cache<Long, String> cache = cacheManager.createCache("cache1", cache1Conf);
+
+    cache.put(1l, "one");
+    cache.put(2l, "two");
+
+    Configuration cache1CompleteConf = cache.getConfiguration(Configuration.class);
+    //This ensures that we have compile time type safety, i.e when configuration does not have types defined but
+    // what you get cache as should work.
+    assertThat((Class<Object>)cache1CompleteConf.getKeyType(), is(equalTo(Object.class)));
+    assertThat((Class<Object>)cache1CompleteConf.getValueType(), is(equalTo(Object.class)));
+
+    assertThat(cache.get(1l), is(equalTo("one")));
+    assertThat(cache.get(2l), is(equalTo("two")));
+
+
+    javax.cache.Cache second = cacheManager.getCache("cache1");
+    second.put("3","three");
+
+    assertThat((String)second.get("3"), is(equalTo("three")));
+    cacheManager.destroyCache("cache1");
+    cacheManager.close();
+
+  }
+
+
+  @Test
+  public void testRunTimeTypeSafety() throws Exception {
+    CachingProvider provider = Caching.getCachingProvider();
+    javax.cache.CacheManager cacheManager =
+        provider.getCacheManager(this.getClass().getResource("/ehcache-107-types.xml").toURI(), getClass().getClassLoader());
+    MutableConfiguration<Long, String> cache1Conf = new MutableConfiguration<Long, String>();
+    cache1Conf.setTypes(Long.class, String.class);
+    javax.cache.Cache<Long, String> cache = cacheManager.createCache("cache1", cache1Conf);
+
+    Configuration cache1CompleteConf = cache.getConfiguration(Configuration.class);
+
+    assertThat((Class<Long>)cache1CompleteConf.getKeyType(), is(equalTo(Long.class)));
+    assertThat((Class<String>)cache1CompleteConf.getValueType(), is(equalTo(String.class)));
+
+    try {
+      cacheManager.getCache("cache1");
+      fail("Caches with runtime types should throw illegal argument exception when different types are used in getcache");
+    } catch (IllegalArgumentException e) {
+      //Empty block as nothing is required to be tested
+    } finally {
+      cacheManager.destroyCache("cache1");
+      cacheManager.close();
+    }
+  }
+
+  @Test
+  public void testTypeOverriding() throws Exception {
+    CachingProvider provider = Caching.getCachingProvider();
+    javax.cache.CacheManager cacheManager =
+        provider.getCacheManager(this.getClass().getResource("/ehcache-107-types.xml").toURI(), getClass().getClassLoader());
+    MutableConfiguration<Long, String> cache1Conf = new MutableConfiguration<Long, String>();
+    cache1Conf.setTypes(Long.class, String.class);
+    javax.cache.Cache<Long, String> cache = cacheManager.createCache("defaultCache", cache1Conf);
+    Configuration cache1CompleteConf = cache.getConfiguration(Configuration.class);
+    assertThat((Class<Long>)cache1CompleteConf.getKeyType(), is(equalTo(Long.class)));
+    assertThat((Class<String>)cache1CompleteConf.getValueType(), is(equalTo(String.class)));
+  }
+
+
+
+
+
+}

--- a/107/src/test/resources/ehcache-107-types.xml
+++ b/107/src/test/resources/ehcache-107-types.xml
@@ -1,0 +1,15 @@
+<ehcache:config
+    xmlns:ehcache="http://www.ehcache.org/v3"
+    xmlns:jcache="http://www.ehcache.org/v3/jsr107">
+
+  <ehcache:service>
+    <jcache:defaults>
+      <jcache:cache name="defaultCache" template="defaultCacheTemplate"/>
+    </jcache:defaults>
+  </ehcache:service>
+
+  <ehcache:cache-template name="defaultCacheTemplate">
+    <ehcache:capacity>200</ehcache:capacity>
+  </ehcache:cache-template>
+
+</ehcache:config>

--- a/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
@@ -271,12 +271,14 @@ public class XmlConfiguration implements Configuration {
     if (cacheTemplate == null) {
       return null;
     }
-
-    if(keyType != null && cacheTemplate.keyType() != null && !keyType.getName().equals(cacheTemplate.keyType())) {
+    final ClassLoader defaultClassLoader = ClassLoading.getDefaultClassLoader();
+    Class keyClass = getClassForName(cacheTemplate.keyType(), defaultClassLoader);
+    Class valueClass = getClassForName(cacheTemplate.valueType(), defaultClassLoader);
+    if(keyType != null && cacheTemplate.keyType() != null && !keyClass.isAssignableFrom(keyType)) {
       throw new IllegalArgumentException("CacheTemplate '" + name + "' declares key type of " + cacheTemplate.keyType());
     }
 
-    if(valueType != null && cacheTemplate.valueType() != null && !valueType.getName().equals(cacheTemplate.valueType())) {
+    if(valueType != null && cacheTemplate.valueType() != null && !valueClass.isAssignableFrom(valueType)) {
       throw new IllegalArgumentException("CacheTemplate '" + name + "' declares value type of " + cacheTemplate.valueType());
     }
 
@@ -286,7 +288,6 @@ public class XmlConfiguration implements Configuration {
           .maxEntriesInCache(cacheTemplate.capacityConstraint());
     }
     final ConfigurationParser.Expiry parsedExpiry = cacheTemplate.expiry();
-    final ClassLoader defaultClassLoader = ClassLoading.getDefaultClassLoader();
     builder = builder
         .usingEvictionPrioritizer(getInstanceOfName(cacheTemplate.evictionPrioritizer(), defaultClassLoader, EvictionPrioritizer.class, Eviction.Prioritizer.class))
         .evitionVeto(getInstanceOfName(cacheTemplate.evictionVeto(), defaultClassLoader, EvictionVeto.class))

--- a/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
@@ -73,12 +73,9 @@ public class XmlConfigurationTest {
 
     assertThat(xmlConfig.newCacheConfigurationBuilderFromTemplate("example"), notNullValue());
     assertThat(xmlConfig.newCacheConfigurationBuilderFromTemplate("example", Object.class, Object.class), notNullValue());
-    try {
-      assertThat(xmlConfig.newCacheConfigurationBuilderFromTemplate("example", Number.class, Object.class), notNullValue());
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("CacheTemplate 'example' declares key type of java.lang.Object"));
-    }
+
+    //Allow the key/value to be assignable for xml configuration in case of type definition in template class
+    assertThat(xmlConfig.newCacheConfigurationBuilderFromTemplate("example", Number.class, Object.class), notNullValue());
   }
 
   @SuppressWarnings("rawtypes")


### PR DESCRIPTION
Relaxing the type restriction imposed by the XMLTemplate. Instead of checking for equal names, checking if cache configuration type can be assigned to types defined in the xml template. This will allow JSR 107 caches to be constructed when no types are defined by templates. Should we relax it further?

Also adding JSR-107 type safety tests.

