### PR TITLE
Fixing issue #284 : Reviewed unit tests related tests in BaseOnHeapStoreTest

### DIFF
--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEventListenerTest.java
@@ -28,7 +28,10 @@ import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.SPITest;
 import org.ehcache.internal.TimeSource;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
I have reviewed the tests in StoreEventListenerTest that are related to tests in BaseOnHeapStoreTest and to me, it makes sense to retain these tests as they can validate the listener if behaviour of Store is changed. I've also added a few negative tests for OnEviction and OnExpiration events. However I did not add tests for each and every store operation as eviction and expiration events would be same for each of them. 
Please provide comments/suggestions on the same