### PR TITLE
Issue #406 Don't assert things you can't assert!

### DIFF
--- a/core/src/test/java/org/ehcache/util/ConcurrentWeakIdentityHashMapTest.java
+++ b/core/src/test/java/org/ehcache/util/ConcurrentWeakIdentityHashMapTest.java
@@ -113,7 +113,6 @@ public class ConcurrentWeakIdentityHashMapTest {
     }
     assertThat(i, not(is(0)));
     assertThat(size, not(is(0)));
-    assertThat(i, is(10240 - size));
   }
 
   <V> Object addToMap(final ConcurrentMap<Object, V> map, final V v) {


### PR DESCRIPTION
@chrisdennis @ljacomet or anyone?... Pure theory, can't reproduce the failure, but basically the issue was this:

```
java.lang.AssertionError:Expected: is <9127>     but: was <10239>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.Assert.assertThat(Assert.java:832)
	at org.ehcache.util.ConcurrentWeakIdentityHashMapTest.testIteration(ConcurrentWeakIdentityHashMapTest.java:116)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:86)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:49)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:69)
```

i.e. we iterated over the `entrySet` and saw 1113 entries, but the last call to `map.size` returned 1 (which is the minimal size it can drop to, because of the integer cache). Thoughts!?