### PR TITLE
Fixing issue #294 : DiskStoreSpi Tests failing on windows

### DIFF
--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
@@ -69,6 +69,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -103,6 +107,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -143,6 +151,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -175,6 +187,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -210,6 +226,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -250,6 +270,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -290,6 +314,10 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
@@ -19,7 +19,9 @@ package org.ehcache.internal.store;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,9 +45,19 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SPITest
   public void mappingFunctionReturnsIterableOfEntriesForEachInputEntry() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
@@ -69,16 +81,12 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void missingIterableEntriesAreIgnoredByTheStore() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     Map<K, V> mappedEntries = new HashMap<K, V>();
@@ -107,16 +115,12 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void mappingIsSameInTheStoreForEntriesReturnedWithDifferentValueFromMappingFunction() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     Map<K, V> mappedEntries = new HashMap<K, V>();
@@ -151,17 +155,13 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
@@ -187,16 +187,12 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void computeValuesForEveryKeyUsingAMappingFunction() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -226,17 +222,13 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testMappingFunctionProducesWrongKeyType() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -270,17 +262,13 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testMappingFunctionProducesWrongValueType() throws Exception {
-     Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -314,10 +302,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
@@ -20,6 +20,7 @@ import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
+import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 
 
@@ -47,6 +48,11 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   protected Store<K, V> kvStore;
 
+  @Before
+  public void setUp() {
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+  }
+
   @After
   public void tearDown() {
     if (kvStore != null) {
@@ -57,8 +63,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void mappingFunctionReturnsIterableOfEntriesForEachInputEntry() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
     for (long i = 0; i < nbElements; i++) {
@@ -86,8 +90,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void missingIterableEntriesAreIgnoredByTheStore() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     Map<K, V> mappedEntries = new HashMap<K, V>();
     int nbElements = 10;
@@ -120,8 +122,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void mappingIsSameInTheStoreForEntriesReturnedWithDifferentValueFromMappingFunction() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     Map<K, V> mappedEntries = new HashMap<K, V>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -161,8 +161,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
     for (long i = 0; i < nbElements; i++) {
@@ -192,8 +190,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void computeValuesForEveryKeyUsingAMappingFunction() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
     int nbElements = 10;
@@ -228,8 +224,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testMappingFunctionProducesWrongKeyType() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
     int nbElements = 10;
@@ -268,8 +262,6 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testMappingFunctionProducesWrongValueType() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
     int nbElements = 10;

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -76,6 +76,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -108,6 +112,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -142,6 +150,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -184,6 +196,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -220,6 +236,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -260,6 +280,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -300,6 +324,10 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -19,7 +19,9 @@ package org.ehcache.internal.store;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,10 +47,20 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  private Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void remappingFunctionReturnsIterableOfEntriesForEachInputEntry() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
@@ -76,17 +88,13 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
@@ -112,16 +120,12 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void mappingIsRemovedFromStoreForNullValueEntriesFromRemappingFunction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
@@ -150,16 +154,12 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void remappingFunctionGetsIterableWithMappedStoreEntryValueOrNull() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> mappedEntries = new HashMap<K, V>();
@@ -196,16 +196,12 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void computeValuesForEveryKeyUsingARemappingFunction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -236,17 +232,13 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void remappingFunctionProducesWrongKeyType() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -280,17 +272,13 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void remappingFunctionProducesWrongValueType() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
@@ -324,10 +312,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -20,6 +20,7 @@ import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
+import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 
 
@@ -49,6 +50,11 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   private Store<K, V> kvStore;
 
+  @Before
+  public void setUp() {
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+  }
+
   @After
   public void tearDown() {
     if (kvStore != null) {
@@ -60,8 +66,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void remappingFunctionReturnsIterableOfEntriesForEachInputEntry() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
     for (long i = 0; i < nbElements; i++) {
@@ -94,8 +98,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
     for (long i = 0; i < nbElements; i++) {
@@ -125,8 +127,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void mappingIsRemovedFromStoreForNullValueEntriesFromRemappingFunction() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     int nbElements = 10;
     for (long i = 0; i < nbElements; i++) {
@@ -159,8 +159,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void remappingFunctionGetsIterableWithMappedStoreEntryValueOrNull() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> mappedEntries = new HashMap<K, V>();
     int nbElements = 10;
@@ -201,8 +199,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void computeValuesForEveryKeyUsingARemappingFunction() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
     int nbElements = 10;
@@ -238,8 +234,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void remappingFunctionProducesWrongKeyType() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
     int nbElements = 10;
@@ -278,8 +272,6 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked" })
   @SPITest
   public void remappingFunctionProducesWrongValueType() throws Exception {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     Set<K> inputKeys = new HashSet<K>();
     final Map<K, V> computedEntries = new HashMap<K, V>();
     int nbElements = 10;

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
@@ -56,5 +56,8 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.containsKey(key), is(false));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
@@ -19,7 +19,9 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -38,10 +40,20 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SPITest
   public void removesAllOfTheMappings()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
@@ -56,8 +68,5 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.containsKey(key), is(false));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
@@ -20,6 +20,7 @@ import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
+import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 
 
@@ -42,6 +43,11 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
 
   protected Store<K, V> kvStore;
 
+  @Before
+  public void setUp() {
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+  }
+
   @After
   public void tearDown() {
     if (kvStore != null) {
@@ -53,8 +59,6 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void removesAllOfTheMappings()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
-
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
@@ -38,10 +38,12 @@ public class StoreCloseTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
   @SPITest
   public void closedStoreCantBeUsed()
       throws CacheAccessException, IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 import org.hamcrest.Matchers;
 
@@ -40,12 +41,15 @@ public class StoreCloseTest<K, V> extends SPIStoreTester<K, V> {
 
   protected Store<K, V> kvStore;
 
+  @Before
+  public void setUp() {
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+        .all(), null));
+  }
+
   @SPITest
   public void closedStoreCantBeUsed()
       throws CacheAccessException, IllegalAccessException, InstantiationException {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
-        .all(), null));
-
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
@@ -41,6 +41,9 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
     if (factory.getValueType() == Object.class) {
       System.err.println("Warning, store uses Object as value type, cannot verify in this configuration");
+      if(kvStore != null) {
+        kvStore.close();
+      }
       return;
     }
 
@@ -66,6 +69,10 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -76,6 +83,9 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
+      if(kvStore != null) {
+        kvStore.close();
+      }
       return;
     }
 
@@ -99,6 +109,10 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -121,6 +135,10 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -146,6 +164,9 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       e.printStackTrace();
     }
     assertThat(kvStore.get(key).value(), is(value));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -172,6 +193,9 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     }
     assertThat(called.get(), is(true));
     assertThat(kvStore.get(key), nullValue());
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -198,5 +222,8 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key), nullValue());
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
@@ -19,7 +19,9 @@ import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.BiFunction;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -31,17 +33,29 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongReturnValueType() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     if (factory.getValueType() == Object.class) {
       System.err.println("Warning, store uses Object as value type, cannot verify in this configuration");
-      if(kvStore != null) {
-        kvStore.close();
-      }
       return;
     }
     
@@ -69,29 +83,22 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
-      if(kvStore != null) {
-        kvStore.close();
-      }
       return;
     }
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
-    kvStore.put(key, value);
+    kvStore2.put(key, value);
 
     final Object badKey;
     if (factory.getKeyType() == String.class) {
@@ -101,7 +108,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     }
     
     try {
-      kvStore.computeIfPresent(badKey, new BiFunction() { // wrong key type
+      kvStore2.computeIfPresent(badKey, new BiFunction() { // wrong key type
             @Override
             public Object apply(Object key, Object value) {
               throw new AssertionError();
@@ -113,16 +120,12 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testNullReturnRemovesEntry() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
@@ -141,16 +144,12 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testComputePutsValueInStoreWhenKeyIsPresent() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
     final V value2 = factory.createValue(System.nanoTime());
@@ -167,16 +166,12 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testFunctionNotCalledWhenAbsent() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
     final K key = factory.getKeyType().newInstance();
 
     try {
@@ -190,16 +185,12 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testException() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
@@ -221,8 +212,5 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(value));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
@@ -39,6 +39,9 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
 
     if (factory.getValueType() == Object.class) {
       System.err.println("Warning, store uses Object as value type, cannot verify in this configuration");
+      if(kvStore != null) {
+        kvStore.close();
+      }
       return;
     }
     
@@ -66,6 +69,10 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -76,6 +83,9 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
+      if(kvStore != null) {
+        kvStore.close();
+      }
       return;
     }
 
@@ -103,6 +113,10 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -127,6 +141,10 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -149,6 +167,10 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -168,6 +190,10 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -195,5 +221,8 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(value));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
@@ -65,6 +65,10 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -98,6 +102,10 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -119,6 +127,10 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -144,6 +156,10 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -166,6 +182,10 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -196,5 +216,8 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(value));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
@@ -19,6 +19,7 @@ import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.BiFunction;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,10 +34,25 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongReturnValueType() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     if (factory.getValueType() == Object.class) {
@@ -65,17 +81,13 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
@@ -90,7 +102,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     try {
-      kvStore.compute(key, new BiFunction() { // wrong key type
+      kvStore2.compute(key, new BiFunction() { // wrong key type
             @Override
             public Object apply(Object key, Object oldValue) {
               throw new AssertionError();
@@ -102,16 +114,12 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testComputePutsValueInStore() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
@@ -127,16 +135,12 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testOverwriteExitingValue() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
@@ -156,16 +160,12 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testNullReturnRemovesEntry() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
@@ -182,16 +182,12 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void testException() throws Exception {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     final K key = factory.getKeyType().newInstance();
     final V value = factory.getValueType().newInstance();
@@ -216,8 +212,5 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(value));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,10 +39,25 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void storeContainsKey()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -54,17 +70,13 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullKeyThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
 
@@ -76,10 +88,6 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -87,13 +95,13 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.containsKey(1.0f);
+        kvStore2.containsKey(1.0f);
       } else {
-        kvStore.containsKey("key");
+        kvStore2.containsKey("key");
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -101,10 +109,6 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
@@ -54,6 +54,10 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -72,6 +76,10 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -93,6 +101,10 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreDestroyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreDestroyTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,10 +39,20 @@ public class StoreDestroyTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore.close();
+    }
+  }
+
   @SPITest
   public void noDataCanBeRecoveredFromDestroyedStore()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreDestroyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreDestroyTest.java
@@ -20,6 +20,7 @@ import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
+import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,6 +42,12 @@ public class StoreDestroyTest<K, V> extends SPIStoreTester<K, V> {
 
   protected Store<K, V> kvStore;
 
+  @Before
+  public void setUp() {
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+        .all(), null));
+  }
+
   @After
   public void tearDown() {
     if (kvStore != null) {
@@ -52,9 +59,6 @@ public class StoreDestroyTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void noDataCanBeRecoveredFromDestroyedStore()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
-        .all(), null));
-
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEventListenerTest.java
@@ -24,6 +24,7 @@ import org.ehcache.expiry.Expirations;
 import org.ehcache.function.BiFunction;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 import org.ehcache.internal.TimeSource;
 
@@ -53,11 +54,21 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   final V v2 = factory.createValue(2l);
   final V v3 = factory.createValue(3l);
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testGetOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -71,7 +82,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testContainsKeyOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -85,7 +96,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testPutIfAbsentOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -100,7 +111,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testRemoveOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -114,7 +125,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testReplaceTwoArgsOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -128,7 +139,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testReplaceThreeArgsOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -142,7 +153,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testComputeOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -162,7 +173,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testComputeIfAbsentOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -183,7 +194,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void testComputeIfPresentOnExpiration() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         null, null, null, Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS))), timeSource);
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -203,7 +214,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testPutOnEviction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         1L, null, null));
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -217,7 +228,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testPutIfAbsentOnEviction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         1L, null, null));
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -232,7 +243,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testReplaceTwoArgsOnEviction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         1L, null, null));
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -248,7 +259,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testComputeOnEviction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         1L, null, null));
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);
@@ -267,7 +278,7 @@ public class StoreEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testComputeIfAbsentOnEviction() throws Exception {
-    Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(),
         1L, null, null));
     TestStoreEventListener listener = new TestStoreEventListener();
     kvStore.enableStoreEventNotifications(listener);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -58,6 +58,10 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -73,6 +77,10 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -91,6 +99,10 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -109,6 +121,10 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -131,6 +147,10 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -19,7 +19,9 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import static org.ehcache.spi.cache.Store.ValueHolder;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,10 +44,25 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void existingKeyMappedInStoreReturnsValueHolder()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -58,17 +75,13 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void keyNotMappedInStoreReturnsNull()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
 
