### PR TITLE
Issue #457

### DIFF
--- a/api/src/main/java/org/ehcache/event/CacheEventListenerProvider.java
+++ b/api/src/main/java/org/ehcache/event/CacheEventListenerProvider.java
@@ -16,12 +16,14 @@
 
 package org.ehcache.event;
 
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceConfiguration;
 
 /**
  * @author Alex Snaps
  */
+@MandatoryService
 public interface CacheEventListenerProvider extends Service {
 
   /**

--- a/api/src/main/java/org/ehcache/spi/ServiceProvider.java
+++ b/api/src/main/java/org/ehcache/spi/ServiceProvider.java
@@ -21,32 +21,22 @@ import org.ehcache.spi.service.ServiceConfiguration;
 
 /**
  *
- * This acts as a repository for {@link Service} instances, that can be use to
- * look them up by type, or their {@link ServiceConfiguration} type.
+ * This acts as a repository for {@link Service} instances, that can be used to
+ * look them up by type.
  *
  * @author Alex Snaps
  */
 public interface ServiceProvider {
 
   /**
-   * Will look up the {@link Service} configured by the {@code config} type. Should the {@link Service} not yet started,
-   * it will be started, passed that {@link ServiceConfiguration} instance. Otherwise it is only used to find the
-   * matching {@link Service} instance.
+   * Will look up the {@link Service} of the {@code serviceType} type.
+   * If no matching {@link Service} can be found, this method will only try to resolve one if it carries the
+   * {@link org.ehcache.spi.service.MandatoryService} annotation.
+   * The returned service will be started or not depending on the started state of the {@code ServiceProvider}.
    *
-   * @param config The type configuring the Service being looked up
-   * @param <T> The actual {@link Service} implementation
-   * @return the service instance for {@code T} type, or null if it couldn't be located
-   */
-  <T extends Service> T findServiceFor(ServiceConfiguration<T> config);
-
-  /**
-   * Will look up the {@link Service} of the {@code serviceType} type. Should the {@link Service} not yet started,
-   * it will be started with a {@code null} {@link ServiceConfiguration} passed to its
-   * {@link Service#start(org.ehcache.spi.service.ServiceConfiguration, ServiceProvider)} method.
-   *
-   * @param serviceType the Class of the instance being looked up
-   * @param <T> The actual {@link Service} implementation
-   * @return the service instance for {@code T} type, or null if it couldn't be located
+   * @param serviceType the {@code class} of the service being looked up
+   * @param <T> The actual {@link Service} type
+   * @return the service instance for {@code T} type, or {@code null} if it couldn't be located
    */
   <T extends Service> T findService(Class<T> serviceType);
 }

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/CacheLoaderWriterProvider.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/CacheLoaderWriterProvider.java
@@ -17,6 +17,7 @@
 package org.ehcache.spi.loaderwriter;
 
 import org.ehcache.config.CacheConfiguration;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 
 /**
@@ -32,6 +33,7 @@ import org.ehcache.spi.service.Service;
  *
  * @author Alex Snaps
  */
+@MandatoryService
 public interface CacheLoaderWriterProvider extends Service {
 
   /**

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindDecoratorLoaderWriterProvider.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindDecoratorLoaderWriterProvider.java
@@ -15,12 +15,14 @@
  */
 package org.ehcache.spi.loaderwriter;
 
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 
 /**
  * @author Abhilash
  *
  */
+@MandatoryService
 public interface WriteBehindDecoratorLoaderWriterProvider extends Service {
   
   /**

--- a/api/src/main/java/org/ehcache/spi/serialization/SerializationProvider.java
+++ b/api/src/main/java/org/ehcache/spi/serialization/SerializationProvider.java
@@ -15,6 +15,7 @@
  */
 package org.ehcache.spi.serialization;
 
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -23,6 +24,7 @@ import org.ehcache.spi.service.ServiceConfiguration;
  *
  * @author cdennis
  */
+@MandatoryService
 public interface SerializationProvider extends Service {
 
   /**

--- a/api/src/main/java/org/ehcache/spi/service/MandatoryService.java
+++ b/api/src/main/java/org/ehcache/spi/service/MandatoryService.java
@@ -16,19 +16,16 @@
 
 package org.ehcache.spi.service;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * @author Ludovic Orban
+ * MandatoryService is a marker annotation indicating that a {@link Service} must be loaded even when no configuration
+ * for it has been provided.
  */
-@MandatoryService
-public interface ThreadPoolsService extends Service {
-
-  ScheduledExecutorService getStatisticsExecutor();
-
-  ExecutorService getEventsOrderedDeliveryExecutor();
-
-  ExecutorService getEventsUnorderedDeliveryExecutor();
-
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MandatoryService {
 }

--- a/core/src/main/java/org/ehcache/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/EhcacheManager.java
@@ -341,7 +341,6 @@ public class EhcacheManager implements PersistentCacheManager {
       Collection<CacheEventListenerConfiguration> evtLsnrConfigs =
       ServiceLocator.findAmongst(CacheEventListenerConfiguration.class, config.getServiceConfigurations().toArray());
       for (CacheEventListenerConfiguration lsnrConfig: evtLsnrConfigs) {
-        // XXX this assumes a new instance returned for each call - yet args are always the same. Is this okay?
         final CacheEventListener<K, V> lsnr = evntLsnrFactory.createEventListener(alias, lsnrConfig);
         if (lsnr != null) {
           ehCache.getRuntimeConfiguration().registerCacheEventListener(lsnr, lsnrConfig.orderingMode(), lsnrConfig.firingMode(),

--- a/core/src/main/java/org/ehcache/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/EhcacheManager.java
@@ -390,12 +390,9 @@ public class EhcacheManager implements PersistentCacheManager {
     final StatusTransitioner.Transition st = statusTransitioner.init();
 
     try {
-      Map<Service, ServiceConfiguration<?>> serviceConfigs = new HashMap<Service, ServiceConfiguration<?>>();
-      for (ServiceConfiguration<?> serviceConfig : configuration.getServiceConfigurations()) {
-        Service service = serviceLocator.discoverService(serviceConfig);
-        if(service == null) {
-          service = serviceLocator.findService(serviceConfig.getServiceType());
-        }
+      Map<Service, ServiceConfiguration<? extends Service>> serviceConfigs = new HashMap<Service, ServiceConfiguration<? extends Service>>();
+      for (ServiceConfiguration<? extends Service> serviceConfig : configuration.getServiceConfigurations()) {
+        Service service = serviceLocator.findServiceFor(serviceConfig);
         if (service == null) {
           throw new IllegalArgumentException("Couldn't resolve Service " + serviceConfig.getServiceType().getName());
         }

--- a/core/src/main/java/org/ehcache/UserManagedCacheBuilder.java
+++ b/core/src/main/java/org/ehcache/UserManagedCacheBuilder.java
@@ -78,16 +78,13 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> {
     try {
       Map<Service, ServiceConfiguration<?>> serviceConfigs = new HashMap<Service, ServiceConfiguration<?>>();
       for (ServiceConfiguration<?> serviceConfig : serviceCfgs) {
-        Service service = serviceLocator.discoverService(serviceConfig);
-        if(service == null) {
-          service = serviceLocator.findService(serviceConfig.getServiceType());
-        }
+        Service service = serviceLocator.findServiceFor(serviceConfig);
         if (service == null) {
           throw new IllegalArgumentException("Couldn't resolve Service " + serviceConfig.getServiceType().getName());
         }
         serviceConfigs.put(service, serviceConfig);
       }
-      serviceLocator.startAllServices(new HashMap<Service, ServiceConfiguration<?>>());
+      serviceLocator.startAllServices(serviceConfigs);
     } catch (Exception e) {
       throw new IllegalStateException("UserManagedCacheBuilder failed to build.", e);
     }

--- a/core/src/main/java/org/ehcache/UserManagedCacheBuilder.java
+++ b/core/src/main/java/org/ehcache/UserManagedCacheBuilder.java
@@ -118,8 +118,13 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> {
       }
     };
     if (persistent) {
-      PersistentUserManagedEhcache<K, V> cache = new PersistentUserManagedEhcache<K, V>(runtimeConfiguration, store, (Store.PersistentStoreConfiguration) storeConfig, serviceLocator
-          .findService(LocalPersistenceService.class), cacheLoaderWriter, cacheEventNotificationService, id);
+      LocalPersistenceService persistenceService = serviceLocator
+          .findService(LocalPersistenceService.class);
+      if (persistenceService == null) {
+        throw new IllegalStateException("No LocalPersistenceService could be found - did you configure one?");
+      }
+
+      PersistentUserManagedEhcache<K, V> cache = new PersistentUserManagedEhcache<K, V>(runtimeConfiguration, store, (Store.PersistentStoreConfiguration) storeConfig, persistenceService, cacheLoaderWriter, cacheEventNotificationService, id);
       cache.addHook(lifeCycled);
       return cast(cache);
     } else {

--- a/core/src/main/java/org/ehcache/events/CacheEventNotificationListenerServiceProvider.java
+++ b/core/src/main/java/org/ehcache/events/CacheEventNotificationListenerServiceProvider.java
@@ -17,6 +17,7 @@ package org.ehcache.events;
 
 import org.ehcache.CacheManager;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 import org.ehcache.event.CacheEventListener;
 
@@ -26,6 +27,7 @@ import org.ehcache.event.CacheEventListener;
  * @author palmanojkumar
  *
  */
+@MandatoryService
 public interface CacheEventNotificationListenerServiceProvider extends Service {
 
   /**

--- a/core/src/main/java/org/ehcache/internal/TimeSourceService.java
+++ b/core/src/main/java/org/ehcache/internal/TimeSourceService.java
@@ -16,12 +16,13 @@
 
 package org.ehcache.internal;
 
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 
 /**
  * Service that offers a {@link TimeSource} to other services needing one.
  */
-// TODO @MandatoryService
+@MandatoryService
 public interface TimeSourceService extends Service {
 
   /**

--- a/core/src/main/java/org/ehcache/management/ManagementRegistry.java
+++ b/core/src/main/java/org/ehcache/management/ManagementRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.ehcache.management;
 
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 
 import java.util.Collection;
@@ -26,6 +27,7 @@ import java.util.Map;
  *
  * @author Ludovic Orban
  */
+@MandatoryService
 public interface ManagementRegistry extends Service {
 
   /**

--- a/core/src/main/java/org/ehcache/spi/ServiceLocator.java
+++ b/core/src/main/java/org/ehcache/spi/ServiceLocator.java
@@ -64,11 +64,7 @@ public final class ServiceLocator implements ServiceProvider {
     }
   }
 
-  public <T extends Service> T discoverService(Class<T> serviceClass) {
-    return discoverService(serviceClass, null);
-  }
-
-  public <T extends Service> T discoverService(Class<T> serviceClass, ServiceConfiguration<T> config) {
+  private <T extends Service> T discoverService(Class<T> serviceClass, ServiceConfiguration<T> config) {
     // TODO Fix me!
     for (ServiceFactory<T> factory : ServiceLocator.<T> getServiceFactories(serviceFactory)) {
       if (serviceClass.isAssignableFrom(factory.getServiceType())) {
@@ -89,10 +85,6 @@ public final class ServiceLocator implements ServiceProvider {
     return list;
   }
 
-  public <T extends Service> T discoverService(ServiceConfiguration<T> config) {
-    return discoverService(config.getServiceType(), config);
-  }
-  
   public void addService(final Service service) {
     addService(service, false);
   }

--- a/core/src/main/java/org/ehcache/spi/ServiceLocator.java
+++ b/core/src/main/java/org/ehcache/spi/ServiceLocator.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.spi;
 
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.ServiceFactory;
@@ -156,7 +157,6 @@ public final class ServiceLocator implements ServiceProvider {
     return interfaces;
   }
 
-  @Override
   public <T extends Service> T findServiceFor(ServiceConfiguration<T> config) {
     return findService(config.getServiceType(), config);
   }
@@ -168,13 +168,17 @@ public final class ServiceLocator implements ServiceProvider {
 
   public <T extends Service> T findService(Class<T> serviceType, ServiceConfiguration<T> config) {
     T service = serviceType.cast(services.get(serviceType));
-    if (service == null) {
+    if (service == null && (config != null || isMandatoryService(serviceType))) {
       return discoverService(serviceType, config);
     } else {
       return service;
     }
   }
-  
+
+  private <T extends Service> boolean isMandatoryService(Class<T> serviceType) {
+    return serviceType.isAnnotationPresent(MandatoryService.class);
+  }
+
   public static <T> Collection<T> findAmongst(Class<T> clazz, Object ... instances) {
     Collection<T> matches = new ArrayList<T>();
     for (Object instance : instances) {

--- a/core/src/main/java/org/ehcache/spi/cache/Store.java
+++ b/core/src/main/java/org/ehcache/spi/cache/Store.java
@@ -27,6 +27,7 @@ import org.ehcache.expiry.Expiry;
 import org.ehcache.function.BiFunction;
 import org.ehcache.function.Function;
 import org.ehcache.function.NullaryFunction;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -422,6 +423,7 @@ public interface Store<K, V> {
    * The Service used to create Stores.
    * Implementation of {@link Provider} have be thread-safe.
    */
+  @MandatoryService
   interface Provider extends Service {
 
     /**

--- a/core/src/test/java/org/ehcache/spi/ServiceLocatorTest.java
+++ b/core/src/test/java/org/ehcache/spi/ServiceLocatorTest.java
@@ -27,6 +27,8 @@ import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.SupplementaryService;
+import org.ehcache.spi.services.DefaultTestService;
+import org.ehcache.spi.services.TestService;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
@@ -97,7 +99,7 @@ public class ServiceLocatorTest {
     });
     
     ServiceLocator serviceLocator = new ServiceLocator();
-    serviceLocator.discoverService(Service.class);
+    serviceLocator.findService(TestService.class);
   }
 
   @Test
@@ -157,6 +159,17 @@ public class ServiceLocatorTest {
     locator.stopAllServices();
     verify(s1, times(1)).stop();
   }
+
+  @Test
+  public void testCanOverrideDefaultServiceFromServiceLoader() {
+    ServiceLocator locator = new ServiceLocator(new ExtendedTestService());
+    TestService testService = locator.findService(TestService.class);
+    assertThat(testService, instanceOf(ExtendedTestService.class));
+  }
+}
+
+class ExtendedTestService extends DefaultTestService {
+
 }
 
 interface FooProvider extends Service {

--- a/core/src/test/java/org/ehcache/spi/services/DefaultTestService.java
+++ b/core/src/test/java/org/ehcache/spi/services/DefaultTestService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.services;
+
+import org.ehcache.spi.ServiceProvider;
+import org.ehcache.spi.service.ServiceConfiguration;
+
+/**
+ * DefaultTestService
+ */
+public class DefaultTestService implements TestService {
+  @Override
+  public void start(ServiceConfiguration<?> config, ServiceProvider serviceProvider) {
+    throw new UnsupportedOperationException("TODO Implement me!");
+  }
+
+  @Override
+  public void stop() {
+    throw new UnsupportedOperationException("TODO Implement me!");
+  }
+}

--- a/core/src/test/java/org/ehcache/spi/services/TestService.java
+++ b/core/src/test/java/org/ehcache/spi/services/TestService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.services;
+
+import org.ehcache.spi.service.Service;
+
+/**
+ * TestService
+ */
+public interface TestService extends Service {
+}

--- a/core/src/test/java/org/ehcache/spi/services/TestServiceFactory.java
+++ b/core/src/test/java/org/ehcache/spi/services/TestServiceFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.services;
+
+import org.ehcache.spi.ServiceLocator;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.ehcache.spi.service.ServiceFactory;
+
+/**
+ * TestServiceFactory
+ */
+public class TestServiceFactory implements ServiceFactory<TestService> {
+  @Override
+  public TestService create(ServiceConfiguration<TestService> serviceConfiguration, ServiceLocator serviceLocator) {
+    return new DefaultTestService();
+  }
+
+  @Override
+  public Class<TestService> getServiceType() {
+    return TestService.class;
+  }
+}

--- a/core/src/test/resources/META-INF/services/org.ehcache.spi.service.ServiceFactory
+++ b/core/src/test/resources/META-INF/services/org.ehcache.spi.service.ServiceFactory
@@ -1,0 +1,17 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.ehcache.spi.services.TestServiceFactory

--- a/impl/src/main/java/org/ehcache/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/disk/OffHeapDiskStore.java
@@ -39,6 +39,7 @@ import org.ehcache.spi.serialization.SerializationProvider;
 import org.ehcache.spi.serialization.Serializer;
 import org.ehcache.spi.service.FileBasedPersistenceContext;
 import org.ehcache.spi.service.LocalPersistenceService;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.SupplementaryService;
 import org.ehcache.util.ConcurrentWeakIdentityHashMap;
@@ -224,6 +225,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
   }
 
   @SupplementaryService
+  @MandatoryService
   public static class Provider implements Store.Provider, AuthoritativeTier.Provider {
 
     private volatile ServiceProvider serviceProvider;

--- a/impl/src/main/java/org/ehcache/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/disk/OffHeapDiskStore.java
@@ -254,6 +254,9 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
       MemoryUnit unit = (MemoryUnit)offHeapPool.getUnit();
 
       LocalPersistenceService localPersistenceService = serviceProvider.findService(LocalPersistenceService.class);
+      if (localPersistenceService == null) {
+        throw new IllegalStateException("No LocalPersistenceService could be found - did you configure it at the CacheManager level?");
+      }
 
       try {
         FileBasedPersistenceContext persistenceContext = localPersistenceService.createPersistenceContext(persistentStoreConfiguration

--- a/impl/src/main/java/org/ehcache/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/heap/OnHeapStore.java
@@ -46,6 +46,7 @@ import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.cache.tiering.CachingTier;
 import org.ehcache.spi.serialization.SerializationProvider;
 import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.statistics.StoreOperationOutcomes;
 import org.ehcache.util.ConcurrentWeakIdentityHashMap;
@@ -974,6 +975,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, CachingTier<K, V> {
     return (o1 == o2) || (o1 != null && o1.equals(o2));
   }
 
+  @MandatoryService
   public static class Provider implements Store.Provider, CachingTier.Provider {
     
     private volatile ServiceProvider serviceProvider;

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/OffHeapStore.java
@@ -31,6 +31,7 @@ import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.cache.tiering.AuthoritativeTier;
 import org.ehcache.spi.serialization.SerializationProvider;
 import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.util.ConcurrentWeakIdentityHashMap;
 import org.terracotta.offheapstore.paging.PageSource;
@@ -107,6 +108,7 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
     return map;
   }
 
+  @MandatoryService
   public static class Provider implements Store.Provider, AuthoritativeTier.Provider {
 
     private volatile ServiceProvider serviceProvider;

--- a/impl/src/main/java/org/ehcache/internal/store/tiering/CacheStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/tiering/CacheStore.java
@@ -26,6 +26,7 @@ import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.cache.tiering.AuthoritativeTier;
 import org.ehcache.spi.cache.tiering.CachingTier;
+import org.ehcache.spi.service.MandatoryService;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.SupplementaryService;
 import org.ehcache.util.ConcurrentWeakIdentityHashMap;
@@ -340,6 +341,7 @@ public class CacheStore<K, V> implements Store<K, V> {
   }
 
   @SupplementaryService
+  @MandatoryService
   public static class Provider implements Store.Provider {
 
     private volatile ServiceProvider serviceProvider;


### PR DESCRIPTION
* Introduction of `MandatoryService` annotation to allow indication of `Service`s that must be loaded even when not explicitly configured
* Improve error reporting when no `LocalPersistenceService` can be found but a disk store is configured
* Misc cleanups in `ServiceProvider` and `ServiceLocator`
* One line delete on an old obsolete comment