### PR TITLE
Issue #448 : extract out single arg null check method

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -1077,20 +1077,22 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V>, Persi
     statusTransitioner.removeHook(hook);
   }
 
+  private static void checkNonNull(Object thing) {
+    if(thing == null) {
+      throw new NullPointerException();
+    }
+  }
+
   private static void checkNonNull(Object... things) {
     for (Object thing : things) {
-      if(thing == null) {
-        throw new NullPointerException();
-      }
+      checkNonNull(thing);
     }
   }
   
   private void checkNonNullContent(Collection<?> collectionOfThings) {
     checkNonNull(collectionOfThings);
     for (Object thing : collectionOfThings) {
-      if (thing == null) {
-        throw new NullPointerException();
-      }
+      checkNonNull(thing);
     }
   }
 


### PR DESCRIPTION
I left out specializing the 2-arg version because it's only called from mutative methods, and hence the gc cost will probably be lost (until proven otherwise at least).