@@ -77,17 +90,13 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void existingKeyMappedInStoreReturnsCorrectValueHolder()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
@@ -99,17 +108,13 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullKeyThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
 
@@ -121,10 +126,6 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -133,13 +134,13 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.get(1.0f);
+        kvStore2.get(1.0f);
       } else {
-        kvStore.get("key");
+        kvStore2.get("key");
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -147,10 +148,6 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
@@ -60,6 +60,9 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
         e.printStackTrace();
       }
     }
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -74,6 +77,10 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
@@ -20,7 +20,9 @@ import org.ehcache.Cache;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -39,10 +41,20 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SPITest
   public void hasNext()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     int nbElements = 3;
@@ -60,15 +72,12 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
         e.printStackTrace();
       }
     }
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   public void hasNextReturnsFalseIfNoElement()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     Store.Iterator<Cache.Entry<K, Store.ValueHolder<V>>> iterator = kvStore.iterator();
 
@@ -77,10 +86,6 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
@@ -20,6 +20,7 @@ import org.ehcache.Cache;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import java.util.NoSuchElementException;
@@ -42,10 +43,20 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SPITest
   public void nextReturnsNextElement()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -61,17 +72,13 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void noMoreElementThrowsException()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     kvStore.put(factory.getKeyType().newInstance(), factory.getValueType().newInstance());
 
