### PR TITLE
Issue 365

### DIFF
--- a/api/src/main/java/org/ehcache/Cache.java
+++ b/api/src/main/java/org/ehcache/Cache.java
@@ -251,6 +251,35 @@ public interface Cache<K, V> extends Iterable<Cache.Entry<K,V>> {
   V computeIfAbsent(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException;
 
   /**
+   * Compute the value for the given key (only if present and non-expired) by invoking the given function to produce the value.
+   *
+   * This is equivalent to:
+   * <pre><code>
+   * if (cache.get(key) != null) {
+   *   V oldValue = map.get(key);
+   *   V newValue = remappingFunction.apply(key, oldValue);
+   *   if (newValue != null)
+   *     cache.put(key, newValue);
+   *   else
+   *     cache.remove(key);
+   * }
+   * </code></pre>
+   * except that the entire operation is performed atomically.
+   *
+   * @param key the key to be associated with
+   * @param mappingFunction the function that produces the value
+   * @return the value produced by the mappingFunction, or null if the key was absent
+   * @throws NullPointerException if any of the mappingFunction, or the key is null
+   * @throws CacheLoadingException if the {@link CacheLoaderWriter}
+   * associated with this cache was invoked and threw an {@link Exception} while loading
+   * the value for the key
+   * @throws CacheWritingException if the {@link CacheLoaderWriter}
+   * associated with this cache was invoked and threw an {@link Exception}
+   * while inserting, updating or deleting value for given key on underlying system of record.
+   */
+  V computeIfPresent(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction);
+
+  /**
    * Exposes the {@link org.ehcache.config.CacheRuntimeConfiguration} associated with this Cache instance.
    *
    * @return the configuration currently in use

--- a/api/src/main/java/org/ehcache/Cache.java
+++ b/api/src/main/java/org/ehcache/Cache.java
@@ -20,6 +20,7 @@ import org.ehcache.exceptions.BulkCacheLoadingException;
 import org.ehcache.exceptions.BulkCacheWritingException;
 import org.ehcache.exceptions.CacheLoadingException;
 import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.function.BiFunction;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 
 import java.util.Map;
@@ -188,6 +189,40 @@ public interface Cache<K, V> extends Iterable<Cache.Entry<K,V>> {
    * while replacing value for given key on underlying system of record.
   */
   boolean replace(K key, V oldValue, V newValue) throws CacheLoadingException, CacheWritingException;
+
+  /**
+   * Compute the value for the given key by invoking the given function to produce the value.
+   *
+   * This is equivalent to:
+   * <pre><code>
+   * V oldValue = cache.get(key);
+   * V newValue = remappingFunction.apply(key, oldValue);
+   * if (oldValue != null ) {
+   *   if (newValue != null)
+   *     cache.put(key, newValue);
+   *   else
+   *     cache.remove(key);
+   * } else {
+   *   if (newValue != null)
+   *     cache.put(key, newValue);
+   *   else
+   *     return null;
+   * }
+   * </code></pre>
+   * except that the entire operation is performed atomically.
+   *
+   * @param key the key to be associated with
+   * @param mappingFunction the function that produces the value
+   * @return the value produced by the mappingFunction
+   * @throws NullPointerException if any of the mappingFunction, or the key is null
+   * @throws CacheLoadingException if the {@link CacheLoaderWriter}
+   * associated with this cache was invoked and threw an {@link Exception} while loading
+   * the value for the key
+   * @throws CacheWritingException if the {@link CacheLoaderWriter}
+   * associated with this cache was invoked and threw an {@link Exception}
+   * while inserting, updating or deleting value for given key on underlying system of record.
+   */
+  V compute(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException;
 
   /**
    * Exposes the {@link org.ehcache.config.CacheRuntimeConfiguration} associated with this Cache instance.

--- a/api/src/main/java/org/ehcache/Cache.java
+++ b/api/src/main/java/org/ehcache/Cache.java
@@ -225,6 +225,32 @@ public interface Cache<K, V> extends Iterable<Cache.Entry<K,V>> {
   V compute(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException;
 
   /**
+   * Compute the value for the given key (only if absent or expired) by invoking the given function to produce the value.
+   *
+   * This is equivalent to:
+   * <pre><code>
+   * if (cache.get(key) == null) {
+   *   V newValue = mappingFunction.apply(key);
+   *   if (newValue != null)
+   *     cache.put(key, newValue);
+   * }
+   * </code></pre>
+   * except that the entire operation is performed atomically.
+   *
+   * @param key the key to be associated with
+   * @param mappingFunction the function that produces the value
+   * @return the value produced by the mappingFunction, or null if the key was present
+   * @throws NullPointerException if any of the mappingFunction, or the key is null
+   * @throws CacheLoadingException if the {@link CacheLoaderWriter}
+   * associated with this cache was invoked and threw an {@link Exception} while loading
+   * the value for the key
+   * @throws CacheWritingException if the {@link CacheLoaderWriter}
+   * associated with this cache was invoked and threw an {@link Exception}
+   * while inserting, updating or deleting value for given key on underlying system of record.
+   */
+  V computeIfAbsent(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException;
+
+  /**
    * Exposes the {@link org.ehcache.config.CacheRuntimeConfiguration} associated with this Cache instance.
    *
    * @return the configuration currently in use

--- a/api/src/main/java/org/ehcache/resilience/ResilienceStrategy.java
+++ b/api/src/main/java/org/ehcache/resilience/ResilienceStrategy.java
@@ -453,4 +453,36 @@ public interface ResilienceStrategy<K, V> {
    * @return the value to return from the operation
    */
   V computeIfAbsentFailure(K key, CacheAccessException e, CacheWritingException f);
+
+  /**
+   * Called when a {@link Cache#computeIfPresent(Object, BiFunction)} fails
+   * due to an underlying store failure.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeIfPresentFailure(K key, CacheAccessException e);
+
+  /**
+   * Called when a {@link Cache#computeIfPresent(Object, BiFunction)} fails
+   * due to an underlying store failure, and the associated cache load
+   * operation also failed.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeIfPresentFailure(K key, CacheAccessException e, CacheLoadingException f);
+
+  /**
+   * Called when a {@link Cache#computeIfPresent(Object, BiFunction)} fails
+   * due to an underlying store failure, and the associated cache write
+   * operation also failed.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeIfPresentFailure(K key, CacheAccessException e, CacheWritingException f);
 }

--- a/api/src/main/java/org/ehcache/resilience/ResilienceStrategy.java
+++ b/api/src/main/java/org/ehcache/resilience/ResilienceStrategy.java
@@ -24,6 +24,7 @@ import org.ehcache.exceptions.BulkCacheWritingException;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.exceptions.CacheLoadingException;
 import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.function.BiFunction;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 
 /**
@@ -388,4 +389,36 @@ public interface ResilienceStrategy<K, V> {
    * @return the value to return from the operation
    */
   Map<K, V> removeAllFailure(Iterable<? extends K> keys, CacheAccessException e, BulkCacheWritingException f);
+
+  /**
+   * Called when a {@link Cache#compute(Object, BiFunction)} fails
+   * due to an underlying store failure.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeFailure(K key, CacheAccessException e);
+
+  /**
+   * Called when a {@link Cache#compute(Object, BiFunction)} fails
+   * due to an underlying store failure, and the associated cache load
+   * operation also failed.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeFailure(K key, CacheAccessException e, CacheLoadingException f);
+
+  /**
+   * Called when a {@link Cache#compute(Object, BiFunction)} fails
+   * due to an underlying store failure, and the associated cache write
+   * operation also failed.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeFailure(K key, CacheAccessException e, CacheWritingException f);
 }

--- a/api/src/main/java/org/ehcache/resilience/ResilienceStrategy.java
+++ b/api/src/main/java/org/ehcache/resilience/ResilienceStrategy.java
@@ -421,4 +421,36 @@ public interface ResilienceStrategy<K, V> {
    * @return the value to return from the operation
    */
   V computeFailure(K key, CacheAccessException e, CacheWritingException f);
+
+  /**
+   * Called when a {@link Cache#computeIfAbsent(Object, BiFunction)} fails
+   * due to an underlying store failure.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeIfAbsentFailure(K key, CacheAccessException e);
+
+  /**
+   * Called when a {@link Cache#computeIfAbsent(Object, BiFunction)} fails
+   * due to an underlying store failure, and the associated cache load
+   * operation also failed.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeIfAbsentFailure(K key, CacheAccessException e, CacheLoadingException f);
+
+  /**
+   * Called when a {@link Cache#computeIfAbsent(Object, BiFunction)} fails
+   * due to an underlying store failure, and the associated cache write
+   * operation also failed.
+   *
+   * @param key the key being computed
+   * @param e the cache failure
+   * @return the value to return from the operation
+   */
+  V computeIfAbsentFailure(K key, CacheAccessException e, CacheWritingException f);
 }

--- a/core/src/main/java/org/ehcache/PersistentUserManagedEhcache.java
+++ b/core/src/main/java/org/ehcache/PersistentUserManagedEhcache.java
@@ -24,6 +24,7 @@ import org.ehcache.exceptions.BulkCacheWritingException;
 import org.ehcache.exceptions.CacheLoadingException;
 import org.ehcache.exceptions.CachePersistenceException;
 import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.function.BiFunction;
 import org.ehcache.spi.LifeCycled;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
@@ -182,6 +183,11 @@ public class PersistentUserManagedEhcache<K, V> implements PersistentUserManaged
   @Override
   public boolean replace(K key, V oldValue, V newValue) throws CacheLoadingException, CacheWritingException {
     return ehcache.replace(key, oldValue, newValue);
+  }
+
+  @Override
+  public V compute(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException {
+    return ehcache.compute(key, mappingFunction);
   }
 
   @Override

--- a/core/src/main/java/org/ehcache/PersistentUserManagedEhcache.java
+++ b/core/src/main/java/org/ehcache/PersistentUserManagedEhcache.java
@@ -196,6 +196,11 @@ public class PersistentUserManagedEhcache<K, V> implements PersistentUserManaged
   }
 
   @Override
+  public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) {
+    return ehcache.computeIfPresent(key, mappingFunction);
+  }
+
+  @Override
   public CacheRuntimeConfiguration<K, V> getRuntimeConfiguration() {
     return ehcache.getRuntimeConfiguration();
   }

--- a/core/src/main/java/org/ehcache/PersistentUserManagedEhcache.java
+++ b/core/src/main/java/org/ehcache/PersistentUserManagedEhcache.java
@@ -191,6 +191,11 @@ public class PersistentUserManagedEhcache<K, V> implements PersistentUserManaged
   }
 
   @Override
+  public V computeIfAbsent(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException {
+    return ehcache.computeIfAbsent(key, mappingFunction);
+  }
+
+  @Override
   public CacheRuntimeConfiguration<K, V> getRuntimeConfiguration() {
     return ehcache.getRuntimeConfiguration();
   }

--- a/core/src/main/java/org/ehcache/resilience/RobustResilienceStrategy.java
+++ b/core/src/main/java/org/ehcache/resilience/RobustResilienceStrategy.java
@@ -210,6 +210,24 @@ public abstract class RobustResilienceStrategy<K, V> implements ResilienceStrate
     throw f;
   }
 
+  @Override
+  public V computeFailure(K key, CacheAccessException e) {
+    cleanup(key, e);
+    return null;
+  }
+
+  @Override
+  public V computeFailure(K key, CacheAccessException e, CacheLoadingException f) {
+    cleanup(key, e);
+    throw f;
+  }
+
+  @Override
+  public V computeFailure(K key, CacheAccessException e, CacheWritingException f) {
+    cleanup(key, e);
+    throw f;
+  }
+
   private void cleanup(CacheAccessException from) {
     try {
       cache.obliterate();

--- a/core/src/main/java/org/ehcache/resilience/RobustResilienceStrategy.java
+++ b/core/src/main/java/org/ehcache/resilience/RobustResilienceStrategy.java
@@ -246,6 +246,24 @@ public abstract class RobustResilienceStrategy<K, V> implements ResilienceStrate
     return null;
   }
 
+  @Override
+  public V computeIfPresentFailure(K key, CacheAccessException e) {
+    cleanup(key, e);
+    return null;
+  }
+
+  @Override
+  public V computeIfPresentFailure(K key, CacheAccessException e, CacheLoadingException f) {
+    cleanup(key, e);
+    return null;
+  }
+
+  @Override
+  public V computeIfPresentFailure(K key, CacheAccessException e, CacheWritingException f) {
+    cleanup(key, e);
+    return null;
+  }
+
   private void cleanup(CacheAccessException from) {
     try {
       cache.obliterate();

--- a/core/src/main/java/org/ehcache/resilience/RobustResilienceStrategy.java
+++ b/core/src/main/java/org/ehcache/resilience/RobustResilienceStrategy.java
@@ -228,6 +228,24 @@ public abstract class RobustResilienceStrategy<K, V> implements ResilienceStrate
     throw f;
   }
 
+  @Override
+  public V computeIfAbsentFailure(K key, CacheAccessException e) {
+    cleanup(key, e);
+    return null;
+  }
+
+  @Override
+  public V computeIfAbsentFailure(K key, CacheAccessException e, CacheLoadingException f) {
+    cleanup(key, e);
+    return null;
+  }
+
+  @Override
+  public V computeIfAbsentFailure(K key, CacheAccessException e, CacheWritingException f) {
+    cleanup(key, e);
+    return null;
+  }
+
   private void cleanup(CacheAccessException from) {
     try {
       cache.obliterate();

--- a/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
@@ -96,5 +96,17 @@ public interface CacheOperationOutcomes {
     MISS_PRESENT,
     MISS_NOT_PRESENT,
     FAILURE
-  };  
+  };
+
+  /**
+   * The compute outcomes.
+   */
+  enum ComputeOutcome implements CacheOperationOutcomes {
+    PRESENT_UPDATED,
+    PRESENT_REMOVED,
+    PRESENT_NOOP,
+    NOT_PRESENT_ADDED,
+    NOT_PRESENT_NOOP,
+    FAILURE
+  };
 }

--- a/core/src/test/java/org/ehcache/EhcacheBasicComputeIfAbsentTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicComputeIfAbsentTest.java
@@ -1,0 +1,577 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache;
+
+import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.function.BiFunction;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
+import org.ehcache.statistics.CacheOperationOutcomes;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.EnumSet;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Provides testing of basic COMPUTEIFABSENT(key, function) operations on an {@code Ehcache}.
+ *
+ * @author Ludovic Orban
+ */
+public class EhcacheBasicComputeIfAbsentTest extends EhcacheBasicCrudBase {
+
+  @Mock
+  protected CacheLoaderWriter<String, String> cacheLoaderWriter;
+
+  @Test
+  public void testComputeIfAbsentNullNull() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.computeIfAbsent(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testComputeIfAbsentKeyNull() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.computeIfAbsent("key", null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testComputeIfAbsentNullValue() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.computeIfAbsent(null, new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return null;
+        }
+      });
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryNoCacheLoaderWriterReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertEquals("value", ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_ADDED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryNoCacheLoaderWriterReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertNull(ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertEquals("value", ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(true));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_ADDED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertNull(ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryHasCacheLoaderWriterEntry() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("oldValue")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryCacheWritingException() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(cacheLoaderWriter);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryCacheAccessExceptionNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).load("key");
+    ordered.verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).load("key");
+    ordered.verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentNoStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntry() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("oldValue")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentHasStoreEntryNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertThat(ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("oldValue")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentHasStoreEntryCacheAccessExceptionNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentHasStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.store, times(1)).remove("key");
+    ordered.verify(this.cacheLoaderWriter).load(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), equalTo("value"));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentHasStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.store, times(1)).remove("key");
+    ordered.verify(this.cacheLoaderWriter).load(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfAbsent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfAbsentHasStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntry() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    ehcache.computeIfAbsent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeIfAbsentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("oldValue")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Gets an initialized {@link Ehcache Ehcache} instance using the
+   * {@link CacheLoaderWriter} provided.
+   *
+   * @param cacheLoaderWriter the {@code CacheLoaderWriter} to use; may be {@code null}
+   *
+   * @return a new {@code Ehcache} instance
+   */
+  private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
+    RuntimeConfiguration<String, String> runtimeConfiguration = new RuntimeConfiguration<String, String>(CACHE_CONFIGURATION, null);
+    final Ehcache<String, String> ehcache
+        = new Ehcache<String, String>(runtimeConfiguration, this.store, cacheLoaderWriter, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicReplaceTest"));
+    ehcache.init();
+    assertThat("cache not initialized", ehcache.getStatus(), is(Status.AVAILABLE));
+    this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);
+    return ehcache;
+  }
+}

--- a/core/src/test/java/org/ehcache/EhcacheBasicComputeIfPresentTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicComputeIfPresentTest.java
@@ -1,0 +1,971 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache;
+
+import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.function.BiFunction;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
+import org.ehcache.statistics.CacheOperationOutcomes;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.EnumSet;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Provides testing of basic COMPUTEIFPRESENT(key, function) operations on an {@code Ehcache}.
+ *
+ * @author Ludovic Orban
+ */
+public class EhcacheBasicComputeIfPresentTest extends EhcacheBasicCrudBase {
+
+  @Mock
+  protected CacheLoaderWriter<String, String> cacheLoaderWriter;
+
+  @Test
+  public void testComputeIfPresentNullNull() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.computeIfPresent(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testComputeIfPresentKeyNull() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.computeIfPresent("key", null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testComputeIfPresentNullValue() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.computeIfPresent(null, new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return null;
+        }
+      });
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertNull(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryNoCacheLoaderWriterEntry() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertNull(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is("value"));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(cacheLoaderWriter);
+
+    try {
+      ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return "value";
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      e.printStackTrace();
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(cacheLoaderWriter);
+
+    try {
+      ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return null;
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      e.printStackTrace();
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheAccessExceptionNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntry() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).load("key");
+    ordered.verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheAccessExceptionCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeIfPresentFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentNoStoreEntryCacheAccessExceptionCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeIfPresentFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryNoCacheLoaderWriterReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is(equalTo("value")));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryNoCacheLoaderWriterReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is(equalTo("value")));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("value")));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), equalTo("value"));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), equalTo(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is(equalTo("value")));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("value")));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), equalTo("value"));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), equalTo(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    try {
+      ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return "value";
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    try {
+      ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return null;
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheAccessExceptionNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntry() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.store, times(1)).remove("key");
+    verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeIfPresentFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheAccessExceptionCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeIfPresentFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#computeIfPresent(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeIfPresentHasStoreEntryCacheAccessExceptionCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.computeIfPresent("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeIfPresentFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+
+  /**
+   * Gets an initialized {@link Ehcache Ehcache} instance using the
+   * {@link CacheLoaderWriter} provided.
+   *
+   * @param cacheLoaderWriter the {@code CacheLoaderWriter} to use; may be {@code null}
+   *
+   * @return a new {@code Ehcache} instance
+   */
+  private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
+    RuntimeConfiguration<String, String> runtimeConfiguration = new RuntimeConfiguration<String, String>(CACHE_CONFIGURATION, null);
+    final Ehcache<String, String> ehcache
+        = new Ehcache<String, String>(runtimeConfiguration, this.store, cacheLoaderWriter, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicReplaceTest"));
+    ehcache.init();
+    assertThat("cache not initialized", ehcache.getStatus(), is(Status.AVAILABLE));
+    this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);
+    return ehcache;
+  }
+}

