### PR TITLE
Issue 233

### DIFF
--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -904,11 +904,12 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
           }
         }
         
+        old.set(inCache);
+
         if (newValueAlreadyExpired(key, inCache, value)) {
           return null;
         }
         
-        old.set(inCache);
         eventNotificationService.onEvent(CacheEvents.update(newCacheEntry(k, inCache),
             newCacheEntry(k, value), Ehcache.this));
         return value;

--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -769,7 +769,10 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
         putIfAbsentObserver.end(PutIfAbsentOutcome.PUT);
         return null;
       } else if (inCache == null) {
-        //dubious - it's a 'hit' in the SoR, but a 'miss' in the cache
+        /*
+         * XXX : This needs reassessing - this means different things whether
+         * there is a loader/writer or not.
+         */
         putIfAbsentObserver.end(PutIfAbsentOutcome.HIT);
         return null;
       } else {

--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -232,7 +232,6 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
         }
         
         if (newValueAlreadyExpired(key, previousValue, value)) {
-          eventNotificationService.onEvent(CacheEvents.expiry(newCacheEntry(key, value), Ehcache.this));
           return null;
         }
         

--- a/core/src/test/java/org/ehcache/EhcacheBasicCrudBase.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicCrudBase.java
@@ -367,7 +367,7 @@ public abstract class EhcacheBasicCrudBase {
 
     @Override
     public void enableStoreEventNotifications(final StoreEventListener<String, String> listener) {
-      throw new UnsupportedOperationException();
+      //no-op
     }
 
     @Override

--- a/core/src/test/java/org/ehcache/EhcacheBasicPutIfAbsentEventsTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicPutIfAbsentEventsTest.java
@@ -28,11 +28,16 @@ import java.util.Collections;
 
 import org.ehcache.event.CacheEvent;
 import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.expiry.Duration;
+import org.ehcache.expiry.Expiry;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.util.IsCreated;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Provides events testing for basic PUT_IF_ABSENT operations on an {@code Ehcache}.
@@ -109,6 +114,18 @@ public class EhcacheBasicPutIfAbsentEventsTest extends EhcacheEventsTestBase {
     final Ehcache<String, String> ehcache = getEhcache(cacheLoaderWriter, "EhcacheBasicPutIfAbsentEventsTest");
     ehcache.putIfAbsent("key", "value");
     verify(cacheEventListener, times(1)).onEvent(argThat(isCreated));
+  }
+
+  @Test
+  public void testPutIfAbsentNewImmediatelyExpiringValue() throws Exception {
+    buildStore(Collections.<String, String>emptyMap());
+    
+    Expiry<String, String> expiry = mock(Expiry.class);
+    when(expiry.getExpiryForCreation("key", "value")).thenReturn(Duration.ZERO);
+    final Ehcache<String, String> ehcache = getEhcache(expiry, "testPutIfAbsentNewImmediatelyExpiringValue");
+    
+    ehcache.putIfAbsent("key", "value");
+    verifyZeroInteractions(cacheEventListener);
   }
 
   private Ehcache<String, String> getEhcache() {

--- a/core/src/test/java/org/ehcache/EhcacheBasicReplaceEventsTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicReplaceEventsTest.java
@@ -30,11 +30,16 @@ import java.util.Collections;
 
 import org.ehcache.event.CacheEvent;
 import org.ehcache.exceptions.CacheWritingException;
+import org.ehcache.expiry.Duration;
+import org.ehcache.expiry.Expiry;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.util.IsUpdated;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * This class provides testing of events for basic REPLACE operations.
@@ -108,6 +113,18 @@ public class EhcacheBasicReplaceEventsTest extends EhcacheEventsTestBase {
     verify(cacheEventListener, never()).onEvent(Matchers.<CacheEvent<String, String>>any());
   }
 
+  @Test
+  public void testReplaceWithImmediatelyExpiringValue() throws Exception {
+    buildStore(Collections.<String, String>singletonMap("key", "value"));
+    
+    Expiry<String, String> expiry = mock(Expiry.class);
+    when(expiry.getExpiryForUpdate("key", "value", "new-value")).thenReturn(Duration.ZERO);
+    final Ehcache<String, String> ehcache = getEhcache(expiry, "testReplaceWithImmediatelyExpiringValue");
+    
+    ehcache.replace("key", "new-value");
+    verifyZeroInteractions(cacheEventListener);
+  }
+  
   private Ehcache<String, String> getEhcache() {
     return getEhcache("EhcacheBasicReplaceEventsTest");
   }

--- a/core/src/test/java/org/ehcache/EhcacheBasicReplaceValueEventsTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheBasicReplaceValueEventsTest.java
@@ -31,11 +31,16 @@ import java.util.Collections;
 
 import org.ehcache.event.CacheEvent;
 import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.expiry.Duration;
+import org.ehcache.expiry.Expiry;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.util.IsUpdated;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * This class provides testing of events for basic REPLACE value operations.
@@ -150,6 +155,18 @@ public class EhcacheBasicReplaceValueEventsTest extends EhcacheEventsTestBase {
     verify(cacheEventListener, never()).onEvent(Matchers.<CacheEvent<String, String>>any());
   }
 
+  @Test
+  public void testReplaceWithImmediatelyExpiringValue() throws Exception {
+    buildStore(Collections.<String, String>singletonMap("key", "value"));
+    
+    Expiry<String, String> expiry = mock(Expiry.class);
+    when(expiry.getExpiryForUpdate("key", "value", "new-value")).thenReturn(Duration.ZERO);
+    final Ehcache<String, String> ehcache = getEhcache(expiry, "testReplaceWithImmediatelyExpiringValue");
+    
+    ehcache.replace("key", "value", "new-value");
+    verifyZeroInteractions(cacheEventListener);
+  }
+  
   private Ehcache<String, String> getEhcache() {
     return getEhcache("EhcacheBasicReplaceValueEventsTest");
   }

--- a/core/src/test/java/org/ehcache/EhcacheEventTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheEventTest.java
@@ -60,6 +60,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class EhcacheEventTest {
@@ -107,7 +108,7 @@ public class EhcacheEventTest {
       }
     });
     cache.put(key, value);
-    verify(eventNotifier).onEvent(eventMatching(EventType.EXPIRED, key, value, value));
+    verifyZeroInteractions(eventNotifier);
   }
 
   @Test


### PR DESCRIPTION
Included in here are tests for the behavior of the various mutative method when inserting entries that "immediately expire".  What I've implemented here is my best attempt at a sensible set of behaviors that also pass the TCK.  I'm going to take up the issue of the correctness of the JSR-107 spec mandated/tested behavior as well, but I wanted to get this merged in without waiting for any resolution on that.