### PR TITLE
Issue #543 write behind config defaults and legal values

### DIFF
--- a/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
@@ -43,7 +43,7 @@ public interface WriteBehindConfiguration extends ServiceConfiguration<WriteBehi
   /**
    * The maximum number of write operations to allow per second.
    *
-   * {@code 0} means no limit.
+   * Only positive values are legal.
    *
    * @return Retrieves the maximum number of write operations to allow per second.
    */

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
@@ -96,7 +96,7 @@ public interface WriteBehindConfiguration extends ServiceConfiguration<WriteBehi
   /**
    * The maximum number of operations allowed on the write behind queue.
    *
-   * {@code 0} indicates an unbound queue.
+   * Only positive values are legal.
    *
    * @return Retrieves the maximum amount of operations allowed on the write behind queue
    */

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/WriteBehindConfiguration.java
@@ -50,13 +50,6 @@ public interface WriteBehindConfiguration extends ServiceConfiguration<WriteBehi
   int getRateLimitPerSecond();
 
   /**
-   * Whether write operations should be batched.
-   *
-   * @return Retrieves whether write operations should be batched
-   */
-  boolean isWriteBatching();
-
-  /**
    * Whether write operations can be coalesced.
    *
    * @return Retrieves the write coalescing behavior is enabled or not
@@ -65,6 +58,8 @@ public interface WriteBehindConfiguration extends ServiceConfiguration<WriteBehi
 
   /**
    * The recommended size of a batch of operations.
+   *
+   * Only positive values are legal. A value of 1 indicates that no batching should happen.
    *
    * Real batch size will be influenced by arrival frequency of operations and max write delay.
    *

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -31,7 +31,6 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   private int maxWriteDelay = Integer.MAX_VALUE;
   private int rateLimitPerSecond = Integer.MAX_VALUE;
   private boolean writeCoalescing = false;
-  private boolean writeBatching = false;
   private int writeBatchSize = 1;
   private int retryAttempts = 1;
   private int retryAttemptDelaySeconds = 1;
@@ -59,11 +58,6 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   @Override
   public boolean isWriteCoalescing() {
     return writeCoalescing;
-  }
-  
-  @Override
-  public boolean isWriteBatching() {
-    return writeBatching;
   }
   
   @Override
@@ -127,7 +121,6 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
       throw new IllegalArgumentException("Batchsize cannot be less than 1.");
     }
     this.writeBatchSize = writeBatchSize;
-    this.writeBatching = writeBatchSize != 1;
   }
 
   public void setRetryAttempts(int retryAttempts) {

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -32,7 +32,7 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   private int rateLimitPerSecond = Integer.MAX_VALUE;
   private boolean writeCoalescing = false;
   private int writeBatchSize = 1;
-  private int retryAttempts = 1;
+  private int retryAttempts = 0;
   private int retryAttemptDelaySeconds = 1;
   private int writeBehindConcurrency = 1;
   private int writeBehindMaxQueueSize = Integer.MAX_VALUE;
@@ -90,7 +90,7 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
       throw new IllegalArgumentException("Minimum write delay seconds cannot be less than 0");
     } else if (minWriteDelay > maxWriteDelay) {
       throw new IllegalArgumentException("Minimum write delay (" + minWriteDelay +
-                                         "must be smaller than or equal to maximum write delay (" + maxWriteDelay + ")");
+                                         ") must be smaller than or equal to maximum write delay (" + maxWriteDelay + ")");
     }
     this.minWriteDelay = minWriteDelay;
   }
@@ -123,17 +123,14 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
     this.writeBatchSize = writeBatchSize;
   }
 
-  public void setRetryAttempts(int retryAttempts) {
+  public void setRetryAttempts(int retryAttempts, int retryAttemptDelaySeconds) {
     if(retryAttempts < 0) {
       throw new IllegalArgumentException("RetryAttempts cannot be less than 0.");
     }
-    this.retryAttempts = retryAttempts;
-  }
-
-  public void setRetryAttemptDelaySeconds(int retryAttemptDelaySeconds) {
     if(retryAttemptDelaySeconds < 1) {
       throw new IllegalArgumentException("RetryAttemptDelaySeconds cannot be less than 1.");
     }
+    this.retryAttempts = retryAttempts;
     this.retryAttemptDelaySeconds = retryAttemptDelaySeconds;
   }
 

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -36,7 +36,7 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   private int retryAttempts = 1;
   private int retryAttemptDelaySeconds = 1;
   private int writeBehindConcurrency = 1;
-  private int writeBehindMaxQueueSize = 0;
+  private int writeBehindMaxQueueSize = Integer.MAX_VALUE;
   
   public DefaultWriteBehindConfiguration() {
   }
@@ -149,8 +149,8 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   }
 
   public void setWriteBehindMaxQueueSize(int writeBehindMaxQueueSize) {
-    if(writeBehindMaxQueueSize < 0) {
-      throw new IllegalArgumentException("WriteBehind queue size cannot be less than 0.");
+    if(writeBehindMaxQueueSize < 1) {
+      throw new IllegalArgumentException("WriteBehind queue size cannot be less than 1.");
     }
     this.writeBehindMaxQueueSize = writeBehindMaxQueueSize;
   }

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -28,7 +28,7 @@ import static java.lang.String.format;
 public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration {
 
   private int minWriteDelay = 0;
-  private int maxWriteDelay = 1;
+  private int maxWriteDelay = Integer.MAX_VALUE;
   private int rateLimitPerSecond = Integer.MAX_VALUE;
   private boolean writeCoalescing = false;
   private boolean writeBatching = false;
@@ -91,20 +91,23 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
     return writeBehindMaxQueueSize;
   }
 
-  public void setWriteDelays(Integer minWriteDelay, Integer maxWriteDelay) {
-    minWriteDelay = minWriteDelay != null ? minWriteDelay : 0;
-    maxWriteDelay = maxWriteDelay != null ? maxWriteDelay : 1;
+  public void setMinWriteDelay(int minWriteDelay) {
     if (minWriteDelay < 0) {
-      throw new IllegalArgumentException("Minimum write delay seconds cannot be less than 0.");
-    }
-    if (maxWriteDelay < 1) {
-      throw new IllegalArgumentException("Maximum write delay seconds cannot be less than 1.");
-    }
-    if (maxWriteDelay < minWriteDelay) {
-      throw new IllegalArgumentException(
-          format("Maximum write delay (%d seconds) must be equal or greater than minimum write delay (%d seconds)", maxWriteDelay, minWriteDelay));
+      throw new IllegalArgumentException("Minimum write delay seconds cannot be less than 0");
+    } else if (minWriteDelay > maxWriteDelay) {
+      throw new IllegalArgumentException("Minimum write delay (" + minWriteDelay +
+                                         "must be smaller than or equal to maximum write delay (" + maxWriteDelay + ")");
     }
     this.minWriteDelay = minWriteDelay;
+  }
+
+  public void setMaxWriteDelay(int maxWriteDelay) {
+    if (maxWriteDelay < 0) {
+      throw new IllegalArgumentException("Maximum write delay cannot be less than 1");
+    } else if (maxWriteDelay < minWriteDelay) {
+      throw new IllegalArgumentException("Maximum write delay (" + maxWriteDelay +
+                                         ") must be larger than or equal to minimum write delay (" + minWriteDelay + ")");
+    }
     this.maxWriteDelay = maxWriteDelay;
   }
 

--- a/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/DefaultWriteBehindConfiguration.java
@@ -29,7 +29,7 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
 
   private int minWriteDelay = 0;
   private int maxWriteDelay = 1;
-  private int rateLimitPerSecond = 0;
+  private int rateLimitPerSecond = Integer.MAX_VALUE;
   private boolean writeCoalescing = false;
   private boolean writeBatching = false;
   private int writeBatchSize = 1;
@@ -109,8 +109,8 @@ public class DefaultWriteBehindConfiguration implements WriteBehindConfiguration
   }
 
   public void setRateLimitPerSecond(int rateLimitPerSecond) {
-    if(rateLimitPerSecond < 0) {
-      throw new IllegalArgumentException("RateLimitPerSecond cannot be less than 0.");
+    if(rateLimitPerSecond < 1) {
+      throw new IllegalArgumentException("RateLimitPerSecond cannot be less than 1.");
     }
     this.rateLimitPerSecond = rateLimitPerSecond;
   }

--- a/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
@@ -72,10 +72,7 @@ public class WriteBehindConfigurationBuilder implements Builder<WriteBehindConfi
       configuration.setWriteBatchSize(writeBatchSize);
     }
     if (retryAttempts != null) {
-      configuration.setRetryAttempts(retryAttempts);
-    }
-    if (retryAttemptDelaySeconds != null) {
-      configuration.setRetryAttemptDelaySeconds(retryAttemptDelaySeconds);
+      configuration.setRetryAttempts(retryAttempts, retryAttemptDelaySeconds);
     }
     if (writeBehindConcurrency != null) {
       configuration.setWriteBehindConcurrency(writeBehindConcurrency);

--- a/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
+++ b/core/src/main/java/org/ehcache/config/writebehind/WriteBehindConfigurationBuilder.java
@@ -56,7 +56,12 @@ public class WriteBehindConfigurationBuilder implements Builder<WriteBehindConfi
   
   public WriteBehindConfiguration build() {
     DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
-    configuration.setWriteDelays(minWriteDelay, maxWriteDelay);
+    if (minWriteDelay != null) {
+      configuration.setMinWriteDelay(minWriteDelay);
+    }
+    if (maxWriteDelay != null) {
+      configuration.setMaxWriteDelay(maxWriteDelay);
+    }
     if (rateLimitPerSecond != null) {
       configuration.setRateLimitPerSecond(rateLimitPerSecond);
     }

--- a/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
@@ -58,4 +58,15 @@ public class DefaultWriteBehindConfigurationTest {
     new DefaultWriteBehindConfiguration().setWriteDelays(10, 5);
   }
 
+  @Test
+  public void testMaxQueueSizeDefault() {
+    DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
+    assertThat(configuration.getWriteBehindMaxQueueSize(), is(Integer.MAX_VALUE));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMaxQueueSizeInvalid() {
+    new DefaultWriteBehindConfiguration().setWriteBehindMaxQueueSize(0);
+  }
+
 }

--- a/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
@@ -18,8 +18,7 @@ package org.ehcache.config.writebehind;
 
 import org.junit.Test;
 
-import java.math.BigInteger;
-
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
@@ -29,35 +28,63 @@ import static org.junit.Assert.*;
 public class DefaultWriteBehindConfigurationTest {
 
   @Test
-  public void testMinMaxWriteDelaysDefaults() {
+  public void testMinWriteDelayDefaults() {
     DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
-    configuration.setWriteDelays(null, null);
-
     assertThat(configuration.getMinWriteDelay(), is(0));
-    assertThat(configuration.getMaxWriteDelay(), is(1));
   }
 
   @Test
-  public void testMinMaxWriteDelaysSet() {
+  public void testMaxWriteDelayDefaults() {
     DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
-    configuration.setWriteDelays(10, 100);
+    assertThat(configuration.getMaxWriteDelay(), is(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testMinWriteDelaySet() {
+    DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
+    configuration.setMinWriteDelay(10);
     assertThat(configuration.getMinWriteDelay(), is(10));
+  }
+
+  @Test
+  public void testMaxWriteDelaySet() {
+    DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
+    configuration.setMaxWriteDelay(100);
     assertThat(configuration.getMaxWriteDelay(), is(100));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMinWriteDelayInvalid() {
-    new DefaultWriteBehindConfiguration().setWriteDelays(-1, null);
+    new DefaultWriteBehindConfiguration().setMinWriteDelay(-1);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMaxWriteDelayInvalid() {
-    new DefaultWriteBehindConfiguration().setWriteDelays(null, -1);
+    new DefaultWriteBehindConfiguration().setMaxWriteDelay(-1);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testMaxWriteDelaysNotLowerThanMinWriteDelays() {
-    new DefaultWriteBehindConfiguration().setWriteDelays(10, 5);
+  @Test
+  public void testMaxWriteDelayNotLowerThanMinWriteDelay() {
+    DefaultWriteBehindConfiguration defaultWriteBehindConfiguration = new DefaultWriteBehindConfiguration();
+    defaultWriteBehindConfiguration.setMinWriteDelay(10);
+    try {
+      defaultWriteBehindConfiguration.setMaxWriteDelay(5);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("Maximum write delay must be larger than minimum write delay"));
+    }
+  }
+
+  @Test
+  public void testMinWriteDelayNotLargerThanMaxWriteDelays() {
+    DefaultWriteBehindConfiguration defaultWriteBehindConfiguration = new DefaultWriteBehindConfiguration();
+    defaultWriteBehindConfiguration.setMaxWriteDelay(5);
+    try {
+      defaultWriteBehindConfiguration.setMinWriteDelay(10);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("Minimum write delay must be smaller than maximum write delay"));
+    }
   }
 
   @Test

--- a/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
@@ -71,7 +71,7 @@ public class DefaultWriteBehindConfigurationTest {
       defaultWriteBehindConfiguration.setMaxWriteDelay(5);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), containsString("Maximum write delay must be larger than minimum write delay"));
+      assertThat(e.getMessage(), containsString("Maximum write delay (5) must be larger than or equal to minimum write delay (10)"));
     }
   }
 
@@ -83,7 +83,7 @@ public class DefaultWriteBehindConfigurationTest {
       defaultWriteBehindConfiguration.setMinWriteDelay(10);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), containsString("Minimum write delay must be smaller than maximum write delay"));
+      assertThat(e.getMessage(), containsString("Minimum write delay (10) must be smaller than or equal to maximum write delay (5)"));
     }
   }
 

--- a/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/config/writebehind/DefaultWriteBehindConfigurationTest.java
@@ -18,6 +18,8 @@ package org.ehcache.config.writebehind;
 
 import org.junit.Test;
 
+import java.math.BigInteger;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
@@ -67,6 +69,17 @@ public class DefaultWriteBehindConfigurationTest {
   @Test(expected = IllegalArgumentException.class)
   public void testMaxQueueSizeInvalid() {
     new DefaultWriteBehindConfiguration().setWriteBehindMaxQueueSize(0);
+  }
+
+  @Test
+  public void testRateLimitDefault() {
+    DefaultWriteBehindConfiguration configuration = new DefaultWriteBehindConfiguration();
+    assertThat(configuration.getRateLimitPerSecond(), is(Integer.MAX_VALUE));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRateLimitInvalid() {
+    new DefaultWriteBehindConfiguration().setRateLimitPerSecond(0);
   }
 
 }

--- a/impl/src/main/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindQueue.java
+++ b/impl/src/main/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindQueue.java
@@ -172,14 +172,12 @@ public abstract class AbstractWriteBehindQueue<K, V> implements WriteBehind<K, V
   }
 
   private void waitForQueueSizeToDrop() {
-    if (maxQueueSize > 0) {
-      while (getQueueSize() >= maxQueueSize) {
-        try {
-          queueIsFull.await();
-        } catch (InterruptedException e) {
-          stop();
-          Thread.currentThread().interrupt();
-        }
+    while (getQueueSize() >= maxQueueSize) {
+      try {
+        queueIsFull.await();
+      } catch (InterruptedException e) {
+        stop();
+        Thread.currentThread().interrupt();
       }
     }
   }

--- a/impl/src/main/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindQueue.java
+++ b/impl/src/main/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindQueue.java
@@ -357,14 +357,12 @@ public abstract class AbstractWriteBehindQueue<K, V> implements WriteBehind<K, V
           }
           // enforce the rate limit and wait for another round if too much would
           // be processed compared to the last time when a batch was executed
-          if (rateLimitPerSecond > 0) {
-            final long secondsSinceLastWorkDone = (System.currentTimeMillis() - lastWorkDone.get()) / MS_IN_SEC;
-            final long maxBatchSizeSinceLastWorkDone = rateLimitPerSecond * secondsSinceLastWorkDone;
-            final int batchSize = determineBatchSize(quarantinedItems);
-            if (batchSize > maxBatchSizeSinceLastWorkDone) {
-              waitUntilEnoughTimeHasPassed(quarantinedItems, batchSize, secondsSinceLastWorkDone);
-              return;
-            }
+          final long secondsSinceLastWorkDone = (System.currentTimeMillis() - lastWorkDone.get()) / MS_IN_SEC;
+          final long maxBatchSizeSinceLastWorkDone = rateLimitPerSecond * secondsSinceLastWorkDone;
+          final int batchSize = determineBatchSize(quarantinedItems);
+          if (batchSize > maxBatchSizeSinceLastWorkDone) {
+            waitUntilEnoughTimeHasPassed(quarantinedItems, batchSize, secondsSinceLastWorkDone);
+            return;
           }
         }
 

--- a/impl/src/main/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindQueue.java
+++ b/impl/src/main/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindQueue.java
@@ -80,8 +80,8 @@ public abstract class AbstractWriteBehindQueue<K, V> implements WriteBehind<K, V
     this.stopping = false;
     this.stopped = true;
     
-    this.minWriteDelayMs = config.getMinWriteDelay() * MS_IN_SEC;
-    this.maxWriteDelayMs = config.getMaxWriteDelay() * MS_IN_SEC;
+    this.minWriteDelayMs = TimeUnit.SECONDS.toMillis(config.getMinWriteDelay());
+    this.maxWriteDelayMs = TimeUnit.SECONDS.toMillis(config.getMaxWriteDelay());
     this.rateLimitPerSecond = config.getRateLimitPerSecond();
     this.maxQueueSize = config.getWriteBehindMaxQueueSize();
     this.writeBatching = config.isWriteBatching();

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
@@ -49,7 +49,7 @@ public class WriteBehindEvictionTest extends AbstractWriteBehindTestBase {
     when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
     
     WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration();
-    WriteBehindConfiguration writeBehindConfiguration = writeBehindConfigurationBuilder.concurrencyLevel(3).batchSize(4)
+    WriteBehindConfiguration writeBehindConfiguration = writeBehindConfigurationBuilder.concurrencyLevel(3)
                                                                                         .queueSize(10)
                                                                                         .build();
     

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindTest.java
@@ -47,7 +47,7 @@ public class WriteBehindTest extends AbstractWriteBehindTestBase {
     when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
     
     WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration();
-    WriteBehindConfiguration writeBehindConfiguration = writeBehindConfigurationBuilder.concurrencyLevel(3).batchSize(4)
+    WriteBehindConfiguration writeBehindConfiguration = writeBehindConfigurationBuilder.concurrencyLevel(3)
                                                                                         .queueSize(10)
                                                                                         .build();
     

--- a/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
@@ -669,6 +669,8 @@ class ConfigurationParser {
     int maxQueueSize();
     
     int concurrency();
+
+    boolean isRetryAttemptsSet();
     
     int retryAttempts();
     
@@ -780,13 +782,18 @@ class ConfigurationParser {
     }
 
     @Override
+    public boolean isRetryAttemptsSet() {
+      return this.writebehind.getRetry() != null;
+    }
+
+    @Override
     public int retryAttempts() {
-      return this.writebehind.getRetryAttempts() != null ? this.writebehind.getRetryAttempts().getValue().intValue() : 0 ;
+      return this.writebehind.getRetry().getAttempts().intValue();
     }
 
     @Override
     public int retryAttemptsDelay() {
-      return this.writebehind.getRetryAttempts() != null ? this.writebehind.getRetryAttempts().getDelay().intValue() : 1;
+      return this.writebehind.getRetry().getDelay().intValue();
     }
 
     @Override

--- a/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
@@ -664,8 +664,6 @@ class ConfigurationParser {
     
     boolean isCoalesced();
     
-    boolean isBatched();
-    
     int batchSize();
     
     int maxQueueSize();
@@ -767,14 +765,8 @@ class ConfigurationParser {
     }
 
     @Override
-    public boolean isBatched() {
-      return this.writebehind.getBatchsize() != null;
-    }
-
-    @Override
     public int batchSize() {
-      if(this.writebehind.getBatchsize() != null) return this.writebehind.getBatchsize().intValue();
-      return 0;
+      return this.writebehind.getBatchsize().intValue();
     }
 
     @Override

--- a/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
@@ -809,7 +809,7 @@ class ConfigurationParser {
 
     @Override
     public int rateLimitPerSecond() {
-      return this.writebehind.getRatelimitpersecond() != null ? this.writebehind.getRatelimitpersecond().intValue() : 0;
+      return this.writebehind.getRatelimitpersecond().intValue();
     }
     
   }

--- a/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/config/xml/ConfigurationParser.java
@@ -799,12 +799,12 @@ class ConfigurationParser {
 
     @Override
     public int minWriteDelay() {
-      return this.writebehind.getWritedelay() != null ? this.writebehind.getWritedelay().getMin().intValue() : 0 ;
+      return this.writebehind.getMinWriteDelay().intValue();
     }
 
     @Override
     public int maxWriteDelay() {
-      return this.writebehind.getWritedelay() != null ? this.writebehind.getWritedelay().getMax().intValue() : 1 ;
+      return this.writebehind.getMaxWriteDelay().intValue();
     }
 
     @Override

--- a/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
@@ -252,10 +252,8 @@ public class XmlConfiguration implements Configuration {
           WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
               .concurrencyLevel(writeBehind.concurrency()).queueSize(writeBehind.maxQueueSize()).rateLimit(writeBehind.rateLimitPerSecond())
               .retry(writeBehind.retryAttempts(), writeBehind.retryAttemptsDelay())
-              .delay(writeBehind.minWriteDelay(), writeBehind.maxWriteDelay());
-          if(writeBehind.isBatched()){
-            writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.batchSize(writeBehind.batchSize());
-          }
+              .delay(writeBehind.minWriteDelay(), writeBehind.maxWriteDelay())
+              .batchSize(writeBehind.batchSize());
           if(writeBehind.isCoalesced()) {
             writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.enableCoalescing();
           }
@@ -441,10 +439,8 @@ public class XmlConfiguration implements Configuration {
         WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
             .concurrencyLevel(writeBehind.concurrency()).queueSize(writeBehind.maxQueueSize()).rateLimit(writeBehind.rateLimitPerSecond())
             .retry(writeBehind.retryAttempts(), writeBehind.retryAttemptsDelay())
-            .delay(writeBehind.minWriteDelay(), writeBehind.maxWriteDelay());
-        if(writeBehind.isBatched()){
-          writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.batchSize(writeBehind.batchSize());
-        }
+            .delay(writeBehind.minWriteDelay(), writeBehind.maxWriteDelay())
+            .batchSize(writeBehind.batchSize());
         if(writeBehind.isCoalesced()) {
           writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.enableCoalescing();
         }

--- a/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/config/xml/XmlConfiguration.java
@@ -251,9 +251,11 @@ public class XmlConfiguration implements Configuration {
           WriteBehind writeBehind = cacheDefinition.writeBehind();
           WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
               .concurrencyLevel(writeBehind.concurrency()).queueSize(writeBehind.maxQueueSize()).rateLimit(writeBehind.rateLimitPerSecond())
-              .retry(writeBehind.retryAttempts(), writeBehind.retryAttemptsDelay())
               .delay(writeBehind.minWriteDelay(), writeBehind.maxWriteDelay())
               .batchSize(writeBehind.batchSize());
+          if (writeBehind.isRetryAttemptsSet()) {
+            writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.retry(writeBehind.retryAttempts(), writeBehind.retryAttemptsDelay());
+          }
           if(writeBehind.isCoalesced()) {
             writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.enableCoalescing();
           }
@@ -438,9 +440,11 @@ public class XmlConfiguration implements Configuration {
         WriteBehind writeBehind = cacheTemplate.writeBehind();
         WriteBehindConfigurationBuilder writeBehindConfigurationBuilder = WriteBehindConfigurationBuilder.newWriteBehindConfiguration()
             .concurrencyLevel(writeBehind.concurrency()).queueSize(writeBehind.maxQueueSize()).rateLimit(writeBehind.rateLimitPerSecond())
-            .retry(writeBehind.retryAttempts(), writeBehind.retryAttemptsDelay())
             .delay(writeBehind.minWriteDelay(), writeBehind.maxWriteDelay())
             .batchSize(writeBehind.batchSize());
+        if (writeBehind.isRetryAttemptsSet()) {
+          writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.retry(writeBehind.retryAttempts(), writeBehind.retryAttemptsDelay());
+        }
         if(writeBehind.isCoalesced()) {
           writeBehindConfigurationBuilder = writeBehindConfigurationBuilder.enableCoalescing();
         }

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -214,16 +214,13 @@
       <xs:element name="writebehind" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
-          <xs:element name="retryAttempts" default="0" minOccurs="0" maxOccurs="1">
-            <xs:complexType>
-              <xs:simpleContent>
-                <xs:extension base="xs:nonNegativeInteger">
-                  <xs:attribute type="xs:positiveInteger" name="delay" default="1" use="optional"/>
-                </xs:extension>
-              </xs:simpleContent>
-            </xs:complexType>
-          </xs:element>
-        </xs:sequence>
+            <xs:element name="retry" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute type="xs:positiveInteger" name="attempts" use="required"/>
+                <xs:attribute type="xs:positiveInteger" name="delay" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
         <xs:attribute type="xs:positiveInteger" name="concurrency" default="1" use="optional"/>
         <xs:attribute type="xs:positiveInteger" name="size" default="2147483647" use="optional"/>
         <xs:attribute type="xs:boolean" name="coalesce" use="optional"/>

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -237,7 +237,7 @@
           </xs:element>
         </xs:sequence>
         <xs:attribute type="xs:positiveInteger" name="concurrency" default="1" use="optional"/>
-        <xs:attribute type="xs:nonNegativeInteger" name="size" default="0" use="optional"/>
+        <xs:attribute type="xs:positiveInteger" name="size" default="2147483647" use="optional"/>
         <xs:attribute type="xs:boolean" name="coalesce" use="optional"/>
       </xs:complexType>
     </xs:element>

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -224,7 +224,6 @@
               </xs:simpleContent>
             </xs:complexType>
           </xs:element>
-          <xs:element type="xs:nonNegativeInteger" name="ratelimitpersecond" default="0" minOccurs="0" maxOccurs="1"/>
           <xs:element type="xs:positiveInteger" name="batchsize" default="1" minOccurs="0" maxOccurs="1"/>
           <xs:element name="retryAttempts" default="0" minOccurs="0" maxOccurs="1">
             <xs:complexType>
@@ -239,6 +238,7 @@
         <xs:attribute type="xs:positiveInteger" name="concurrency" default="1" use="optional"/>
         <xs:attribute type="xs:positiveInteger" name="size" default="2147483647" use="optional"/>
         <xs:attribute type="xs:boolean" name="coalesce" use="optional"/>
+        <xs:attribute name="ratelimitpersecond" type="xs:positiveInteger" default="2147483647" use="optional"/>
       </xs:complexType>
     </xs:element>
       <xs:element name="listener" minOccurs="0" maxOccurs="unbounded">

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -214,16 +214,6 @@
       <xs:element name="writebehind" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
-           <xs:element name="writedelay" minOccurs="0" maxOccurs="1">
-            <xs:complexType>
-              <xs:simpleContent>
-                <xs:extension base="xs:string">
-                  <xs:attribute type="xs:nonNegativeInteger" name="min" default="0" use="optional"/>
-                  <xs:attribute type="xs:positiveInteger" name="max" default="1" use="optional"/>
-                </xs:extension>
-              </xs:simpleContent>
-            </xs:complexType>
-          </xs:element>
           <xs:element type="xs:positiveInteger" name="batchsize" default="1" minOccurs="0" maxOccurs="1"/>
           <xs:element name="retryAttempts" default="0" minOccurs="0" maxOccurs="1">
             <xs:complexType>
@@ -239,6 +229,8 @@
         <xs:attribute type="xs:positiveInteger" name="size" default="2147483647" use="optional"/>
         <xs:attribute type="xs:boolean" name="coalesce" use="optional"/>
         <xs:attribute name="ratelimitpersecond" type="xs:positiveInteger" default="2147483647" use="optional"/>
+        <xs:attribute name="minWriteDelay" type="xs:nonNegativeInteger" default="0" use="optional"/>
+        <xs:attribute name="maxWriteDelay" type="xs:positiveInteger" default="2147483647" use="optional"/>
       </xs:complexType>
     </xs:element>
       <xs:element name="listener" minOccurs="0" maxOccurs="unbounded">

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -221,15 +221,15 @@
               </xs:complexType>
             </xs:element>
           </xs:sequence>
-        <xs:attribute type="xs:positiveInteger" name="concurrency" default="1" use="optional"/>
-        <xs:attribute type="xs:positiveInteger" name="size" default="2147483647" use="optional"/>
-        <xs:attribute type="xs:boolean" name="coalesce" use="optional"/>
-        <xs:attribute name="ratelimitpersecond" type="xs:positiveInteger" default="2147483647" use="optional"/>
-        <xs:attribute name="minWriteDelay" type="xs:nonNegativeInteger" default="0" use="optional"/>
-        <xs:attribute name="maxWriteDelay" type="xs:positiveInteger" default="2147483647" use="optional"/>
-        <xs:attribute name="batchsize" type="xs:positiveInteger" default="1" use="optional"/>
-      </xs:complexType>
-    </xs:element>
+          <xs:attribute type="xs:positiveInteger" name="concurrency" default="1" use="optional"/>
+          <xs:attribute type="xs:positiveInteger" name="size" default="2147483647" use="optional"/>
+          <xs:attribute type="xs:boolean" name="coalesce" use="optional"/>
+          <xs:attribute name="ratelimitpersecond" type="xs:positiveInteger" default="2147483647" use="optional"/>
+          <xs:attribute name="minWriteDelay" type="xs:nonNegativeInteger" default="0" use="optional"/>
+          <xs:attribute name="maxWriteDelay" type="xs:positiveInteger" default="2147483647" use="optional"/>
+          <xs:attribute name="batchsize" type="xs:positiveInteger" default="1" use="optional"/>
+        </xs:complexType>
+      </xs:element>
       <xs:element name="listener" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType>
           <xs:sequence>

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -214,7 +214,6 @@
       <xs:element name="writebehind" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
-          <xs:element type="xs:positiveInteger" name="batchsize" default="1" minOccurs="0" maxOccurs="1"/>
           <xs:element name="retryAttempts" default="0" minOccurs="0" maxOccurs="1">
             <xs:complexType>
               <xs:simpleContent>
@@ -231,6 +230,7 @@
         <xs:attribute name="ratelimitpersecond" type="xs:positiveInteger" default="2147483647" use="optional"/>
         <xs:attribute name="minWriteDelay" type="xs:nonNegativeInteger" default="0" use="optional"/>
         <xs:attribute name="maxWriteDelay" type="xs:positiveInteger" default="2147483647" use="optional"/>
+        <xs:attribute name="batchsize" type="xs:positiveInteger" default="1" use="optional"/>
       </xs:complexType>
     </xs:element>
       <xs:element name="listener" minOccurs="0" maxOccurs="unbounded">

--- a/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
@@ -503,7 +503,7 @@ public class XmlConfigurationTest {
     
     for (ServiceConfiguration<?> configuration : serviceConfiguration) {
       if(configuration instanceof DefaultWriteBehindConfiguration) {
-        assertThat(((WriteBehindConfiguration) configuration).getMaxWriteDelay(), is(1));
+        assertThat(((WriteBehindConfiguration) configuration).getMaxWriteDelay(), is(Integer.MAX_VALUE));
         assertThat(((WriteBehindConfiguration) configuration).getMinWriteDelay(), is(0));
         assertThat(((WriteBehindConfiguration) configuration).isWriteCoalescing(), is(false));
         assertThat(((WriteBehindConfiguration) configuration).isWriteBatching(), is(true));

--- a/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
@@ -506,7 +506,6 @@ public class XmlConfigurationTest {
         assertThat(((WriteBehindConfiguration) configuration).getMaxWriteDelay(), is(Integer.MAX_VALUE));
         assertThat(((WriteBehindConfiguration) configuration).getMinWriteDelay(), is(0));
         assertThat(((WriteBehindConfiguration) configuration).isWriteCoalescing(), is(false));
-        assertThat(((WriteBehindConfiguration) configuration).isWriteBatching(), is(true));
         assertThat(((WriteBehindConfiguration) configuration).getWriteBatchSize(), is(2));
         assertThat(((WriteBehindConfiguration) configuration).getWriteBehindConcurrency(), is(1));
         assertThat(((WriteBehindConfiguration) configuration).getWriteBehindMaxQueueSize(), is(10));

--- a/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/XmlConfigurationTest.java
@@ -510,7 +510,7 @@ public class XmlConfigurationTest {
         assertThat(((WriteBehindConfiguration) configuration).getWriteBatchSize(), is(2));
         assertThat(((WriteBehindConfiguration) configuration).getWriteBehindConcurrency(), is(1));
         assertThat(((WriteBehindConfiguration) configuration).getWriteBehindMaxQueueSize(), is(10));
-        assertThat(((WriteBehindConfiguration) configuration).getRateLimitPerSecond(), is(0));
+        assertThat(((WriteBehindConfiguration) configuration).getRateLimitPerSecond(), is(Integer.MAX_VALUE));
         assertThat(((WriteBehindConfiguration) configuration).getRetryAttempts(), is(0));
         assertThat(((WriteBehindConfiguration) configuration).getRetryAttemptDelaySeconds(), is(1));
         break;

--- a/xml/src/test/resources/configs/writebehind-cache.xml
+++ b/xml/src/test/resources/configs/writebehind-cache.xml
@@ -41,9 +41,7 @@
         <ehcache:loaderwriter>
           <ehcache:class>com.pany.ehcache.integration.TestCacheLoaderWriter</ehcache:class>
         </ehcache:loaderwriter>
-        <ehcache:writebehind coalesce="false" concurrency="1" size="10">
-          <ehcache:batchsize>2</ehcache:batchsize>
-        </ehcache:writebehind>
+        <ehcache:writebehind coalesce="false" concurrency="1" size="10" batchsize="2"/>
       </ehcache:integration>
       <ehcache:resources>
         <ehcache:heap size="20"/>


### PR DESCRIPTION
First part for issue #543, addresses defaults and legal values for:
* queue size
* rate limit
* min and max write delay

Follow ups will be added here or in a new PR if this gets merged before.