### PR TITLE
Fix XSD includes: use -1 as end of file indicator

### DIFF
--- a/docs/src/docs/asciidoc/user/xsds.adoc
+++ b/docs/src/docs/asciidoc/user/xsds.adoc
@@ -8,12 +8,12 @@ include::menu.adoc[]
 
 [source,xsd,indent=0]
 ----
-include::{sourcedir}/xml/src/main/resources/ehcache-core.xsd[lines=18..260]
+include::{sourcedir}/xml/src/main/resources/ehcache-core.xsd[lines=18..-1]
 ----
 
 == JSR-107 extension
 
 [source,xsd,indent=0]
 ----
-include::{sourcedir}/107/src/main/resources/ehcache-107ext.xsd[lines=18..44]
+include::{sourcedir}/107/src/main/resources/ehcache-107ext.xsd[lines=18..-1]
 ----


### PR DESCRIPTION
Changes to the XSD had caused the doc include to no longer be valid as the end of the file was indicated explicitly. Using -1 allows inclusion up to the end of the file.