### PR TITLE
Issue #391 Clean up CacheConfigurationBuilder

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
@@ -210,7 +210,7 @@ class Eh107CacheManager implements CacheManager {
 
     OnHeapStoreServiceConfig onHeapStoreServiceConfig = builder.getExistingServiceConfiguration(OnHeapStoreServiceConfig.class);
     if (onHeapStoreServiceConfig == null) {
-      builder.addServiceConfig(new OnHeapStoreServiceConfig().storeByValue(jsr107Config.isStoreByValue()));
+      builder = builder.add(new OnHeapStoreServiceConfig().storeByValue(jsr107Config.isStoreByValue()));
     } else {
       onHeapStoreServiceConfig.storeByValue(jsr107Config.isStoreByValue());
     }
@@ -235,7 +235,7 @@ class Eh107CacheManager implements CacheManager {
       DefaultCacheLoaderWriterConfiguration conf = builder.getExistingServiceConfiguration(DefaultCacheLoaderWriterConfiguration.class);
       if(conf != null) {
         LOG.warn("Removing the loader/writer service configuration from the JSR107 cache {}", cacheName);
-        builder.removeServiceConfig(conf);
+        builder = builder.remove(conf);
       }
     }
 

--- a/core/src/main/java/org/ehcache/config/Builder.java
+++ b/core/src/main/java/org/ehcache/config/Builder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.config;
+
+/**
+ * Abstraction of something that can build a {@code T}
+ *
+ * @param <T> the type this builder can build
+ */
+public interface Builder<T> {
+
+  T build();
+}

--- a/core/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
+++ b/core/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
@@ -21,10 +21,12 @@ import org.ehcache.spi.service.ServiceConfiguration;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.ehcache.expiry.Expirations;
 import org.ehcache.expiry.Expiry;
 
+import static java.util.Collections.emptySet;
 import static org.ehcache.config.ResourcePoolsBuilder.newResourcePoolsBuilder;
 
 /**
@@ -46,40 +48,48 @@ public class CacheConfigurationBuilder<K, V> {
     return new CacheConfigurationBuilder<K, V>();
   }
 
-  private CacheConfigurationBuilder(final Expiry<? super K, ? super V> expiry, final ClassLoader classLoader,
-                                   final EvictionPrioritizer<? super K, ? super V> evictionPrioritizer,
-                                   final EvictionVeto<? super K, ? super V> evictionVeto,
-                                   final ResourcePools resourcePools,
-                                   final Collection<ServiceConfiguration<?>> serviceConfigurations) {
-    this.expiry = expiry;
-    this.classLoader = classLoader;
-    this.evictionPrioritizer = evictionPrioritizer;
-    this.evictionVeto = evictionVeto;
-    this.resourcePools = resourcePools;
-    this.serviceConfigurations.addAll(serviceConfigurations);
+  private CacheConfigurationBuilder(CacheConfigurationBuilder<? super K, ? super V> other) {
+    this.expiry = other.expiry;
+    this.classLoader = other.classLoader;
+    this.evictionPrioritizer = other.evictionPrioritizer;
+    this.evictionVeto = other.evictionVeto;
+    this.resourcePools = other.resourcePools;
+    this.serviceConfigurations.addAll(other.serviceConfigurations);
+
   }
 
-  public CacheConfigurationBuilder<K, V> addServiceConfig(ServiceConfiguration<?> configuration) {
-    serviceConfigurations.add(configuration);
-    return this;
+  public CacheConfigurationBuilder<K, V> add(ServiceConfiguration<?> configuration) {
+    CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
+    otherBuilder.serviceConfigurations.add(configuration);
+    return otherBuilder;
+  }
+
+  public CacheConfigurationBuilder<K, V> add(Builder<? extends ServiceConfiguration<?>> configurationBuilder) {
+    return add(configurationBuilder.build());
   }
 
   public <NK extends K, NV extends V> CacheConfigurationBuilder<NK, NV> usingEvictionPrioritizer(final EvictionPrioritizer<? super NK, ? super NV> evictionPrioritizer) {
-    return new CacheConfigurationBuilder<NK, NV>(expiry, classLoader, evictionPrioritizer, evictionVeto, resourcePools, serviceConfigurations);
+    CacheConfigurationBuilder<NK, NV> otherBuilder = new CacheConfigurationBuilder<NK, NV>(this);
+    otherBuilder.evictionPrioritizer = evictionPrioritizer;
+    return otherBuilder;
   }
 
   public <NK extends K, NV extends V> CacheConfigurationBuilder<NK, NV> evictionVeto(final EvictionVeto<? super NK, ? super NV> veto) {
-    return new CacheConfigurationBuilder<NK, NV>(expiry, classLoader, evictionPrioritizer, veto, resourcePools, serviceConfigurations);
+    CacheConfigurationBuilder<NK, NV> otherBuilder = new CacheConfigurationBuilder<NK, NV>(this);
+    otherBuilder.evictionVeto = veto;
+    return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> removeServiceConfig(ServiceConfiguration<?> configuration) {
-    serviceConfigurations.remove(configuration);
-    return this;
+  public CacheConfigurationBuilder<K, V> remove(ServiceConfiguration<?> configuration) {
+    CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
+    otherBuilder.serviceConfigurations.remove(configuration);
+    return otherBuilder;
   }
 
   public CacheConfigurationBuilder<K, V> clearAllServiceConfig() {
-    serviceConfigurations.clear();
-    return this;
+    CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
+    otherBuilder.serviceConfigurations.clear();
+    return otherBuilder;
   }
 
   public <T extends ServiceConfiguration<?>> T getExistingServiceConfiguration(Class<T> clazz) {
@@ -106,16 +116,24 @@ public class CacheConfigurationBuilder<K, V> {
   }
   
   public CacheConfigurationBuilder<K, V> withClassLoader(ClassLoader classLoader) {
-    this.classLoader = classLoader;
-    return this;
+    CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
+    otherBuilder.classLoader = classLoader;
+    return otherBuilder;
   }
   
   public CacheConfigurationBuilder<K, V> withResourcePools(ResourcePools resourcePools) {
-    this.resourcePools = resourcePools;
-    return this;
+    if (resourcePools == null) {
+      throw new NullPointerException("Null resource pools");
+    }
+    CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
+    otherBuilder.resourcePools = resourcePools;
+    return otherBuilder;
   }
 
   public CacheConfigurationBuilder<K, V> withResourcePools(ResourcePoolsBuilder resourcePoolsBuilder) {
+    if (resourcePoolsBuilder == null) {
+      throw new NullPointerException("Null resource pools builder");
+    }
     return withResourcePools(resourcePoolsBuilder.build());
   }
 
@@ -123,7 +141,9 @@ public class CacheConfigurationBuilder<K, V> {
     if (expiry == null) {
       throw new NullPointerException("Null expiry");
     }
-    return new CacheConfigurationBuilder<NK, NV>(expiry, classLoader, evictionPrioritizer, evictionVeto, resourcePools, serviceConfigurations);
+    CacheConfigurationBuilder<NK, NV> otherBuilder = new CacheConfigurationBuilder<NK, NV>(this);
+    otherBuilder.expiry = expiry;
+    return otherBuilder;
   }
 
 }

--- a/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
@@ -15,11 +15,13 @@
  */
 package org.ehcache.config.writebehind;
 
+import org.ehcache.config.Builder;
+
 /**
  * @author Abhilash
  *
  */
-public class WriteBehindConfigurationBuilder {
+public class WriteBehindConfigurationBuilder implements Builder<WriteBehindConfiguration> {
   
   private int minWriteDelay = 1;
   private int maxWriteDelay = 1;

--- a/core/src/test/java/org/ehcache/config/CacheConfigurationBuilderTest.java
+++ b/core/src/test/java/org/ehcache/config/CacheConfigurationBuilderTest.java
@@ -63,7 +63,7 @@ public class CacheConfigurationBuilderTest {
 
   @Test
   public void testOffheapGetsAddedToCacheConfiguration() {
-    final CacheConfigurationBuilder<Long, CharSequence> builder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder<Long, CharSequence> builder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
 
     final EvictionPrioritizer<Long, CharSequence> prioritizer = new EvictionPrioritizer<Long, CharSequence>() {
       @Override
@@ -74,7 +74,7 @@ public class CacheConfigurationBuilderTest {
 
     final Expiry<Object, Object> expiry = Expirations.timeToIdleExpiration(Duration.FOREVER);
 
-    builder.withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES)
+    builder = builder.withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES)
         .offheap(10, MemoryUnit.MB));
     CacheConfiguration config = builder
         .evictionVeto(new EvictionVeto<Long, String>() {

--- a/impl/src/main/java/org/ehcache/config/event/CacheEventListenerBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/event/CacheEventListenerBuilder.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.config.event;
 
+import org.ehcache.config.Builder;
 import org.ehcache.event.CacheEventListener;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
@@ -28,7 +29,7 @@ import java.util.Set;
 /**
  * @author rism
  */
-public class CacheEventListenerBuilder {
+public class CacheEventListenerBuilder implements Builder<DefaultCacheEventListenerConfiguration> {
   private EventOrdering eventOrdering;
   private EventFiring eventFiringMode;
   private EnumSet<EventType> eventsToFireOn;

--- a/impl/src/test/java/org/ehcache/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/GettingStarted.java
@@ -202,12 +202,12 @@ public class GettingStarted {
     performAssertions(cache1, true);
 
     final Cache<Long, String> cache2 = cacheManager.createCache("cache2",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder().addServiceConfig(new OnHeapStoreServiceConfig().storeByValue(true))
+        CacheConfigurationBuilder.newCacheConfigurationBuilder().add(new OnHeapStoreServiceConfig().storeByValue(true))
             .buildConfig(Long.class, String.class));
     performAssertions(cache2, false);
 
     final Cache<Long, String> cache3 = cacheManager.createCache("cache3",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder().addServiceConfig(new OnHeapStoreServiceConfig().storeByValue(false))
+        CacheConfigurationBuilder.newCacheConfigurationBuilder().add(new OnHeapStoreServiceConfig().storeByValue(false))
             .buildConfig(Long.class, String.class));
     performAssertions(cache3, true);
 
@@ -216,14 +216,14 @@ public class GettingStarted {
 
   @Test
   public void testCacheEventListener() {
-    DefaultCacheEventListenerConfiguration cacheEventListenerConfiguration = CacheEventListenerBuilder
+    CacheEventListenerBuilder cacheEventListenerConfiguration = CacheEventListenerBuilder
         .newEventListenerConfig(ListenerObject.class, EventType.CREATED, EventType.UPDATED)
-        .unordered().asynchronous().build();
+        .unordered().asynchronous();
     
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
             CacheConfigurationBuilder.newCacheConfigurationBuilder()
-                .addServiceConfig(cacheEventListenerConfiguration)
+                .add(cacheEventListenerConfiguration)
                 .buildConfig(String.class, String.class)).build(true);
 
     final Cache<String, String> cache = manager.getCache("foo", String.class, String.class);
@@ -245,7 +245,7 @@ public class GettingStarted {
     
     final Cache<Long, String> writeThroughCache = cacheManager.createCache("writeThroughCache", 
         CacheConfigurationBuilder.newCacheConfigurationBuilder()
-            .addServiceConfig(new DefaultCacheLoaderWriterConfiguration(klazz)) // <1>
+            .add(new DefaultCacheLoaderWriterConfiguration(klazz)) // <1>
             .buildConfig(Long.class, String.class));
     
     writeThroughCache.put(42L, "one");
@@ -265,8 +265,8 @@ public class GettingStarted {
     
     final Cache<Long, String> writeBehindCache = cacheManager.createCache("writeBehindCache", 
         CacheConfigurationBuilder.newCacheConfigurationBuilder()
-            .addServiceConfig(new DefaultCacheLoaderWriterConfiguration(klazz)) // <1>
-            .addServiceConfig(WriteBehindConfigurationBuilder.newWriteBehindConfiguration() // <2> 
+            .add(new DefaultCacheLoaderWriterConfiguration(klazz)) // <1>
+            .add(WriteBehindConfigurationBuilder.newWriteBehindConfiguration() // <2>
                 .queueSize(3)// <3>
                 .concurrencyLevel(1) // <4>
                 .batchSize(3) // <5>

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
@@ -63,7 +63,7 @@ public class WriteBehindEvictionTest extends AbstractWriteBehindTestBase {
     testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder()
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(100, TimeUnit.MILLISECONDS)))
         .withResourcePools(resourcePoolsBuilder)
-        .addServiceConfig(writeBehindConfiguration)
+        .add(writeBehindConfiguration)
         .buildConfig(String.class, String.class));
 
   }

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindTest.java
@@ -57,7 +57,7 @@ public class WriteBehindTest extends AbstractWriteBehindTestBase {
     cacheManager = builder.build(true);
     testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder()
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS)))
-        .addServiceConfig(writeBehindConfiguration)
+        .add(writeBehindConfiguration)
         .buildConfig(String.class, String.class));
 
   }

--- a/impl/src/test/java/org/ehcache/spi/event/DefaultCacheEventListenerFactoryTest.java
+++ b/impl/src/test/java/org/ehcache/spi/event/DefaultCacheEventListenerFactoryTest.java
@@ -54,7 +54,7 @@ public class DefaultCacheEventListenerFactoryTest {
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
             CacheConfigurationBuilder.newCacheConfigurationBuilder()
-                .addServiceConfig(cacheEventListenerConfiguration)
+                .add(cacheEventListenerConfiguration)
                 .buildConfig(Object.class, Object.class)).build(true);
     final Collection<?> bar = manager.getCache("foo", Object.class, Object.class).getRuntimeConfiguration().getServiceConfigurations();
     assertThat(bar.iterator().next().getClass().toString(), is(ListenerObject.object.toString()));

--- a/impl/src/test/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterFactoryTest.java
+++ b/impl/src/test/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterFactoryTest.java
@@ -38,7 +38,7 @@ public class DefaultCacheLoaderWriterFactoryTest {
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
             CacheConfigurationBuilder.newCacheConfigurationBuilder()
-                .addServiceConfig(new DefaultCacheLoaderWriterConfiguration(MyLoader.class))
+                .add(new DefaultCacheLoaderWriterConfiguration(MyLoader.class))
                 .buildConfig(Object.class, Object.class)).build(true);
     final Object foo = manager.getCache("foo", Object.class, Object.class).get(new Object());
     assertThat(foo, is(MyLoader.object));
@@ -63,7 +63,7 @@ public class DefaultCacheLoaderWriterFactoryTest {
   @Test
   public void testCacheConfigOverridesCacheManagerConfig() {
     final CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
-        .addServiceConfig(new DefaultCacheLoaderWriterConfiguration(MyOtherLoader.class))
+        .add(new DefaultCacheLoaderWriterConfiguration(MyOtherLoader.class))
         .buildConfig(Object.class, Object.class);
 
     final Map<String, CacheConfiguration<?, ?>> caches = new HashMap<String, CacheConfiguration<?, ?>>();

--- a/integration-test/src/test/java/org/ehcache/integration/ExpiryEhcacheTestBase.java
+++ b/integration-test/src/test/java/org/ehcache/integration/ExpiryEhcacheTestBase.java
@@ -53,7 +53,7 @@ public abstract class ExpiryEhcacheTestBase {
     CacheManagerBuilder<CacheManager> builder = CacheManagerBuilder.newCacheManagerBuilder();
     cacheManager = builder.build(true);
     CacheConfigurationBuilder<Object, Object> objectObjectCacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
-        .addServiceConfig(new TimeSourceConfiguration(manualTimeSource))
+        .add(new TimeSourceConfiguration(manualTimeSource))
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.SECONDS)));
     testCache = cacheManager.createCache("testCache", objectObjectCacheConfigurationBuilder.buildConfig(Number.class, CharSequence.class));
   }

--- a/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
@@ -178,13 +178,13 @@ public class XmlConfiguration implements Configuration {
       for (ResourcePool resourcePool : cacheDefinition.resourcePools()) {
         resourcePoolsBuilder = resourcePoolsBuilder.with(resourcePool.getType(), resourcePool.getSize(), resourcePool.getUnit(), resourcePool.isPersistent());
       }
-      builder.withResourcePools(resourcePoolsBuilder);
+      builder = builder.withResourcePools(resourcePoolsBuilder);
       for (ServiceConfiguration<?> serviceConfig : cacheDefinition.serviceConfigs()) {
-        builder = builder.addServiceConfig(serviceConfig);
+        builder = builder.add(serviceConfig);
       }
       if(cacheDefinition.loaderWriter()!= null) {
         final Class<CacheLoaderWriter<?, ?>> cacheLoaderWriterClass = (Class<CacheLoaderWriter<?,?>>)getClassForName(cacheDefinition.loaderWriter(), cacheClassLoader);
-        builder = builder.addServiceConfig(new DefaultCacheLoaderWriterConfiguration(cacheLoaderWriterClass));
+        builder = builder.add(new DefaultCacheLoaderWriterConfiguration(cacheLoaderWriterClass));
         if(cacheDefinition.writeBehind() != null) {
           WriteBehind writeBehind = cacheDefinition.writeBehind();
           WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
@@ -197,7 +197,7 @@ public class XmlConfiguration implements Configuration {
           if(writeBehind.isCoalesced()) {
             writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.enableCoalescing();
           }
-          builder = builder.addServiceConfig(writeBehindConfigurationBuilder.build());
+          builder = builder.add(writeBehindConfigurationBuilder);
         }
       }
       if(cacheDefinition.listeners()!= null) {
@@ -230,13 +230,12 @@ public class XmlConfiguration implements Configuration {
               .newEventListenerConfig(cacheEventListenerClass, eventSetToFireOn);
           listenerBuilder.firingMode(EventFiring.valueOf(listener.eventFiring().value()));
           listenerBuilder.eventOrdering(EventOrdering.valueOf(listener.eventOrdering().value()));
-          DefaultCacheEventListenerConfiguration defaultCacheEventListenerConfiguration = listenerBuilder.build();
-          builder = builder.addServiceConfig(defaultCacheEventListenerConfiguration);
+          builder = builder.add(listenerBuilder);
         }
       }
       final OnHeapStoreServiceConfig onHeapStoreServiceConfig = new OnHeapStoreServiceConfig();
       onHeapStoreServiceConfig.storeByValue(cacheDefinition.storeByValueOnHeap());
-      builder.addServiceConfig(onHeapStoreServiceConfig);
+      builder = builder.add(onHeapStoreServiceConfig);
       final CacheConfiguration<?, ?> config = builder.buildConfig(keyType, valueType, evictionVeto, evictionPrioritizer);
       cacheConfigurations.put(alias, config);
     }
@@ -359,7 +358,7 @@ public class XmlConfiguration implements Configuration {
     final String loaderWriter = cacheTemplate.loaderWriter();
     if(loaderWriter!= null) {
       final Class<CacheLoaderWriter<?, ?>> cacheLoaderWriterClass = (Class<CacheLoaderWriter<?,?>>)getClassForName(loaderWriter, defaultClassLoader);
-      builder = builder.addServiceConfig(new DefaultCacheLoaderWriterConfiguration(cacheLoaderWriterClass));
+      builder = builder.add(new DefaultCacheLoaderWriterConfiguration(cacheLoaderWriterClass));
       if(cacheTemplate.writeBehind() != null) {
         WriteBehind writeBehind = cacheTemplate.writeBehind();
         WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
@@ -372,7 +371,7 @@ public class XmlConfiguration implements Configuration {
         if(writeBehind.isCoalesced()) {
           writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.enableCoalescing();
         }
-        builder = builder.addServiceConfig(writeBehindConfigurationBuilder.build());
+        builder = builder.add(writeBehindConfigurationBuilder);
       }
     }
     if(cacheTemplate.listeners()!= null) {
@@ -405,22 +404,20 @@ public class XmlConfiguration implements Configuration {
             .newEventListenerConfig(cacheEventListenerClass, eventSetToFireOn);
         listenerBuilder.firingMode(EventFiring.valueOf(listener.eventFiring().value()));
         listenerBuilder.eventOrdering(EventOrdering.valueOf(listener.eventOrdering().value()));
-        DefaultCacheEventListenerConfiguration defaultCacheEventListenerConfiguration
-            = listenerBuilder.build();
-        builder = builder.addServiceConfig(defaultCacheEventListenerConfiguration);
+        builder = builder.add(listenerBuilder);
       }
     }
     ResourcePoolsBuilder resourcePoolsBuilder = newResourcePoolsBuilder();
     for (ResourcePool resourcePool : cacheTemplate.resourcePools()) {
       resourcePoolsBuilder = resourcePoolsBuilder.with(resourcePool.getType(), resourcePool.getSize(), resourcePool.getUnit(), resourcePool.isPersistent());
     }
-    builder.withResourcePools(resourcePoolsBuilder);
+    builder = builder.withResourcePools(resourcePoolsBuilder);
     for (ServiceConfiguration<?> serviceConfiguration : cacheTemplate.serviceConfigs()) {
-      builder = builder.addServiceConfig(serviceConfiguration);
+      builder = builder.add(serviceConfiguration);
     }
     final OnHeapStoreServiceConfig onHeapStoreServiceConfig = new OnHeapStoreServiceConfig();
     onHeapStoreServiceConfig.storeByValue(cacheTemplate.storeByValueOnHeap());
-    builder.addServiceConfig(onHeapStoreServiceConfig);
+    builder = builder.add(onHeapStoreServiceConfig);
     return builder;
   }
 


### PR DESCRIPTION
* Always copy when modifying
* Rename addServiceConfig to add and removeServiceConfig to remove
* Overload add to take a Builder<? extends ServiceConfiguration<?>>, introducing that new interface
* WriteBehindConfigurationBuilder and CacheEventListenerBuilder now implements Builder
* Fix all CacheConfigurationBuilder usage to take method return into account