@@ -86,10 +93,6 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
@@ -61,6 +61,10 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -82,6 +86,10 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
@@ -19,7 +19,9 @@ package org.ehcache.internal.store;
 import org.ehcache.Cache;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,11 +44,21 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+  }
+
   @SPITest
   @SuppressWarnings("unchecked")
   public void iterableContainsValuesInAnyOrder()
       throws CacheAccessException, IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key1 = factory.createKey(1L);
     K key2 = factory.createKey(2L);
@@ -69,8 +81,5 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
     }
     assertThat(keys, containsInAnyOrder(equalTo(key1), equalTo(key2), equalTo(key3)));
     assertThat(values, containsInAnyOrder(equalTo(value1), equalTo(value2), equalTo(value3)));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
@@ -20,6 +20,7 @@ import org.ehcache.Cache;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
+import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 
 
@@ -46,6 +47,11 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
 
   protected Store<K, V> kvStore;
 
+  @Before
+  public void setUp() {
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+  }
+
   @After
   public void tearDown() {
     if (kvStore != null) {
@@ -58,8 +64,6 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings("unchecked")
   public void iterableContainsValuesInAnyOrder()
       throws CacheAccessException, IllegalAccessException, InstantiationException {
-    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
-
     K key1 = factory.createKey(1L);
     K key2 = factory.createKey(2L);
     K key3 = factory.createKey(3L);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
@@ -69,5 +69,8 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
     }
     assertThat(keys, containsInAnyOrder(equalTo(key1), equalTo(key2), equalTo(key3)));
     assertThat(values, containsInAnyOrder(equalTo(value1), equalTo(value2), equalTo(value3)));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,10 +42,25 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void mapsKeyToValueWhenMappingDoesntExist()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -55,17 +71,13 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void doesntMapKeyToValueWhenMappingExists()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
@@ -84,17 +96,13 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullKeyThrowsException()
       throws CacheAccessException, IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
     V value = factory.getValueType().newInstance();
@@ -104,17 +112,13 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       throw new AssertionError("Expected NullPointerException because the key is null");
     } catch (NullPointerException e) {
       // expected
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullValueThrowsException()
       throws CacheAccessException, IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
     V value = null;
@@ -124,10 +128,6 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       throw new AssertionError("Expected NullPointerException because the value is null");
     } catch (NullPointerException e) {
       // expected
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -135,15 +135,15 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     V value = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.putIfAbsent(1.0f, value);
+        kvStore2.putIfAbsent(1.0f, value);
       } else {
-        kvStore.putIfAbsent("key", value);
+        kvStore2.putIfAbsent("key", value);
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -151,10 +151,6 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -162,15 +158,15 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
 
     try {
       if (this.factory.getValueType() == String.class) {
-        kvStore.putIfAbsent(key, 1.0f);
+        kvStore2.putIfAbsent(key, 1.0f);
       } else {
-        kvStore.putIfAbsent(key, "value");
+        kvStore2.putIfAbsent(key, "value");
       }
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
@@ -178,10 +174,6 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -55,6 +55,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -80,6 +84,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -96,6 +104,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       throw new AssertionError("Expected NullPointerException because the key is null");
     } catch (NullPointerException e) {
       // expected
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -112,6 +124,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       throw new AssertionError("Expected NullPointerException because the value is null");
     } catch (NullPointerException e) {
       // expected
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -135,6 +151,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -158,6 +178,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -56,6 +56,10 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -75,6 +79,10 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -95,6 +103,9 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key), is(instanceOf(Store.ValueHolder.class)));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -117,6 +128,10 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -140,6 +155,10 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,10 +41,25 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void nullKeyThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
     V value = factory.getValueType().newInstance();
@@ -56,17 +72,13 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullValueThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
     V value = null;
@@ -79,17 +91,13 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void valueHolderCanBeRetrievedWithEqualKey()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -103,24 +111,21 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key), is(instanceOf(Store.ValueHolder.class)));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     V value = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.put(1.0f, value);
+        kvStore2.put(1.0f, value);
       } else {
-        kvStore.put("key", value);
+        kvStore2.put("key", value);
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -128,10 +133,6 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -139,15 +140,15 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
 
     try {
       if (this.factory.getValueType() == String.class) {
-        kvStore.put(key, 1.0f);
+        kvStore2.put(key, 1.0f);
       } else {
-        kvStore.put(key, "value");
+        kvStore2.put(key, "value");
       }
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
@@ -155,10 +156,6 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
@@ -59,6 +59,9 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.containsKey(key), is(false));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -72,6 +75,10 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.remove(key);
     } catch (CacheAccessException e) {
       throw new AssertionError(e);
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -90,6 +97,10 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -111,6 +122,10 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,10 +39,25 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void removeKeyAndValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -59,15 +75,12 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.containsKey(key), is(false));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   public void removeKeyAndValueDoesNothingWhenKeyIsNotMapped()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
 
