### PR TITLE
Issue #413 : Fixing WriteBehind writer blocks cache put operation

### DIFF
--- a/impl/src/main/java/org/ehcache/internal/classes/ClassInstanceProvider.java
+++ b/impl/src/main/java/org/ehcache/internal/classes/ClassInstanceProvider.java
@@ -97,9 +97,14 @@ public class ClassInstanceProvider<T> {
   }
 
   public void start(ServiceConfiguration<?> config, ServiceProvider serviceProvider) {
-    if (config != null && factoryConfig.isAssignableFrom(config.getClass())) {
-      ClassInstanceProviderFactoryConfiguration<T> instanceProviderFactoryConfig = factoryConfig.cast(config);
-      preconfiguredLoaders.putAll(instanceProviderFactoryConfig.getDefaults());
+    if (config != null ) {
+      if(cacheLevelConfig.isAssignableFrom(config.getClass())) {
+        throw new IllegalArgumentException(cacheLevelConfig.getSimpleName() + " must not be provided at CacheManager level");
+      }
+      if(factoryConfig.isAssignableFrom(config.getClass())) {
+        ClassInstanceProviderFactoryConfiguration<T> instanceProviderFactoryConfig = factoryConfig.cast(config);
+        preconfiguredLoaders.putAll(instanceProviderFactoryConfig.getDefaults());
+      }
     }
   }
 

--- a/impl/src/main/java/org/ehcache/loaderwriter/writebehind/WriteBehindDecoratorLoaderWriterProviderFactory.java
+++ b/impl/src/main/java/org/ehcache/loaderwriter/writebehind/WriteBehindDecoratorLoaderWriterProviderFactory.java
@@ -43,8 +43,9 @@ public class WriteBehindDecoratorLoaderWriterProviderFactory implements ServiceF
       
       @Override
       public void start(ServiceConfiguration<?> config, ServiceProvider serviceProvider) {
-        // no op
-        
+        if (config != null) {
+          throw new IllegalArgumentException("WriteBehind configuration must not be provided at CacheManager level");
+        }
       }
       
       @Override

--- a/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterFactory.java
+++ b/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterFactory.java
@@ -40,5 +40,4 @@ public class DefaultCacheLoaderWriterFactory extends ClassInstanceProvider<Cache
   public void releaseCacheLoaderWriter(final CacheLoaderWriter<?, ?> cacheLoaderWriter) {
     // noop
   }
-
 }

--- a/impl/src/test/java/org/ehcache/WriteBehindDecoratorLoaderWriterProviderFactoryTest.java
+++ b/impl/src/test/java/org/ehcache/WriteBehindDecoratorLoaderWriterProviderFactoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache;
+
+import org.ehcache.config.CacheConfigurationBuilder;
+import org.ehcache.config.ResourcePoolsBuilder;
+import org.ehcache.config.loaderwriter.DefaultCacheLoaderWriterConfiguration;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.writebehind.WriteBehindConfigurationBuilder;
+import org.ehcache.exceptions.StateTransitionException;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
+import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.hamcrest.core.IsCollectionContaining;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author rism
+ */
+public class WriteBehindDecoratorLoaderWriterProviderFactoryTest {
+  
+  @Test
+  public void testAddingWriteBehindConfigurationAtManagerLevelThrows() {
+    CacheManagerBuilder<CacheManager> cacheManagerBuilder = CacheManagerBuilder.newCacheManagerBuilder();
+    WriteBehindConfiguration writeBehindConfiguration = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
+        .concurrencyLevel(3).batchSize(1)
+        .queueSize(10)
+        .build();
+    cacheManagerBuilder.using(writeBehindConfiguration);
+    CacheManager cacheManager = null;
+    try {
+      cacheManager = cacheManagerBuilder.build(true);
+    } catch (StateTransitionException ste) {
+      assertThat(ste.getMessage(), is("WriteBehind configuration must not be provided at CacheManager level"));
+    } finally {
+      if(cacheManager != null) {
+        cacheManager.close();
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testAddingWriteBehindConfigurationAtCacheLevel() {
+    CacheManagerBuilder<CacheManager> cacheManagerBuilder = CacheManagerBuilder.newCacheManagerBuilder();
+    WriteBehindConfiguration writeBehindConfiguration = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
+        .concurrencyLevel(3).batchSize(1)
+        .queueSize(10)
+        .build();
+    Class<CacheLoaderWriter<?, ?>> klazz = (Class<CacheLoaderWriter<?, ?>>) (Class) (SampleLoaderWriter.class);
+    CacheManager cacheManager = cacheManagerBuilder.build(true);
+    final Cache<Long, String> cache = cacheManager.createCache("cache",
+        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+            .add(writeBehindConfiguration)
+            .add(new DefaultCacheLoaderWriterConfiguration(klazz))
+            .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .heap(100, EntryUnit.ENTRIES).build())
+            .buildConfig(Long.class, String.class));
+    Collection<ServiceConfiguration<?>> serviceConfiguration = cache.getRuntimeConfiguration()
+        .getServiceConfigurations();
+    assertThat(serviceConfiguration, IsCollectionContaining.<ServiceConfiguration<?>>hasItem(instanceOf(WriteBehindConfiguration.class)));
+    cacheManager.close();
+  }
+
+  public static class SampleLoaderWriter<K, V> implements CacheLoaderWriter<K, V> {
+
+    @Override
+    public V load(K key) throws Exception {
+      throw new UnsupportedOperationException("Implement Me");
+    }
+
+    @Override
+    public Map<K, V> loadAll(Iterable<? extends K> keys) throws Exception {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
+    public void write(K key, V value) throws Exception {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
+    public void writeAll(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries) throws Exception {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
+    public void delete(K key) throws Exception {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends K> keys) throws Exception {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+  }
+}

--- a/impl/src/test/java/org/ehcache/internal/classes/ClassInstanceProviderTest.java
+++ b/impl/src/test/java/org/ehcache/internal/classes/ClassInstanceProviderTest.java
@@ -72,6 +72,17 @@ public class ClassInstanceProviderTest {
     TestService obj = classInstanceProvider.newInstance("test stuff", (ServiceConfiguration) null);
     assertThat(obj.theString, is(nullValue()));
   }
+  
+  @Test
+  public void testAddingCacheLevelConfigurationAtCacheManagerLevel() {
+    ClassInstanceProvider<TestService> classInstanceProvider = new ClassInstanceProvider<TestService>((Class)ClassInstanceProviderFactoryConfiguration.class, (Class)ClassInstanceProviderConfiguration.class);
+    TestServiceProviderConfiguration cacheLevelConfig = new TestServiceProviderConfiguration();
+    try {
+      classInstanceProvider.start(cacheLevelConfig, null);
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage(), is("ClassInstanceProviderConfiguration must not be provided at CacheManager level"));
+    }
+  }
 
   public static class TestService implements Service {
     public final String theString;


### PR DESCRIPTION
Added validations to disallow cache specific configurations to be added at cache manager level