### PR TITLE
Issue #279 Passing ServiceProvider on Service.start()

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/DefaultJsr107Service.java
+++ b/107/src/main/java/org/ehcache/jsr107/DefaultJsr107Service.java
@@ -17,6 +17,7 @@
 package org.ehcache.jsr107;
 
 import org.ehcache.config.Jsr107Configuration;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.service.ServiceConfiguration;
 
 /**
@@ -31,7 +32,7 @@ public class DefaultJsr107Service implements Jsr107Service {
   }
 
   @Override
-  public void start(final ServiceConfiguration<?> serviceConfiguration) {
+  public void start(final ServiceConfiguration<?> serviceConfiguration, final ServiceProvider serviceProvider) {
     if (configuration != null) {
       if (!configuration.equals(serviceConfiguration)) {
         throw new IllegalStateException("Trying to start service with different configuration");

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheLoaderWriterFactory.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheLoaderWriterFactory.java
@@ -18,6 +18,7 @@ package org.ehcache.jsr107;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.DefaultCacheLoaderWriterFactory;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -30,7 +31,7 @@ class Eh107CacheLoaderWriterFactory extends DefaultCacheLoaderWriterFactory {
   private final ConcurrentMap<String, CacheLoaderWriter<?, ?>> cacheLoaderWriters = new ConcurrentHashMap<String, CacheLoaderWriter<?, ?>>();
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     //
   }
 

--- a/107/src/main/java/org/ehcache/jsr107/Jsr107Service.java
+++ b/107/src/main/java/org/ehcache/jsr107/Jsr107Service.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.jsr107;
 
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -24,7 +25,7 @@ import org.ehcache.spi.service.ServiceConfiguration;
  */
 public interface Jsr107Service extends Service {
   @Override
-  void start(ServiceConfiguration<?> serviceConfiguration);
+  void start(ServiceConfiguration<?> serviceConfiguration, final ServiceProvider serviceProvider);
 
   @Override
   void stop();

--- a/api/src/main/java/org/ehcache/spi/ServiceProvider.java
+++ b/api/src/main/java/org/ehcache/spi/ServiceProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
+
+/**
+ *
+ * This acts as a repository for {@link Service} instances, that can be use to
+ * look them up by type, or their {@link ServiceConfiguration} type.
+ *
+ * @author Alex Snaps
+ */
+public interface ServiceProvider {
+
+  /**
+   * Will look up the {@link Service} configured by the {@code config} type. Should the {@link Service} not yet started,
+   * it will be started, passed that {@link ServiceConfiguration} instance. Otherwise it is only used to find the
+   * matching {@link Service} instance.
+   *
+   * @param config The type configuring the Service being looked up
+   * @param <T> The actual {@link Service} implementation
+   * @return the service instance for {@code T} type, or null if it couldn't be located
+   */
+  <T extends Service> T findServiceFor(ServiceConfiguration<T> config);
+
+  /**
+   * Will look up the {@link Service} of the {@code serviceType} type. Should the {@link Service} not yet started,
+   * it will be started with a {@code null} {@link ServiceConfiguration} passed to its
+   * {@link Service#start(org.ehcache.spi.service.ServiceConfiguration, ServiceProvider)} method.
+   *
+   * @param serviceType the Class of the instance being looked up
+   * @param <T> The actual {@link Service} implementation
+   * @return the service instance for {@code T} type, or null if it couldn't be located
+   */
+  <T extends Service> T findService(Class<T> serviceType);
+}

--- a/api/src/main/java/org/ehcache/spi/service/Service.java
+++ b/api/src/main/java/org/ehcache/spi/service/Service.java
@@ -16,12 +16,14 @@
 
 package org.ehcache.spi.service;
 
+import org.ehcache.spi.ServiceProvider;
+
 /**
  * @author Alex Snaps
  */
 public interface Service {
 
-  void start(ServiceConfiguration<?> config);
+  void start(ServiceConfiguration<?> config, ServiceProvider serviceProvider);
 
   void stop();
 }

--- a/core/src/test/java/org/ehcache/EhcacheManagerTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheManagerTest.java
@@ -23,6 +23,7 @@ import org.ehcache.events.CacheManagerListener;
 import org.ehcache.exceptions.StateTransitionException;
 import org.ehcache.config.ConfigurationBuilder;
 import org.ehcache.spi.ServiceLocator;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriterFactory;
@@ -400,7 +401,7 @@ public class EhcacheManagerTest {
   static class NoSuchService implements Service {
 
     @Override
-    public void start(ServiceConfiguration<?> config) {
+    public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
       throw new UnsupportedOperationException("Implement me!");
     }
 

--- a/core/src/test/java/org/ehcache/spi/ServiceLocatorTest.java
+++ b/core/src/test/java/org/ehcache/spi/ServiceLocatorTest.java
@@ -145,7 +145,7 @@ interface FooProvider extends Service {
 class ParentTestService implements FooProvider {
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     throw new UnsupportedOperationException("Implement me!");
   }
 
@@ -157,7 +157,7 @@ class ParentTestService implements FooProvider {
 class ChildTestService extends ParentTestService {
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     throw new UnsupportedOperationException("Implement me!");
   }
 }
@@ -177,7 +177,7 @@ class FancyCacheProvider implements CacheProvider {
   }
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     ++startStopCounter;
   }
 
@@ -199,7 +199,7 @@ class DullCacheProvider implements CacheProvider {
   }
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     throw new UnsupportedOperationException("Implement me!");
   }
 

--- a/impl/src/main/java/org/ehcache/internal/EhcacheProvider.java
+++ b/impl/src/main/java/org/ehcache/internal/EhcacheProvider.java
@@ -17,6 +17,7 @@
 package org.ehcache.internal;
 
 import org.ehcache.Ehcache;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.CacheProvider;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -39,7 +40,7 @@ public class EhcacheProvider implements CacheProvider {
   }
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     //no-op
   }
 

--- a/impl/src/main/java/org/ehcache/internal/HeapCachingTierResource.java
+++ b/impl/src/main/java/org/ehcache/internal/HeapCachingTierResource.java
@@ -17,6 +17,7 @@
 package org.ehcache.internal;
 
 import org.ehcache.internal.cachingtier.ClockEvictingHeapCachingTier;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.tiering.CachingTier;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -39,7 +40,7 @@ public class HeapCachingTierResource implements CachingTier.Provider {
   }
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     //no-op
   }
 