@@ -75,17 +88,13 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.remove(key);
     } catch (CacheAccessException e) {
       throw new AssertionError(e);
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullKeyThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
 
@@ -97,10 +106,6 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -108,13 +113,13 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.remove(1.0f);
+        kvStore2.remove(1.0f);
       } else {
-        kvStore.remove("key");
+        kvStore2.remove("key");
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -122,10 +127,6 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,10 +39,25 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void removeEntryForKeyIfMappedToValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.createKey(1L);
@@ -63,15 +79,12 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.containsKey(key), is(false));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   public void doNothingForKeyNotMappedToValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
@@ -84,17 +97,12 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       throw new AssertionError(e);
     }
-    finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
-    }
   }
 
   @SPITest
   public void doNothingForWrongValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.createValue(1L);
@@ -110,17 +118,12 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       throw new AssertionError(e);
     }
-    finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
-    }
   }
 
   @SPITest
   public void returnTrueIfValueWasRemoved()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
@@ -134,17 +137,13 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void returnFalseIfValueWasNotRemoved()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V value = factory.getValueType().newInstance();
@@ -156,17 +155,13 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullKeyThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
     V value = factory.getValueType().newInstance();
@@ -179,17 +174,13 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullValueThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
     V value = null;
