### PR TITLE
Issue 220

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -248,7 +248,7 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
       if (computed != null) {
         putObserver.end(PutOutcome.ADDED);
       } else {
-        // XXX: is there an outcome we want here?
+        putObserver.end(PutOutcome.NOOP);
       }
     } catch (CacheAccessException e) {
       try {
@@ -330,7 +330,7 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
       if (modified.get()) {
         removeObserver.end(RemoveOutcome.SUCCESS);
       } else {
-        // XXX: Is there an outcome we want here?
+        removeObserver.end(RemoveOutcome.NOOP);
       }
     } catch (CacheAccessException e) {
       try {

--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -232,6 +232,7 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
         }
         
         if (newValueAlreadyExpired(key, previousValue, value)) {
+          eventNotificationService.onEvent(CacheEvents.expiry(newCacheEntry(key, value), Ehcache.this));
           return null;
         }
         

--- a/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
@@ -45,6 +45,8 @@ public interface CacheOperationOutcomes {
   enum PutOutcome implements CacheOperationOutcomes {
     /** added. */
     ADDED,
+    /** no op. */
+    NOOP,
     /** failure */
     FAILURE
   };
@@ -55,6 +57,8 @@ public interface CacheOperationOutcomes {
   enum RemoveOutcome implements CacheOperationOutcomes {
     /** success. */
     SUCCESS,
+    /** no op. */
+    NOOP,
     /** failure */
     FAILURE
   };

--- a/core/src/test/java/org/ehcache/EhcacheBasicRemoveTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicRemoveTest.java
@@ -78,7 +78,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
     verify(this.store).compute(eq("key"), getAnyBiFunction());
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.RemoveOutcome.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.RemoveOutcome.NOOP));
   }
 
   /**
@@ -101,7 +101,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
     assertThat(fakeWriter.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.RemoveOutcome.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.RemoveOutcome.NOOP));
   }
 
   /**
@@ -124,7 +124,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
     assertThat(fakeWriter.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.RemoveOutcome.class));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.RemoveOutcome.NOOP));
   }
 
   /**

--- a/core/src/test/java/org/ehcache/EhcacheEventTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheEventTest.java
@@ -35,6 +35,8 @@ import org.ehcache.event.EventType;
 import org.ehcache.events.CacheEventNotificationService;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.expiry.Duration;
+import org.ehcache.expiry.Expirations;
 import org.ehcache.function.BiFunction;
 import org.ehcache.function.Function;
 import org.ehcache.function.NullaryFunction;
@@ -83,6 +85,29 @@ public class EhcacheEventTest {
   public void tearDown() {
     // Make sure no more events have been sent
     verify(eventNotifier, new NoMoreInteractions()).onEvent(any(CacheEvent.class));
+  }
+
+  @Test
+  public void testImmediatelyExpiringEntry() throws Exception {
+    RuntimeConfiguration<Number, String> runtimeConfiguration = new RuntimeConfiguration<Number, String>(newCacheConfigurationBuilder()
+        .withExpiry(Expirations.timeToLiveExpiration(Duration.ZERO))
+        .buildConfig(Number.class, String.class), eventNotifier);
+    Ehcache<Number, String> cache = new Ehcache<Number, String>(
+        runtimeConfiguration, store, null, eventNotifier, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheEventTest-testImmediatelyExpiringEntry"));
+    cache.init();
+
+    Number key = 1;
+    String value = "one";
+    when(store.compute(any(Number.class), anyBiFunction())).thenAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        BiFunction<Number, String, String> function = asBiFunction(invocation);
+        function.apply((Number)invocation.getArguments()[0], null);
+        return null;
+      }
+    });
+    cache.put(key, value);
+    verify(eventNotifier).onEvent(eventMatching(EventType.EXPIRED, key, value, value));
   }
 
   @Test


### PR DESCRIPTION
JSR 107 needs a way to discriminate put-immediately-expiring from other puts and remove-non-existent-key from other removes in its statistics as the TCK tests specifically for such behavior.

I do believe that those so-called special outcomes aren't so special and should be counted as puts/removes, hence the introduction of a special "noop" outcome on our statistic that our JSR107 stats do not account for.

Added bonus: a fix for a missing expiration event when putting an already expired mapping.