--- a/core/src/test/java/org/ehcache/EhcacheBasicComputeTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicComputeTest.java
@@ -1,0 +1,1139 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache;
+
+import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.function.BiFunction;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
+import org.ehcache.statistics.CacheOperationOutcomes;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.EnumSet;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Provides testing of basic COMPUTE(key, function) operations on an {@code Ehcache}.
+ *
+ * @author Ludovic Orban
+ */
+public class EhcacheBasicComputeTest extends EhcacheBasicCrudBase {
+
+  @Mock
+  protected CacheLoaderWriter<String, String> cacheLoaderWriter;
+
+  @Test
+  public void testComputeNullNull() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.compute(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testComputeKeyNull() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.compute("key", null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testComputeNullValue() {
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    try {
+      ehcache.compute(null, new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return null;
+        }
+      });
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryNoCacheLoaderWriterReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertEquals("value", ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_ADDED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryNoCacheLoaderWriterReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertNull(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertEquals("value", ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(true));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_ADDED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertNull(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    }));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.NOT_PRESENT_NOOP));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is("value"));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(true));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(cacheLoaderWriter);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return "value";
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      e.printStackTrace();
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(cacheLoaderWriter);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return null;
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      e.printStackTrace();
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).load("key");
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).load("key");
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return "value";
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key not present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeNoStoreEntryCacheAccessExceptionCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.<String, String>emptyMap());
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return null;
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryNoCacheLoaderWriterReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is(equalTo("value")));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryNoCacheLoaderWriterReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is(equalTo("value")));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("value")));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), equalTo("value"));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), equalTo(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    }), is(equalTo("value")));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().get("key"), is(equalTo("value")));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), equalTo("value"));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_UPDATED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    final Ehcache<String, String> ehcache = this.getEhcache(fakeLoaderWriter);
+
+    assertThat(ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    }), is(nullValue()));
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), equalTo(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.PRESENT_REMOVED));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return "value";
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return null;
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verifyZeroInteractions(this.spiedResilienceStrategy);
+    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.ComputeOutcome.class));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>no {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionNoCacheLoaderWriter() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final Ehcache<String, String> ehcache = this.getEhcache(null);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        throw new AssertionError("should not be called");
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.store, times(1)).remove("key");
+    ordered.verify(this.cacheLoaderWriter).load(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), equalTo("value"));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key not present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionNoCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.<String, String>emptyMap());
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertNull(v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    verify(this.store, times(1)).remove("key");
+    ordered.verify(this.cacheLoaderWriter).load(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return "value";
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().get("key"), is(equalTo("value")));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>key present via {@code CacheLoaderWriter}</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionHasCacheLoaderWriterEntryReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    ehcache.compute("key", new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String k, String v) {
+        assertEquals("key", k);
+        assertEquals("oldValue", v);
+        return null;
+      }
+    });
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy).computeFailure(eq("key"), any(CacheAccessException.class));
+    assertThat(fakeLoaderWriter.getEntryMap().containsKey("key"), is(false));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning a value</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionCacheWritingExceptionReturnValue() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).write("key", "value");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return "value";
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).write(eq("key"), any(String.class));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+  /**
+   * Tests the effect of a {@link Ehcache#compute(Object, BiFunction)} for
+   * <ul>
+   *   <li>key present in {@code Store}</li>
+   *   <li>function returning null</li>
+   *   <li>{@code Store.compute} throws</li>
+   *   <li>{@code CacheLoaderWriter.write} throws</li>
+   * </ul>
+   */
+  @Test
+  public void testComputeHasStoreEntryCacheAccessExceptionCacheWritingExceptionReturnNull() throws Exception {
+    final FakeStore fakeStore = new FakeStore(Collections.singletonMap("key", "oldValue"));
+    this.store = spy(fakeStore);
+    doThrow(new CacheAccessException("")).when(this.store).compute(eq("key"), getAnyBiFunction());
+
+    final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(Collections.singletonMap("key", "oldValue"));
+    this.cacheLoaderWriter = spy(fakeLoaderWriter);
+    doThrow(new Exception()).when(this.cacheLoaderWriter).delete("key");
+    final Ehcache<String, String> ehcache = this.getEhcache(this.cacheLoaderWriter);
+
+    final InOrder ordered = inOrder(this.cacheLoaderWriter, this.spiedResilienceStrategy);
+
+    try {
+      ehcache.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String k, String v) {
+          assertEquals("key", k);
+          assertEquals("oldValue", v);
+          return null;
+        }
+      });
+      fail();
+    } catch (CacheWritingException e) {
+      // Expected
+    }
+    verify(this.store).compute(eq("key"), getAnyBiFunction());
+    ordered.verify(this.cacheLoaderWriter).delete(eq("key"));
+    ordered.verify(this.spiedResilienceStrategy)
+        .computeFailure(eq("key"), any(CacheAccessException.class), any(CacheWritingException.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.ComputeOutcome.FAILURE));
+  }
+
+
+  /**
+   * Gets an initialized {@link Ehcache Ehcache} instance using the
+   * {@link CacheLoaderWriter} provided.
+   *
+   * @param cacheLoaderWriter the {@code CacheLoaderWriter} to use; may be {@code null}
+   *
+   * @return a new {@code Ehcache} instance
+   */
+  private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
+    RuntimeConfiguration<String, String> runtimeConfiguration = new RuntimeConfiguration<String, String>(CACHE_CONFIGURATION, null);
+    final Ehcache<String, String> ehcache
+        = new Ehcache<String, String>(runtimeConfiguration, this.store, cacheLoaderWriter, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicReplaceTest"));
+    ehcache.init();
+    assertThat("cache not initialized", ehcache.getStatus(), is(Status.AVAILABLE));
+    this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);
+    return ehcache;
+  }
+}