@@ -202,10 +193,6 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -213,15 +200,15 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     V value = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.remove(1.0f, value);
+        kvStore2.remove(1.0f, value);
       } else {
-        kvStore.remove("key", value);
+        kvStore2.remove("key", value);
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -229,10 +216,6 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -240,15 +223,15 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
 
     try {
       if (this.factory.getValueType() == String.class) {
-        kvStore.remove(key, 1.0f);
+        kvStore2.remove(key, 1.0f);
       } else {
-        kvStore.remove(key, "value");
+        kvStore2.remove(key, "value");
       }
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
@@ -256,10 +239,6 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
@@ -63,6 +63,9 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.containsKey(key), is(false));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -80,6 +83,11 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
       assertThat(isRemoved, is(false));
     } catch (CacheAccessException e) {
       throw new AssertionError(e);
+    }
+    finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -102,6 +110,11 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       throw new AssertionError(e);
     }
+    finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
+    }
   }
 
   @SPITest
@@ -121,6 +134,10 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -139,6 +156,10 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -158,6 +179,10 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -177,6 +202,10 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -200,6 +229,10 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -223,6 +256,10 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -61,6 +61,9 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(equalTo(newValue)));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -80,6 +83,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -99,6 +106,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -118,6 +129,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -137,6 +152,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -160,6 +179,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -183,6 +206,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,10 +41,25 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void replaceKeyAndValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -61,15 +77,12 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(equalTo(newValue)));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   public void replaceReturnsOldValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V originalValue = factory.getValueType().newInstance();
@@ -83,17 +96,13 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void replaceKeyNotMappedReturnsNull()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
 
