### PR TITLE
 #220: remove special-case stat counting

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -244,12 +244,8 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
     });
 
     try {
-      ValueHolder<V> computed = store.compute(key, remappingFunction);
-      if (computed != null) {
-        putObserver.end(PutOutcome.ADDED);
-      } else {
-        // XXX: is there an outcome we want here?
-      }
+      store.compute(key, remappingFunction);
+      putObserver.end(PutOutcome.ADDED);
     } catch (CacheAccessException e) {
       try {
         if (cacheLoaderWriter == null) {
@@ -327,11 +323,7 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
 
     try {
       store.compute(key, remappingFunction);
-      if (modified.get()) {
-        removeObserver.end(RemoveOutcome.SUCCESS);
-      } else {
-        // XXX: Is there an outcome we want here?
-      }
+      removeObserver.end(RemoveOutcome.SUCCESS);
     } catch (CacheAccessException e) {
       try {
         try {

--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -232,6 +232,7 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
         }
         
         if (newValueAlreadyExpired(key, previousValue, value)) {
+          eventNotificationService.onEvent(CacheEvents.expiry(newCacheEntry(key, value), Ehcache.this));
           return null;
         }
         

--- a/core/src/test/java/org/ehcache/EhcacheBasicRemoveTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicRemoveTest.java
@@ -78,7 +78,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
     verify(this.store).compute(eq("key"), getAnyBiFunction());
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.RemoveOutcome.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.RemoveOutcome.SUCCESS));
   }
 
   /**
@@ -101,7 +101,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
     assertThat(fakeWriter.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.RemoveOutcome.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.RemoveOutcome.SUCCESS));
   }
 
   /**
@@ -124,7 +124,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
     assertThat(fakeWriter.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.RemoveOutcome.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.RemoveOutcome.SUCCESS));
   }
 
   /**


### PR DESCRIPTION
IMHO there should not be special stats for the two special cases: putting an immediately expiring value is counted as a normal put, and removing a key that's not present should be counted as a plain normal remove.

Agree? Disagree?