--- a/core/src/test/java/org/ehcache/UserManagedCacheBuilderTest.java
+++ b/core/src/test/java/org/ehcache/UserManagedCacheBuilderTest.java
@@ -19,9 +19,11 @@ package org.ehcache;
 import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.config.UserManagedCacheConfiguration;
 import org.ehcache.exceptions.BulkCacheWritingException;
+import org.ehcache.exceptions.CacheLoadingException;
+import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.function.BiFunction;
 import org.ehcache.spi.ServiceLocator;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -128,6 +130,11 @@ public class UserManagedCacheBuilderTest {
 
     @Override
     public boolean replace(K key, V oldValue, V newValue) {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException {
       throw new UnsupportedOperationException("Implement me!");
     }
 

--- a/core/src/test/java/org/ehcache/UserManagedCacheBuilderTest.java
+++ b/core/src/test/java/org/ehcache/UserManagedCacheBuilderTest.java
@@ -139,6 +139,11 @@ public class UserManagedCacheBuilderTest {
     }
 
     @Override
+    public V computeIfAbsent(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws CacheLoadingException, CacheWritingException {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
     public CacheRuntimeConfiguration<K, V> getRuntimeConfiguration() {
       throw new UnsupportedOperationException("Implement me!");
     }

--- a/core/src/test/java/org/ehcache/UserManagedCacheBuilderTest.java
+++ b/core/src/test/java/org/ehcache/UserManagedCacheBuilderTest.java
@@ -144,6 +144,11 @@ public class UserManagedCacheBuilderTest {
     }
 
     @Override
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) {
+      throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
     public CacheRuntimeConfiguration<K, V> getRuntimeConfiguration() {
       throw new UnsupportedOperationException("Implement me!");
     }


### PR DESCRIPTION
Added compute / computeIfAbsent / computeIfPresent to Cache with signatures comparable to CHMv8 ones. Unfortunately there is no way to make the 107 EntryProcessor mechanism fit into the ehcache one without bastardizing it some way or another.