@@ -106,17 +115,13 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullKeyThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = null;
     V value = factory.getValueType().newInstance();
@@ -129,17 +134,13 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
   @SPITest
   public void nullValueThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
     V value = null;
@@ -152,10 +153,6 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -163,15 +160,15 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     V value = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.replace(1.0f, value);
+        kvStore2.replace(1.0f, value);
       } else {
-        kvStore.replace("key", value);
+        kvStore2.replace("key", value);
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -179,10 +176,6 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -190,15 +183,15 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
 
     try {
       if (this.factory.getValueType() == String.class) {
-        kvStore.replace(key, 1.0f);
+        kvStore2.replace(key, 1.0f);
       } else {
-        kvStore.replace(key, "value");
+        kvStore2.replace(key, "value");
       }
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
@@ -206,10 +199,6 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
@@ -19,6 +19,7 @@ package org.ehcache.internal.store;
 import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.CoreMatchers.not;
@@ -41,10 +42,25 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     super(factory);
   }
 
+  protected Store<K, V> kvStore;
+  protected Store kvStore2;
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore.close();
+      kvStore = null;
+    }
+    if (kvStore2 != null) {
+      kvStore2.close();
+      kvStore2 = null;
+    }
+  }
+
   @SPITest
   public void replaceCorrectKeyAndValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction
         .all(), null));
 
     K key = factory.getKeyType().newInstance();
@@ -62,15 +78,12 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(equalTo(newValue)));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   public void replaceCorrectKeyAndWrongValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.createKey(1L);
     V originalValue = factory.createValue(1L);
@@ -88,15 +101,12 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(not(equalTo(wrongValue))));
-    if(kvStore != null) {
-      kvStore.close();
-    }
   }
 
   @SPITest
   public void successfulReplaceReturnsTrue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V originalValue = factory.getValueType().newInstance();
@@ -111,17 +121,12 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
     }
-    finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
-    }
   }
 
   @SPITest
   public void unsuccessfulReplaceReturnsFalse()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    final Store<K, V> kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
+    kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, Eviction.all(), null));
 
     K key = factory.getKeyType().newInstance();
     V originalValue = factory.createValue(1L);
@@ -136,11 +141,6 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -148,16 +148,16 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     V originalValue = factory.getValueType().newInstance();
     V newValue = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getKeyType() == String.class) {
-        kvStore.replace(1.0f, originalValue);
+        kvStore2.replace(1.0f, originalValue);
       } else {
-        kvStore.replace("key", originalValue, newValue);
+        kvStore2.replace("key", originalValue, newValue);
       }
       throw new AssertionError("Expected ClassCastException because the key is of the wrong type");
     } catch (ClassCastException e) {
@@ -165,10 +165,6 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 
@@ -176,16 +172,16 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongOriginalValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
     V newValue = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getValueType() == String.class) {
-        kvStore.replace(key, 1.0f, newValue);
+        kvStore2.replace(key, 1.0f, newValue);
       } else {
-        kvStore.replace(key, "value", newValue);
+        kvStore2.replace(key, "value", newValue);
       }
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
@@ -193,28 +189,23 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
-
   }
 
   @SPITest
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void wrongNewValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException {
-    final Store kvStore = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
+    kvStore2 = factory.newStore(factory.newConfiguration(factory.getKeyType(), factory.getValueType(), null, null, null));
 
     K key = factory.getKeyType().newInstance();
     V originalValue = factory.getValueType().newInstance();
 
     try {
       if (this.factory.getValueType() == String.class) {
-        kvStore.replace(key, originalValue, 1.0f);
+        kvStore2.replace(key, originalValue, 1.0f);
       } else {
-        kvStore.replace(key, originalValue, "value");
+        kvStore2.replace(key, originalValue, "value");
       }
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
@@ -222,10 +213,6 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
-    } finally {
-      if(kvStore != null) {
-        kvStore.close();
-      }
     }
   }
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
@@ -62,6 +62,9 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(equalTo(newValue)));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -85,6 +88,9 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     assertThat(kvStore.get(key).value(), is(not(equalTo(wrongValue))));
+    if(kvStore != null) {
+      kvStore.close();
+    }
   }
 
   @SPITest