--- a/impl/src/main/java/org/ehcache/internal/classes/ClassInstanceProvider.java
+++ b/impl/src/main/java/org/ehcache/internal/classes/ClassInstanceProvider.java
@@ -17,6 +17,7 @@
 package org.ehcache.internal.classes;
 
 import org.ehcache.config.CacheConfiguration;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.service.ServiceConfiguration;
 
 import java.util.HashMap;
@@ -63,7 +64,7 @@ public class ClassInstanceProvider<T> {
 
 
 
-  public void start(final ServiceConfiguration<?> config) {
+  public void start(final ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     if(config != null && factoryConfig.isAssignableFrom(config.getClass())) {
       final ClassInstanceProviderFactoryConfig<T> instanceProviderFactoryConfig = factoryConfig.cast(config);
       preconfiguredLoaders.putAll(instanceProviderFactoryConfig.getDefaults());

--- a/impl/src/main/java/org/ehcache/internal/executor/DefaultThreadPoolsService.java
+++ b/impl/src/main/java/org/ehcache/internal/executor/DefaultThreadPoolsService.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.internal.executor;
 
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.ThreadPoolsService;
 import org.ehcache.util.ThreadPoolUtil;
@@ -57,7 +58,7 @@ public class DefaultThreadPoolsService implements ThreadPoolsService {
   }
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     this.statisticsExecutor = ThreadPoolUtil.createStatisticsExecutor();
     this.eventsOrderedDeliveryExecutor = ThreadPoolUtil.createEventsOrderedDeliveryExecutor();
     this.eventsUnorderedDeliveryExecutor = ThreadPoolUtil.createEventsUnorderedDeliveryExecutor();

--- a/impl/src/main/java/org/ehcache/internal/persistence/DefaultLocalPersistenceService.java
+++ b/impl/src/main/java/org/ehcache/internal/persistence/DefaultLocalPersistenceService.java
@@ -18,6 +18,7 @@ package org.ehcache.internal.persistence;
 
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.persistence.PersistenceConfiguration;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.service.LocalPersistenceService;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -40,7 +41,7 @@ public class DefaultLocalPersistenceService implements LocalPersistenceService {
   }
 
   @Override
-  public synchronized void start(final ServiceConfiguration<?> config) {
+  public synchronized void start(final ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     createLocationIfRequiredAndVerify(rootDirectory);
     try {
       lockFile = new File(rootDirectory + File.separator + ".lock");

--- a/impl/src/main/java/org/ehcache/internal/serialization/JavaSerializationProvider.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/JavaSerializationProvider.java
@@ -15,6 +15,7 @@
  */
 package org.ehcache.internal.serialization;
 
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.serialization.SerializationProvider;
 import org.ehcache.spi.serialization.Serializer;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -31,7 +32,7 @@ public class JavaSerializationProvider implements SerializationProvider {
   }
 
   @Override
-  public void start(ServiceConfiguration<?> config) {
+  public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
     //no-op
   }
 

--- a/impl/src/main/java/org/ehcache/internal/store/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/OnHeapStore.java
@@ -35,6 +35,7 @@ import org.ehcache.internal.TimeSource;
 import org.ehcache.internal.TimeSourceConfiguration;
 import org.ehcache.internal.concurrent.ConcurrentHashMap;
 import org.ehcache.internal.store.service.OnHeapStoreServiceConfig;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.serialization.Serializer;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -769,7 +770,7 @@ public class OnHeapStore<K, V> implements Store<K, V> {
     }
 
     @Override
-    public void start(ServiceConfiguration<?> cfg) {
+    public void start(ServiceConfiguration<?> cfg, final ServiceProvider serviceProvider) {
       // nothing to do
     }
 

--- a/impl/src/test/java/org/ehcache/internal/persistence/DefaultLocalPersistenceServiceTest.java
+++ b/impl/src/test/java/org/ehcache/internal/persistence/DefaultLocalPersistenceServiceTest.java
@@ -41,7 +41,7 @@ public class DefaultLocalPersistenceServiceTest {
     when(f.canWrite()).thenReturn(false);
     final DefaultLocalPersistenceService service = new DefaultLocalPersistenceService(new PersistenceConfiguration(f));
     try {
-      service.start(null);
+      service.start(null, null);
     } catch(IllegalArgumentException e) {
       assertThat(e.getMessage(), equalTo("Location isn't writable: " + PATH));
     }
@@ -56,7 +56,7 @@ public class DefaultLocalPersistenceServiceTest {
     when(f.canWrite()).thenReturn(false);
     final DefaultLocalPersistenceService service = new DefaultLocalPersistenceService(new PersistenceConfiguration(f));
     try {
-      service.start(null);
+      service.start(null, null);
     } catch(IllegalArgumentException e) {
       assertThat(e.getMessage(), equalTo("Location is not a directory: " + PATH));
     }
@@ -70,7 +70,7 @@ public class DefaultLocalPersistenceServiceTest {
     when(f.mkdirs()).thenReturn(false);
     final DefaultLocalPersistenceService service = new DefaultLocalPersistenceService(new PersistenceConfiguration(f));
     try {
-      service.start(null);
+      service.start(null, null);
     } catch(IllegalArgumentException e) {
       assertThat(e.getMessage(), equalTo("Directory couldn't be created: " + PATH));
     }
@@ -90,7 +90,7 @@ public class DefaultLocalPersistenceServiceTest {
     f.deleteOnExit();
 
     final DefaultLocalPersistenceService service = new DefaultLocalPersistenceService(new PersistenceConfiguration(f));
-    service.start(null);
+    service.start(null, null);
     assertThat(service.getLockFile().exists(), is(true));
     service.stop();
     assertThat(service.getLockFile().exists(), is(false));

--- a/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
@@ -26,6 +26,7 @@ import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.internal.SystemTimeSource;
 import org.ehcache.internal.store.OnHeapStore;
+import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriterFactory;
@@ -525,7 +526,7 @@ public class EhcacheBulkMethodsITest {
     }
 
     @Override
-    public void start(ServiceConfiguration<?> config) {
+    public void start(ServiceConfiguration<?> config, final ServiceProvider serviceProvider) {
 
     }
 


### PR DESCRIPTION
Actually we were already passing the `ServiceProvider` to the factory on `Service` creation time. 
That's nice, so the factory can look up _all_ dependencies and inject them in the actual `Service` implementation on instantiation. Now... not all services are required the factory indirection, so I still think this changeset is meaningful, as discussed here:
https://www.youtube.com/watch?v=Yt1NjgDVQyQ&list=UU43PVCp2j0b2og2DtxNOU1A