### PR TITLE
Issue #355 rework persistence service

### DIFF
--- a/core/src/main/java/org/ehcache/spi/service/FileBasedPersistenceContext.java
+++ b/core/src/main/java/org/ehcache/spi/service/FileBasedPersistenceContext.java
@@ -22,7 +22,5 @@ import java.io.File;
  * FileBased
  */
 public interface FileBasedPersistenceContext {
-  File getDataFile();
-
-  File getIndexFile();
+  File getDirectory();
 }


### PR DESCRIPTION
* a directory for each context, and no assumptions about index and data files.
* a reworked naming scheme that avoids escaping capital letters and instead relies on a SHA1 suffix to prevent FS limitation induced collisions.