@@ -104,6 +110,11 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    }
+    finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -125,6 +136,11 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -149,6 +165,10 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 
@@ -173,7 +193,12 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
+
   }
 
   @SPITest
@@ -197,6 +222,10 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
     } catch (CacheAccessException e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();
+    } finally {
+      if(kvStore != null) {
+        kvStore.close();
+      }
     }
   }
 }

--- a/spi-tester/src/main/java/org/ehcache/spi/test/After.java
+++ b/spi-tester/src/main/java/org/ehcache/spi/test/After.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.test;
+
+/**
+ * Indicates the annotated method has to be run after each SPI Test
+ * Created by rism on 19-02-2015.
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface After {
+//
+}

--- a/spi-tester/src/main/java/org/ehcache/spi/test/Before.java
+++ b/spi-tester/src/main/java/org/ehcache/spi/test/Before.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.test;
+
+/**
+ * Indicates the annotated method has to be run before each SPI Test
+ * Created by rism on 19-02-2015.
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Before {
+  //
+}

--- a/spi-tester/src/main/java/org/ehcache/spi/test/SPITester.java
+++ b/spi-tester/src/main/java/org/ehcache/spi/test/SPITester.java
@@ -39,16 +39,17 @@ public abstract class SPITester {
         afterMethodList.add(m);
       }
     }
-    if(!beforeMethodList.isEmpty()) {
-      for (Method bm : beforeMethodList) {
-        try {
-          bm.invoke(this, (Object[]) null);
-        } catch (Exception e) {
-          throw new RuntimeException(e);
+
+    for (Method m : testClass.getDeclaredMethods()) {
+      if(m.isAnnotationPresent(SPITest.class) && !m.isAnnotationPresent(Ignore.class)) {
+        for (Method bm : beforeMethodList) {
+          try {
+            bm.invoke(this, (Object[]) null);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
         }
       }
-    }
-    for (Method m : testClass.getDeclaredMethods()) {
       if (m.isAnnotationPresent(SPITest.class)) {
         if (m.isAnnotationPresent(Ignore.class)) {
           result.testSkipped(new ResultState(testClass, m.getName(), m.getAnnotation(Ignore.class).reason()));

--- a/spi-tester/src/main/java/org/ehcache/spi/test/SPITester.java
+++ b/spi-tester/src/main/java/org/ehcache/spi/test/SPITester.java
@@ -41,20 +41,18 @@ public abstract class SPITester {
     }
 
     for (Method m : testClass.getDeclaredMethods()) {
-      if(m.isAnnotationPresent(SPITest.class) && !m.isAnnotationPresent(Ignore.class)) {
-        for (Method bm : beforeMethodList) {
-          try {
-            bm.invoke(this, (Object[]) null);
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        }
-      }
       if (m.isAnnotationPresent(SPITest.class)) {
         if (m.isAnnotationPresent(Ignore.class)) {
           result.testSkipped(new ResultState(testClass, m.getName(), m.getAnnotation(Ignore.class).reason()));
         }
         else try {
+          for (Method bm : beforeMethodList) {
+            try {
+              bm.invoke(this, (Object[]) null);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
           m.invoke(this, (Object[]) null);
           result.testFinished();
         } catch (InvocationTargetException wrappedExc) {


### PR DESCRIPTION
Tests missing DiskStore.close(), causing failure of file.delete