### PR TITLE
Issue #525 Switch to using an attribute for disk path

### DIFF
--- a/107/src/test/resources/ehcache-107-stats.xml
+++ b/107/src/test/resources/ehcache-107-stats.xml
@@ -14,9 +14,7 @@
   </service>
 
   <service>
-    <persistence>
-      <directory>build/ehcache-107-stats</directory>
-    </persistence>
+    <persistence directory="build/ehcache-107-stats"/>
   </service>
   
   <cache-template name="diskCache">

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -58,9 +58,7 @@
   </xs:complexType>
 
   <xs:complexType name="persistence-type">
-    <xs:sequence>
-      <xs:element name="directory" type="xs:string" minOccurs="1" maxOccurs="1"/>
-    </xs:sequence>
+    <xs:attribute name="directory" type="xs:string" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="serializer-type">
@@ -404,8 +402,8 @@
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="fqcn-type">
-  	<xs:restriction base="xs:string">
-  	  <xs:whiteSpace value="collapse"></xs:whiteSpace>
-  	</xs:restriction>
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="collapse"></xs:whiteSpace>
+    </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
@@ -82,6 +82,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import org.w3c.dom.Element;
 
 /**
  *
@@ -441,7 +442,22 @@ public class XmlConfigurationTest {
     assertThat(serviceConfig, instanceOf(PersistenceConfiguration.class));
 
     PersistenceConfiguration persistenceConfiguration = (PersistenceConfiguration)serviceConfig;
-    assertThat(persistenceConfiguration.getRootDirectory(), is(new File("/some/dir")));
+    assertThat(persistenceConfiguration.getRootDirectory(), is(new File("   \n\t/my/caching/persistence  directory\r\n      ")));
+  }
+
+  @Test
+  public void testPersistenceConfigXmlPersistencePathHasWhitespaces() throws Exception {
+    final URL resource = XmlConfigurationTest.class.getResource("/configs/persistence-config.xml");
+    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+    Document doc = dBuilder.parse(new File(resource.toURI()));
+
+    Element persistence = (Element) doc.getElementsByTagName("ehcache:persistence").item(0);
+    String directoryValue = persistence.getAttribute("directory");
+    assertThat(directoryValue, containsString(" "));
+    assertThat(directoryValue, containsString("\r"));
+    assertThat(directoryValue, containsString("\n"));
+    assertThat(directoryValue, containsString("\t"));
   }
   
   @Test

--- a/xml/src/test/resources/configs/persistence-config.xml
+++ b/xml/src/test/resources/configs/persistence-config.xml
@@ -4,9 +4,7 @@
     xsi:schemaLocation="http://www.ehcache.org/v3 ../../../main/resources/ehcache-core.xsd">
 
   <ehcache:service>
-    <ehcache:persistence>
-      <ehcache:directory>/some/dir</ehcache:directory>
-    </ehcache:persistence>
+    <ehcache:persistence directory="   &#xA;&#x9;/my/caching/persistence  directory&#xD;&#xA;      "/>
   </ehcache:service>
 
 </ehcache:config>


### PR DESCRIPTION
@cschanck wisely recommended that the simplest solution to the disk path trimming problem would be to move to using an attribute rather than an element body to hold the disk path.  This is my attempt at doing exactly that.