### PR TITLE
Issue #534 Enforce min write delay smaller or equal to max write delay

### DIFF
--- a/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
@@ -73,28 +73,28 @@ public interface WriteBehindConfiguration extends ServiceConfiguration<WriteBehi
   int getWriteBatchSize();
 
   /**
-   * The number of times the write of a mapping is retried in case it fails.
+   * The number of times the write of a mapping will be retried in the case of failure.
    *
    * @return Retrieves the number of times the write of element is retried.
    */
   int getRetryAttempts();
 
   /**
-   * The number of seconds to wait before retrying an failed operation.
+   * A number of seconds to wait before retrying an failed operation.
    *
    * @return Retrieves the number of seconds to wait before retrying an failed operation.
    */
   int getRetryAttemptDelaySeconds();
 
   /**
-   * The amount of bucket/thread pairs configured for this cache's write behind.
+   * A number of bucket/thread pairs configured for this cache's write behind.
    *
    * @return Retrieves the amount of bucket/thread pairs configured for this cache's write behind
    */
   int getWriteBehindConcurrency();
 
   /**
-   * The maximum amount of operations allowed on the write behind queue.
+   * The maximum number of operations allowed on the write behind queue.
    *
    * {@code 0} indicates an unbound queue.
    *

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
@@ -23,70 +23,80 @@ import org.ehcache.spi.service.ServiceConfiguration;
  */
 public interface WriteBehindConfiguration extends ServiceConfiguration<WriteBehindDecoratorLoaderWriterProvider> {
   /**
-   * the minimum number of seconds to wait before writing behind
+   * The minimum number of seconds to wait before writing behind.
+   *
+   * Lower than or equal to {@see getMaxWriteDelay}.
    *
    * @return Retrieves the minimum number of seconds to wait before writing behind
    */
   int getMinWriteDelay();
 
   /**
-   * the maximum number of seconds to wait before writing behind
+   * The maximum number of seconds to wait before writing behind.
+   *
+   * Greater than or equal to {@see getMinWriteDelay}
    *
    * @return Retrieves the maximum number of seconds to wait before writing behind
    */
   int getMaxWriteDelay();
 
   /**
-   * the maximum number of write operations to allow per second.
+   * The maximum number of write operations to allow per second.
+   *
+   * {@code 0} means no limit.
    *
    * @return Retrieves the maximum number of write operations to allow per second.
    */
   int getRateLimitPerSecond();
 
   /**
-   * whether write operations should be batched
+   * Whether write operations should be batched.
    *
    * @return Retrieves whether write operations should be batched
    */
   boolean isWriteBatching();
 
   /**
-   * write coalescing behavior
+   * Whether write operations can be coalesced.
    *
    * @return Retrieves the write coalescing behavior is enabled or not
    */
   boolean isWriteCoalescing();
 
   /**
-   * the size of the batch operation.
+   * The recommended size of a batch of operations.
+   *
+   * Real batch size will be influenced by arrival frequency of operations and max write delay.
    *
    * @return Retrieves the size of the batch operation.
    */
   int getWriteBatchSize();
 
   /**
-   * the number of times the write of element is retried.
+   * The number of times the write of a mapping is retried in case it fails.
    *
    * @return Retrieves the number of times the write of element is retried.
    */
   int getRetryAttempts();
 
   /**
-   * the number of seconds to wait before retrying an failed operation.
+   * The number of seconds to wait before retrying an failed operation.
    *
    * @return Retrieves the number of seconds to wait before retrying an failed operation.
    */
   int getRetryAttemptDelaySeconds();
 
   /**
-   * the amount of bucket/thread pairs configured for this cache's write behind
+   * The amount of bucket/thread pairs configured for this cache's write behind.
    *
    * @return Retrieves the amount of bucket/thread pairs configured for this cache's write behind
    */
   int getWriteBehindConcurrency();
 
   /**
-   * the maximum amount of operations allowed on the write behind queue
+   * The maximum amount of operations allowed on the write behind queue.
+   *
+   * {@code 0} indicates an unbound queue.
    *
    * @return Retrieves the maximum amount of operations allowed on the write behind queue
    */

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
  */
 public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration {
 
-  private int minWriteDelay = 1;
+  private int minWriteDelay = 0;
   private int maxWriteDelay = 1;
   private int rateLimitPerSecond = 0;
   private boolean writeCoalescing = false;
@@ -92,10 +92,10 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   }
 
   public void setWriteDelays(Integer minWriteDelay, Integer maxWriteDelay) {
-    minWriteDelay = minWriteDelay != null ? minWriteDelay : 1;
+    minWriteDelay = minWriteDelay != null ? minWriteDelay : 0;
     maxWriteDelay = maxWriteDelay != null ? maxWriteDelay : 1;
-    if (minWriteDelay < 1) {
-      throw new IllegalArgumentException("Minimum write delay seconds cannot be less then 1.");
+    if (minWriteDelay < 0) {
+      throw new IllegalArgumentException("Minimum write delay seconds cannot be less then 0.");
     }
     if (maxWriteDelay < 1) {
       throw new IllegalArgumentException("Maximum write delay seconds cannot be less then 1.");

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -18,6 +18,8 @@ package org.ehcache.config.writebehind;
 import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
 import org.ehcache.spi.loaderwriter.WriteBehindDecoratorLoaderWriterProvider;
 
+import static java.lang.String.format;
+
 /**
  * @author Geert Bevin
  * @author Chris Dennis
@@ -89,17 +91,20 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
     return writeBehindMaxQueueSize;
   }
 
-  public void setMinWriteDelay(int minWriteDelay) {
-    if(minWriteDelay < 1) {
+  public void setWriteDelays(Integer minWriteDelay, Integer maxWriteDelay) {
+    minWriteDelay = minWriteDelay != null ? minWriteDelay : 1;
+    maxWriteDelay = maxWriteDelay != null ? maxWriteDelay : 1;
+    if (minWriteDelay < 1) {
       throw new IllegalArgumentException("Minimum write delay seconds cannot be less then 1.");
     }
-    this.minWriteDelay = minWriteDelay;
-  }
-
-  public void setMaxWriteDelay(int maxWriteDelay) {
-    if(maxWriteDelay < 1) {
+    if (maxWriteDelay < 1) {
       throw new IllegalArgumentException("Maximum write delay seconds cannot be less then 1.");
     }
+    if (maxWriteDelay < minWriteDelay) {
+      throw new IllegalArgumentException(
+          format("Maximum write delay (%d seconds) must be equal or greater than minimum write delay (%d seconds)", maxWriteDelay, minWriteDelay));
+    }
+    this.minWriteDelay = minWriteDelay;
     this.maxWriteDelay = maxWriteDelay;
   }
 

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -95,10 +95,10 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
     minWriteDelay = minWriteDelay != null ? minWriteDelay : 0;
     maxWriteDelay = maxWriteDelay != null ? maxWriteDelay : 1;
     if (minWriteDelay < 0) {
-      throw new IllegalArgumentException("Minimum write delay seconds cannot be less then 0.");
+      throw new IllegalArgumentException("Minimum write delay seconds cannot be less than 0.");
     }
     if (maxWriteDelay < 1) {
-      throw new IllegalArgumentException("Maximum write delay seconds cannot be less then 1.");
+      throw new IllegalArgumentException("Maximum write delay seconds cannot be less than 1.");
     }
     if (maxWriteDelay < minWriteDelay) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
@@ -56,12 +56,7 @@ public class WriteBehindConfigurationBuilder implements Builder<WriteBehindConfi
   
   public WriteBehindConfiguration build() {
     DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
-    if (minWriteDelay != null) {
-      configuration.setMinWriteDelay(minWriteDelay);
-    }
-    if (maxWriteDelay != null) {
-      configuration.setMaxWriteDelay(maxWriteDelay);
-    }
+    configuration.setWriteDelays(minWriteDelay, maxWriteDelay);
     if (rateLimitPerSecond != null) {
       configuration.setRateLimitPerSecond(rateLimitPerSecond);
     }

--- a/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.config.writebehind;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * DefaultWriteBehindConfigurationTest
+ */
+public class DefaultWriteBehindConfigurationTest {
+
+  @Test
+  public void testMinMaxWriteDelaysDefaults() {
+    DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
+    configuration.setWriteDelays(null, null);
+
+    assertThat(configuration.getMaxWriteDelay(), is(1));
+    assertThat(configuration.getMinWriteDelay(), is(1));
+  }
+
+  @Test
+  public void testMinMaxWriteDelaysSet() {
+    DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
+    configuration.setWriteDelays(10, 100);
+    assertThat(configuration.getMinWriteDelay(), is(10));
+    assertThat(configuration.getMaxWriteDelay(), is(100));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMinWriteDelayInvalid() {
+    new DefaultWriteBehindConfiguration().setWriteDelays(-1, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMaxWriteDelayInvalid() {
+    new DefaultWriteBehindConfiguration().setWriteDelays(null, -1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMaxWriteDelaysNotLowerThanMinWriteDelays() {
+    new DefaultWriteBehindConfiguration().setWriteDelays(10, 5);
+  }
+
+}

--- a/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
@@ -31,8 +31,8 @@ public class DefaultWriteBehindConfigurationTest {
     DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
     configuration.setWriteDelays(null, null);
 
+    assertThat(configuration.getMinWriteDelay(), is(0));
     assertThat(configuration.getMaxWriteDelay(), is(1));
-    assertThat(configuration.getMinWriteDelay(), is(1));
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
@@ -54,7 +54,7 @@ public class WriteBehindEvictionTest extends AbstractWriteBehindTestBase {
                                                                                         .build();
     
     ResourcePoolsBuilder resourcePoolsBuilder = newResourcePoolsBuilder()
-        .with(org.ehcache.config.ResourceType.Core.HEAP, 10, EntryUnit.ENTRIES, false);
+        .heap(10, EntryUnit.ENTRIES);
    
     cacheManager = newCacheManagerBuilder().using(cacheLoaderWriterProvider).build(true);
     testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder()

--- a/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
@@ -782,7 +782,7 @@ class ConfigurationParser {
 
     @Override
     public int minWriteDelay() {
-      return this.writebehind.getWritedelay() != null ? this.writebehind.getWritedelay().getMin().intValue() : 1 ;
+      return this.writebehind.getWritedelay() != null ? this.writebehind.getWritedelay().getMin().intValue() : 0 ;
     }
 
     @Override

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -210,7 +210,7 @@
             <xs:complexType>
               <xs:simpleContent>
                 <xs:extension base="xs:string">
-                  <xs:attribute type="xs:positiveInteger" name="min" default="1" use="optional"/>
+                  <xs:attribute type="xs:nonNegativeInteger" name="min" default="0" use="optional"/>
                   <xs:attribute type="xs:positiveInteger" name="max" default="1" use="optional"/>
                 </xs:extension>
               </xs:simpleContent>

--- a/xml/src/test/java/org/ehcache/config/xml/IntegrationConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/IntegrationConfigurationTest.java
@@ -102,7 +102,7 @@ public class IntegrationConfigurationTest {
     final Cache<Number, String> cache = cacheManager.getCache("bar", Number.class, String.class);
     assertThat(cache, notNullValue());
     assertThat(cache.get(1), notNullValue());
-    final Number key = new Long(42);
+    final Number key = 42L;
     TestCacheLoaderWriter.latch = new CountDownLatch(1);
     cache.put(key, "Bye y'all!");
     TestCacheLoaderWriter.latch.await(2, TimeUnit.SECONDS);
@@ -112,8 +112,9 @@ public class IntegrationConfigurationTest {
     final Cache<Number, String> templateCache = cacheManager.getCache("template1", Number.class, String.class);
     assertThat(templateCache, notNullValue());
     assertThat(templateCache.get(1), notNullValue());
-    final Number key1 = new Long(100);
-    TestCacheLoaderWriter.latch = new CountDownLatch(1);
+    final Number key1 = 100L;
+    TestCacheLoaderWriter.latch = new CountDownLatch(2);
+    templateCache.put(42L, "Howdy!");
     templateCache.put(key1, "Bye y'all!");
     TestCacheLoaderWriter.latch.await(2, TimeUnit.SECONDS);
     assertThat(TestCacheLoaderWriter.lastWrittenKey, is(key1));

--- a/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
@@ -476,11 +476,11 @@ public class XmlConfigurationTest {
     for (ServiceConfiguration<?> configuration : serviceConfiguration) {
       if(configuration instanceof DefaultWriteBehindConfiguration) {
         assertThat(((WriteBehindConfiguration) configuration).getMaxWriteDelay(), is(1));
-        assertThat(((WriteBehindConfiguration) configuration).getMinWriteDelay(), is(1));
+        assertThat(((WriteBehindConfiguration) configuration).getMinWriteDelay(), is(0));
         assertThat(((WriteBehindConfiguration) configuration).isWriteCoalescing(), is(false));
         assertThat(((WriteBehindConfiguration) configuration).isWriteBatching(), is(true));
-        assertThat(((WriteBehindConfiguration) configuration).getWriteBatchSize(), is(5));
-        assertThat(((WriteBehindConfiguration) configuration).getWriteBehindConcurrency(), is(3));
+        assertThat(((WriteBehindConfiguration) configuration).getWriteBatchSize(), is(2));
+        assertThat(((WriteBehindConfiguration) configuration).getWriteBehindConcurrency(), is(1));
         assertThat(((WriteBehindConfiguration) configuration).getWriteBehindMaxQueueSize(), is(10));
         assertThat(((WriteBehindConfiguration) configuration).getRateLimitPerSecond(), is(0));
         assertThat(((WriteBehindConfiguration) configuration).getRetryAttempts(), is(0));

--- a/xml/src/test/resources/configs/writebehind-cache.xml
+++ b/xml/src/test/resources/configs/writebehind-cache.xml
@@ -27,9 +27,7 @@
         <ehcache:loaderwriter>
           <ehcache:class>com.pany.ehcache.integration.TestCacheLoaderWriter</ehcache:class>
         </ehcache:loaderwriter>
-        <ehcache:writebehind coalesce="false" concurrency="3" size="10">
-          <ehcache:batchsize>5</ehcache:batchsize>
-        </ehcache:writebehind>
+        <ehcache:writebehind coalesce="false" concurrency="1" size="10"/>
       </ehcache:integration>
       <ehcache:resources>
         <ehcache:heap size="10"/>
@@ -43,8 +41,8 @@
         <ehcache:loaderwriter>
           <ehcache:class>com.pany.ehcache.integration.TestCacheLoaderWriter</ehcache:class>
         </ehcache:loaderwriter>
-        <ehcache:writebehind coalesce="false" concurrency="3" size="10">
-          <ehcache:batchsize>5</ehcache:batchsize>
+        <ehcache:writebehind coalesce="false" concurrency="1" size="10">
+          <ehcache:batchsize>2</ehcache:batchsize>
         </ehcache:writebehind>
       </ehcache:integration>
       <ehcache:resources>


### PR DESCRIPTION
* Enforce the contract
* Improve javadocs
* Change default min write delay to 0
  * As a consequence, build is faster as write behind related tests run faster