### PR TITLE
Add script to generate ehcache.github.io content from adocs

### DIFF
--- a/docs/generate
+++ b/docs/generate
@@ -1,0 +1,89 @@
+#!/bin/bash
+## Generate content for github.com/ehcache/ehcache.github.io
+##
+## TODO: Convert this to Gradle
+##
+## This script presumes:
+## 1) ehcache/ehcache.github.io is checked out and available
+## 2) asciidoctor is installed and available in PATH
+## 3) this script is being executed from it's "home" directory (the 'docs' directory of the ehcache3 project)
+
+declare -r syntax="Syntax: ${0} <ehcache.github.io_project_root> <version>"
+
+declare -r contentRoot="$( cd "$(dirname "${0}")" ; pwd )"
+declare -r siteDocDir="${contentRoot}/user"
+
+## 'adoc' files which don't need direct conversion
+declare -ar adocExclusions=(
+    common.adoc
+    menu.adoc
+)
+
+if [ ! -d "${siteDocDir}" ]; then
+    echo "Directory '${siteDocDir}' not found" >&2
+    exit 1
+fi
+
+## Take the first  argument as the location of the ehcache.github.io project root
+if [ "${1}" == "" ]; then
+    echo "Location of ehcache/ehcache.github.io project root must be provided" >&2
+    echo "${syntax}" >&2
+    exit 2
+fi
+
+if [ ! -d "${1}" ]; then
+    echo "Directory '${1}' not found" >&2
+    exit 1
+fi
+declare -r siteRoot="$(cd "${1}" ; pwd)"
+
+if [ "${2}" == "" ]; then
+    echo "The version identifier must be provided" >&2
+    echo "${syntax}" >&2
+    exit 2
+fi
+declare -r version="${2}"
+
+## Confirm replacement if content already exists
+declare -r docsTarget="${siteRoot}/docs/user/${version}"
+if [ -e "${docsTarget}/ehcache.css" ]; then
+    read -p "Content exists at '${docsTarget}'; replace? (y|n)"
+    if [ "${REPLY}" != "y" ]; then
+        echo "Abandoning web site document installation" >&2
+        exit 3
+    fi
+    echo "Replacing content at '${docsTarget}'"
+else
+    echo "Installing content to '${docsTarget}'"
+fi
+
+## 0) If target directory does not exist, create it
+if [ ! -d "${docsTarget}" ]; then
+    mkdir -p "${docsTarget}" || exit
+fi
+
+## 1) Copy/replace ehcache.css
+echo "Copying 'ehcache.css'"
+cp -p "${siteDocDir}/ehcache.css" "${docsTarget}/." || exit
+
+## 2) Assemble the list of adoc files to convert; some are nested files and are not converted directly
+declare -a adocs
+for adoc in "${siteDocDir}"/*.adoc ; do
+    for exclusion in "${adocExclusions[@]}"; do
+        if [ "$(basename "${adoc}")" == "${exclusion}" ]; then
+            continue 2
+        fi
+    done
+    adocs+=( "${adoc}" )
+done
+
+## 3) Convert the adocs & place into site
+echo "Converting & installing adocs"
+asciidoctor --destination-dir "${docsTarget}" "${adocs[@]}" || exit
+
+echo "Done"
+
+    
+
+
+


### PR DESCRIPTION
Bash script to generate `ehcache.github.io` HTML content from `ehcache3` adoc files.  Requires `asciidoctor` to be available in path.