### PR TITLE
Issue #545 - Added NamingService, responsible of providing the...

### DIFF
--- a/api/src/main/java/org/ehcache/spi/alias/AliasConfiguration.java
+++ b/api/src/main/java/org/ehcache/spi/alias/AliasConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.alias;
+
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+/**
+ * Configure the {@link AliasService}
+ *
+ * @author Mathieu Carbou
+ */
+public interface AliasConfiguration extends ServiceCreationConfiguration<AliasService> {
+
+  /**
+   * @return The cache manager alias to be used for the cache manager configured with this configuration in case a user would like to customize the default generated name
+   */
+  String getCacheManagerAlias();
+
+}

--- a/api/src/main/java/org/ehcache/spi/alias/AliasService.java
+++ b/api/src/main/java/org/ehcache/spi/alias/AliasService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.alias;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.spi.service.Service;
+
+/**
+ * Service used to provide configured aliases of {@link CacheManager} and {@link org.ehcache.Cache}.
+ * This service can be configured by using a {@link AliasConfiguration}.
+ * <p/>
+ * Configuring an alias to a cache manager is optional, but can be useful for example when you are using the management
+ * module to collect statistics and you would like to identify the cache managers by using another alias than the one generated.
+ * <p/>
+ * Implementations of this interface are free to decide how the alias are generated, returned and configured, whatever configuration is used.
+ *
+ * @author Mathieu Carbou
+ */
+public interface AliasService extends Service {
+
+  /**
+   * @return the {@link CacheManager} alias this service is used into
+   */
+  String getCacheManagerAlias();
+
+  /**
+   * Get the alias of a cache
+   *
+   * @param cache A {@link Cache} instance
+   * @return The alias set for a cache
+   */
+  String getCacheAlias(Cache<?, ?> cache);
+
+}

--- a/core/src/main/java/org/ehcache/Ehcache.java
+++ b/core/src/main/java/org/ehcache/Ehcache.java
@@ -21,6 +21,7 @@ import org.ehcache.event.CacheEvent;
 import org.ehcache.events.CacheEventNotificationService;
 import org.ehcache.events.CacheEvents;
 import org.ehcache.events.DisabledCacheEventNotificationService;
+import org.ehcache.events.StateChangeListener;
 import org.ehcache.exceptions.BulkCacheLoadingException;
 import org.ehcache.exceptions.BulkCacheWritingException;
 import org.ehcache.exceptions.CacheAccessException;
@@ -1083,6 +1084,14 @@ public class Ehcache<K, V> implements Cache<K, V>, UserManagedCache<K, V> {
 
   void removeHook(LifeCycled hook) {
     statusTransitioner.removeHook(hook);
+  }
+
+  void registerListener(StateChangeListener listener) {
+    statusTransitioner.registerListener(listener);
+  }
+
+  void deregisterListener(StateChangeListener listener) {
+    statusTransitioner.deregisterListener(listener);
   }
 
   private static void checkNonNull(Object thing) {

--- a/core/src/main/java/org/ehcache/EhcacheBinding.java
+++ b/core/src/main/java/org/ehcache/EhcacheBinding.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache;
+
+/**
+ * Class representing an association between an object and an alias, name, identifier
+ *
+ * @author Mathieu Carbou
+ */
+public final class EhcacheBinding {
+
+  private final String alias;
+  private final Ehcache<?, ?> value;
+
+  public EhcacheBinding(String alias, Ehcache<?, ?> value) {
+    if (alias == null) throw new NullPointerException();
+    if (value == null) throw new NullPointerException();
+    this.alias = alias;
+    this.value = value;
+  }
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public Ehcache<?, ?> getCache() {
+    return value;
+  }
+
+}

--- a/core/src/main/java/org/ehcache/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/EhcacheManager.java
@@ -555,7 +555,7 @@ public class EhcacheManager implements PersistentCacheManager {
         @Override
         public void close() {
           persistenceService.stop();
-          statusTransitioner.exitMaintenance();
+          statusTransitioner.exitMaintenance().succeeded();
         }
       };
       st.succeeded();

--- a/core/src/main/java/org/ehcache/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/EhcacheManager.java
@@ -33,6 +33,8 @@ import org.ehcache.management.ManagementRegistry;
 import org.ehcache.spi.LifeCycled;
 import org.ehcache.spi.ServiceLocator;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.lifecycle.DefaultLifeCycleManager;
+import org.ehcache.spi.lifecycle.LifeCycleManager;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
 import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
@@ -52,7 +54,6 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.context.annotations.ContextAttribute;
 import org.terracotta.statistics.StatisticsManager;
 
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -103,6 +104,7 @@ public class EhcacheManager implements PersistentCacheManager {
   private final CopyOnWriteArrayList<CacheManagerListener> listeners = new CopyOnWriteArrayList<CacheManagerListener>();
   private final StatisticsManager statisticsManager = new StatisticsManager();
   private final EhcacheManagerStatsSettings ehcacheManagerStatsSettings = new EhcacheManagerStatsSettings(Collections.<String, Object>singletonMap("Setting", "CacheManagerName"));
+  private final LifeCycleManager lifeCycleManager;
 
   public EhcacheManager(Configuration config) {
     this(config, Collections.<Service>emptyList(), true);
@@ -112,10 +114,25 @@ public class EhcacheManager implements PersistentCacheManager {
     this(config, services, true);
   }
   public EhcacheManager(Configuration config, Collection<Service> services, boolean useLoaderInAtomics) {
-    this.serviceLocator = new ServiceLocator(services.toArray(new Service[services.size()]));
+    this.serviceLocator = new ServiceLocator();
     this.useLoaderInAtomics = useLoaderInAtomics;
     this.cacheManagerClassLoader = config.getClassLoader() != null ? config.getClassLoader() : ClassLoading.getDefaultClassLoader();
     this.configuration = config;
+
+    // DefaultLifeCycleManager exposed a service to register lifecycle listeners from services
+    DefaultLifeCycleManager defaultLifeCycleManager = new DefaultLifeCycleManager();
+    this.serviceLocator.addService(defaultLifeCycleManager);
+    this.lifeCycleManager = defaultLifeCycleManager;
+
+    // add other services after (this way the LifeCycleService) cannot be override by the user
+    for (Service service : services) {
+      this.serviceLocator.addService(service);
+    }
+
+    // register a state change listener on this cache manager. 
+    // We use a StateChangeListener because they are fired AFTER all init / close hooks
+    this.statusTransitioner.registerListener(lifeCycleManager.createStateChangeListener(this));
+
     StatisticsManager.associate(ehcacheManagerStatsSettings).withParent(this);
   }
 
@@ -376,6 +393,10 @@ public class EhcacheManager implements PersistentCacheManager {
 
     final ManagementRegistry managementRegistry = serviceLocator.getService(ManagementRegistry.class);
     final EhcacheStatsSettings ehcacheStatsSettings = new EhcacheStatsSettings(alias, Collections.<String, Object>singletonMap("Setting", "CacheName"));
+
+    // registers a listener on ehcache status transitioner, when all init / close hoot are done
+    // to provide a way for services to know when an ehcache instance is initialized or closed
+    ehCache.registerListener(lifeCycleManager.createStateChangeListener(ehCache));
 
     lifeCycledList.add(new LifeCycled() {
       @Override

--- a/core/src/main/java/org/ehcache/spi/lifecycle/DefaultLifeCycleManager.java
+++ b/core/src/main/java/org/ehcache/spi/lifecycle/DefaultLifeCycleManager.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.lifecycle;
+
+import org.ehcache.CacheManager;
+import org.ehcache.Status;
+import org.ehcache.events.StateChangeListener;
+import org.ehcache.spi.ServiceProvider;
+
+import java.util.ListIterator;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultLifeCycleManager implements LifeCycleManager, LifeCycleService {
+
+  private final CopyOnWriteArrayList<Listener<?>> listeners = new CopyOnWriteArrayList<Listener<?>>();
+  private final LifeCycleListenerAdapter<CacheManager> refCleaner = new LifeCycleListenerAdapter<CacheManager>() {
+    @Override
+    public void afterClosing(CacheManager instance) {
+      listeners.clear();
+    }
+  };
+
+  @Override
+  public <T> void register(Class<T> listenedType, LifeCycleListener<T> listener) {
+    listeners.add(new Listener<T>(listenedType, listener));
+  }
+
+  @Override
+  public void unregister(LifeCycleListener<?> listener) {
+    for (Listener<?> l : listeners) {
+      if (l.listener == listener) {
+        listeners.remove(l);
+      }
+    }
+  }
+
+  @Override
+  public void start(ServiceProvider serviceProvider) {
+    // just to make sure all listeners are cleared when the cache manager is closed
+    if (!listeners.contains(refCleaner)) {
+      register(CacheManager.class, refCleaner);
+    }
+  }
+
+  @Override
+  public void stop() {
+  }
+
+  @Override
+  public StateChangeListener createStateChangeListener(final Object o) {
+    return new StateChangeListener() {
+      @Override
+      public void stateTransition(Status from, Status to) {
+        if (from == Status.UNINITIALIZED && to == Status.AVAILABLE) {
+          initialized(o);
+        } else if (from == Status.AVAILABLE && to == Status.UNINITIALIZED) {
+          closed(o);
+        }
+      }
+    };
+  }
+
+  private static class Listener<T> {
+    final Class<T> type;
+    final LifeCycleListener<T> listener;
+
+    Listener(Class<T> type, LifeCycleListener<T> listener) {
+      this.type = type;
+      this.listener = listener;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> void initialized(T o) {
+    for (Listener<?> listener : listeners) {
+      if (listener.type.isInstance(o)) {
+        ((LifeCycleListener<T>) listener.listener).afterInitialization(o);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> void closed(T o) {
+    ListIterator<Listener<?>> it = listeners.listIterator(listeners.size());
+    while (it.hasPrevious()) {
+      Listener<?> listener = it.previous();
+      if (listener.type.isInstance(o)) {
+        ((LifeCycleListener<T>) listener.listener).afterClosing(o);
+      }
+    }
+  }
+
+}

--- a/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleListener.java
+++ b/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.lifecycle;
+
+/**
+ * Listens of life cycle change on a particular object
+ * 
+ * @author Mathieu Carbou
+ */
+public interface LifeCycleListener<T> {
+
+  /**
+   * Called when the instance is initialized
+   */
+  void afterInitialization(T instance);
+
+  /**
+   * Called when the instance is closed
+   */
+  void afterClosing(T instance);
+}

--- a/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleListenerAdapter.java
+++ b/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleListenerAdapter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.lifecycle;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Mathieu Carbou
+ */
+public abstract class LifeCycleListenerAdapter<T> implements LifeCycleListener<T> {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void afterInitialization(T instance) {
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void afterClosing(T instance) {
+
+  }
+}

--- a/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleManager.java
+++ b/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.lifecycle;
+
+import org.ehcache.events.StateChangeListener;
+
+/**
+ * Service used internally to create a StateChangeListener based on an instance having a lifecycle.
+ * <p/>
+ * A StateChangeListener runs after all init / close hooks.
+ *
+ * @author Mathieu Carbou
+ */
+public interface LifeCycleManager {
+
+  /**
+   * Create a {@link StateChangeListener} instance based an object which will trigger all listeners of type {@link LifeCycleListener}
+   * having registered for this object type with the {@link LifeCycleService}
+   *
+   * @param o The Object to be lifecycled
+   * @return A listener that can be registered into a {@link org.ehcache.StatusTransitioner}
+   */
+  StateChangeListener createStateChangeListener(Object o);
+
+}

--- a/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleService.java
+++ b/core/src/main/java/org/ehcache/spi/lifecycle/LifeCycleService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.lifecycle;
+
+import org.ehcache.spi.service.Service;
+
+/**
+ * Service which can be used to register some listeners that will be triggers on initialization and close on some objects.
+ *
+ * @author Mathieu Carbou
+ */
+public interface LifeCycleService extends Service {
+
+  /**
+   * Registers a listener for the lifecycle of objects of a specific type
+   *
+   * @param listenedType The class of objects to listen to
+   * @param listener     The listener
+   * @param <T>          The type of object to listen
+   */
+  <T> void register(Class<T> listenedType, LifeCycleListener<T> listener);
+
+  /**
+   * Unregisters a listener instance
+   * 
+   * @param listener The listener to unregister
+   */
+  void unregister(LifeCycleListener<?> listener);
+}

--- a/core/src/test/java/org/ehcache/spi/lifecycle/LifeCycleServiceTest.java
+++ b/core/src/test/java/org/ehcache/spi/lifecycle/LifeCycleServiceTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.lifecycle;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheConfigurationChangeListener;
+import org.ehcache.CacheManager;
+import org.ehcache.CacheManagerBuilder;
+import org.ehcache.EhcacheManager;
+import org.ehcache.Maintainable;
+import org.ehcache.PersistentCacheManager;
+import org.ehcache.Status;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.CacheConfigurationBuilder;
+import org.ehcache.config.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.event.CacheEventListenerProvider;
+import org.ehcache.events.CacheEventNotificationListenerServiceProvider;
+import org.ehcache.events.CacheEventNotificationService;
+import org.ehcache.events.StateChangeListener;
+import org.ehcache.spi.ServiceProvider;
+import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
+import org.ehcache.spi.loaderwriter.WriteBehindDecoratorLoaderWriterProvider;
+import org.ehcache.spi.service.LocalPersistenceService;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.ehcache.spi.service.ServiceDependencies;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class LifeCycleServiceTest {
+
+  @Test
+  public void testServicesCanListenOnLifeCycles() {
+
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
+        .buildConfig(Long.class, String.class);
+
+    MyService myService = new MyService();
+
+    Store.Provider storeProvider = mock(Store.Provider.class);
+    Store store = mock(Store.class);
+    CacheEventNotificationListenerServiceProvider cacheEventNotificationListenerServiceProvider = mock(CacheEventNotificationListenerServiceProvider.class);
+
+    when(storeProvider.createStore(any(Store.Configuration.class), Matchers.<ServiceConfiguration>anyVararg())).thenReturn(store);
+    when(store.getConfigurationChangeListeners()).thenReturn(new ArrayList<CacheConfigurationChangeListener>());
+    when(cacheEventNotificationListenerServiceProvider.createCacheEventNotificationService(store)).thenReturn(mock(CacheEventNotificationService.class));
+
+    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+        .withCache("aCache", cacheConfiguration)
+        .using(myService)
+        .using(storeProvider)
+        .using(mock(CacheLoaderWriterProvider.class))
+        .using(mock(WriteBehindDecoratorLoaderWriterProvider.class))
+        .using(cacheEventNotificationListenerServiceProvider)
+        .using(mock(CacheEventListenerProvider.class))
+        .using(mock(LocalPersistenceService.class))
+        .build(true);
+
+    assertEquals("[start, cache-init, cache-manager-init]", myService.calls.toString());
+
+    cacheManager.close();
+    assertEquals("[start, cache-init, cache-manager-init, cache-closed, stop, cache-manager-closed]", myService.calls.toString());
+
+    cacheManager.init();
+    assertEquals("[start, cache-init, cache-manager-init, cache-closed, stop, cache-manager-closed, start, cache-init, cache-manager-init]", myService.calls.toString());
+
+    cacheManager.close();
+    assertEquals("[start, cache-init, cache-manager-init, cache-closed, stop, cache-manager-closed, start, cache-init, cache-manager-init, cache-closed, stop, cache-manager-closed]", myService.calls.toString());
+
+    myService.calls.clear();
+
+    Maintainable maintainable = ((PersistentCacheManager) cacheManager).toMaintenance();
+    assertEquals("[]", myService.calls.toString());
+
+    // maintenance mode does not trigger cache / cache manager lifecycle events 
+    maintainable.close();
+    assertEquals("[]", myService.calls.toString());
+
+    cacheManager.init();
+    assertEquals("[start, cache-init, cache-manager-init]", myService.calls.toString());
+
+    cacheManager.close();
+    assertEquals("[start, cache-init, cache-manager-init, cache-closed, stop, cache-manager-closed]", myService.calls.toString());
+  }
+
+  @Test
+  public void testCanUseAdapter() {
+    assertTrue(Modifier.isAbstract(LifeCycleListenerAdapter.class.getModifiers()));
+    final List<String> calls = new ArrayList<String>();
+    LifeCycleListenerAdapter<String> adapter1 = new LifeCycleListenerAdapter<String>() {
+    };
+    LifeCycleListenerAdapter<String> adapter2 = new LifeCycleListenerAdapter<String>() {
+      @Override
+      public void afterInitialization(String instance) {
+        calls.add("adapter2-init");
+        assertEquals("data", instance);
+      }
+    };
+    LifeCycleListenerAdapter<String> adapter3 = new LifeCycleListenerAdapter<String>() {
+      @Override
+      public void afterClosing(String instance) {
+        calls.add("adapter3-close");
+        assertEquals("data", instance);
+      }
+    };
+    LifeCycleListenerAdapter<String> adapter4 = new LifeCycleListenerAdapter<String>() {
+      @Override
+      public void afterInitialization(String instance) {
+        calls.add("adapter4-init");
+        assertEquals("data", instance);
+      }
+
+      @Override
+      public void afterClosing(String instance) {
+        calls.add("adapter4-close");
+        assertEquals("data", instance);
+      }
+    };
+    DefaultLifeCycleManager lifeCycleManager = new DefaultLifeCycleManager();
+    lifeCycleManager.register(String.class, adapter1);
+    lifeCycleManager.register(String.class, adapter2);
+    lifeCycleManager.register(String.class, adapter3);
+    lifeCycleManager.register(String.class, adapter4);
+
+    StateChangeListener changeListener = lifeCycleManager.createStateChangeListener("data");
+
+    lifeCycleManager.start(null);
+    changeListener.stateTransition(Status.UNINITIALIZED, Status.AVAILABLE);
+    assertEquals("[adapter2-init, adapter4-init]", calls.toString());
+
+    lifeCycleManager.stop();
+    changeListener.stateTransition(Status.AVAILABLE, Status.UNINITIALIZED);
+    assertEquals("[adapter2-init, adapter4-init, adapter4-close, adapter3-close]", calls.toString());
+    
+    lifeCycleManager.start(null);
+    changeListener.stateTransition(Status.UNINITIALIZED, Status.MAINTENANCE);
+    assertEquals("[adapter2-init, adapter4-init, adapter4-close, adapter3-close]", calls.toString());
+
+    lifeCycleManager.stop();
+    changeListener.stateTransition(Status.MAINTENANCE, Status.UNINITIALIZED);
+    assertEquals("[adapter2-init, adapter4-init, adapter4-close, adapter3-close]", calls.toString());
+  }
+
+  @ServiceDependencies(LifeCycleService.class)
+  static class MyService implements Service {
+
+    List<String> calls = new ArrayList<String>();
+
+    @Override
+    public void start(ServiceProvider serviceProvider) {
+      calls.add("start");
+
+      final LifeCycleService lifeCycleService = serviceProvider.getService(LifeCycleService.class);
+
+      // could listen to Cache, Ehcache, etc.
+      final LifeCycleListener<Cache> cacheListener = new LifeCycleListener<Cache>() {
+        @Override
+        public void afterInitialization(Cache instance) {
+          calls.add("cache-init");
+        }
+
+        @Override
+        public void afterClosing(Cache instance) {
+          calls.add("cache-closed");
+        }
+      };
+
+      lifeCycleService.register(Cache.class, cacheListener);
+
+      // could listen to CacheManager, EhCacheManager, etc
+      lifeCycleService.register(EhcacheManager.class, new LifeCycleListener<EhcacheManager>() {
+        @Override
+        public void afterInitialization(EhcacheManager instance) {
+          calls.add("cache-manager-init");
+        }
+
+        @Override
+        public void afterClosing(EhcacheManager instance) {
+          calls.add("cache-manager-closed");
+
+          //lifeCycleService.unregister(this);
+          //lifeCycleService.unregister(cacheListener);
+        }
+      });
+    }
+
+    @Override
+    public void stop() {
+      calls.add("stop");
+    }
+  }
+
+}

--- a/impl/src/main/java/org/ehcache/spi/alias/DefaultAliasConfiguration.java
+++ b/impl/src/main/java/org/ehcache/spi/alias/DefaultAliasConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.alias;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultAliasConfiguration implements AliasConfiguration {
+
+  private static final AtomicLong COUNTER = new AtomicLong();
+  private final String cacheManagerAlias;
+
+  public DefaultAliasConfiguration() {
+    this(null);
+  }
+
+  public DefaultAliasConfiguration(String name) {
+    this.cacheManagerAlias = name != null && name.trim().length() > 0 ? name : "cache-manager-" + COUNTER.incrementAndGet();
+  }
+
+  @Override
+  public Class<AliasService> getServiceType() {
+    return AliasService.class;
+  }
+
+  @Override
+  public String getCacheManagerAlias() {
+    return cacheManagerAlias;
+  }
+
+  public static DefaultAliasConfiguration cacheManagerAlias(String alias) {
+    return new DefaultAliasConfiguration(alias);
+  }
+
+}

--- a/impl/src/main/java/org/ehcache/spi/alias/DefaultAliasService.java
+++ b/impl/src/main/java/org/ehcache/spi/alias/DefaultAliasService.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.alias;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.EhcacheBinding;
+import org.ehcache.internal.concurrent.ConcurrentHashMap;
+import org.ehcache.spi.ServiceProvider;
+import org.ehcache.spi.lifecycle.LifeCycleListener;
+import org.ehcache.spi.lifecycle.LifeCycleListenerAdapter;
+import org.ehcache.spi.lifecycle.LifeCycleService;
+import org.ehcache.spi.service.ServiceDependencies;
+
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author Mathieu Carbou
+ */
+@ServiceDependencies(LifeCycleService.class)
+public class DefaultAliasService implements AliasService {
+
+  private final AliasConfiguration configuration;
+  private final ConcurrentMap<Cache<?, ?>, String> caches = new ConcurrentHashMap<Cache<?, ?>, String>();
+
+  public DefaultAliasService() {
+    this(null);
+  }
+
+  public DefaultAliasService(AliasConfiguration configuration) {
+    this.configuration = configuration != null ? configuration : new DefaultAliasConfiguration();
+  }
+
+  @Override
+  public void start(ServiceProvider serviceProvider) {
+    LifeCycleService lifeCycleService = serviceProvider.getService(LifeCycleService.class);
+
+    lifeCycleService.register(EhcacheBinding.class, new LifeCycleListener<EhcacheBinding>() {
+      @Override
+      public void afterInitialization(EhcacheBinding instance) {
+        caches.putIfAbsent(instance.getCache(), instance.getAlias());
+      }
+
+      @Override
+      public void afterClosing(EhcacheBinding instance) {
+        caches.remove(instance.getCache());
+      }
+    });
+
+    lifeCycleService.register(CacheManager.class, new LifeCycleListenerAdapter<CacheManager>() {
+      @Override
+      public void afterClosing(CacheManager instance) {
+        // ensure the map is cleared when closing cache manager.
+        caches.clear();
+      }
+    });
+  }
+
+  @Override
+  public void stop() {
+  }
+
+  @Override
+  public String getCacheManagerAlias() {
+    return configuration.getCacheManagerAlias();
+  }
+
+  @Override
+  public String getCacheAlias(Cache<?, ?> cache) {
+    String alias = caches.get(cache);
+    if (alias == null) {
+      throw new IllegalArgumentException("Cache " + cache + " is not part of cache manager " + getCacheManagerAlias());
+    }
+    return alias;
+  }
+
+}

--- a/impl/src/main/java/org/ehcache/spi/alias/DefaultAliasServiceFactory.java
+++ b/impl/src/main/java/org/ehcache/spi/alias/DefaultAliasServiceFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.alias;
+
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.ehcache.spi.service.ServiceFactory;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultAliasServiceFactory implements ServiceFactory<AliasService> {
+  @Override
+  public AliasService create(ServiceCreationConfiguration<AliasService> configuration) {
+    return new DefaultAliasService((AliasConfiguration) configuration);
+  }
+
+  @Override
+  public Class<AliasService> getServiceType() {
+    return AliasService.class;
+  }
+}

--- a/impl/src/main/resources/META-INF/services/org.ehcache.spi.service.ServiceFactory
+++ b/impl/src/main/resources/META-INF/services/org.ehcache.spi.service.ServiceFactory
@@ -1,3 +1,5 @@
+org.ehcache.spi.alias.DefaultAliasServiceFactory
+
 org.ehcache.internal.store.DefaultStoreProviderFactory
 org.ehcache.internal.store.heap.OnHeapStoreProviderFactory
 org.ehcache.internal.store.offheap.OffHeapStoreProviderFactory

--- a/impl/src/test/java/org/ehcache/spi/alias/DefaultAliasServiceTest.java
+++ b/impl/src/test/java/org/ehcache/spi/alias/DefaultAliasServiceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.alias;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.CacheManagerBuilder;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.CacheConfigurationBuilder;
+import org.ehcache.config.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.spi.ServiceProvider;
+import org.ehcache.spi.service.Service;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.ehcache.spi.alias.DefaultAliasConfiguration.cacheManagerAlias;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultAliasServiceTest {
+
+  AliasService unNamedIdServ;
+  AliasService namedIdServ;
+  CacheManager unnamedCM;
+  CacheManager namedCM;
+
+  @Before
+  public void before() {
+    CacheConfiguration<String, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
+        .buildConfig(String.class, String.class);
+
+    unnamedCM = CacheManagerBuilder.newCacheManagerBuilder()
+        .withCache("aCache3", cacheConfiguration)
+        .using(unNamedIdServ = new DefaultAliasService())
+        .build(true);
+
+    namedCM = CacheManagerBuilder.newCacheManagerBuilder()
+        .withCache("aCache1", cacheConfiguration)
+        .using(cacheManagerAlias("my-cm"))
+        .using(new Service() {
+          @Override
+          public void start(ServiceProvider serviceProvider) {
+            namedIdServ = serviceProvider.getService(AliasService.class);
+          }
+
+          @Override
+          public void stop() {
+
+          }
+        })
+        .build(true);
+  }
+
+  @After
+  public void after() {
+    unnamedCM.close();
+    namedCM.close();
+  }
+
+  @Test
+  public void test_identification_service() throws Exception {
+    assertTrue(unNamedIdServ.getCacheManagerAlias().matches("cache-manager-\\d+"));
+    assertEquals("my-cm", namedIdServ.getCacheManagerAlias());
+    assertEquals("aCache1", namedIdServ.getCacheAlias(namedCM.getCache("aCache1", String.class, String.class)));
+
+    Cache<String, String> cache3 = unnamedCM.getCache("aCache3", String.class, String.class);
+
+    assertEquals("aCache3", unNamedIdServ.getCacheAlias(cache3));
+
+    try {
+      namedIdServ.getCacheAlias(cache3);
+      fail();
+    } catch (Exception e) {
+      assertEquals(IllegalArgumentException.class, e.getClass());
+    }
+  }
+
+}

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryTest.java
@@ -15,6 +15,9 @@
  */
 package org.ehcache.management.registry;
 
+import org.ehcache.spi.ServiceLocator;
+import org.ehcache.spi.lifecycle.DefaultLifeCycleManager;
+import org.ehcache.spi.alias.DefaultAliasService;
 import org.junit.Test;
 
 import static junit.framework.Assert.fail;
@@ -24,6 +27,8 @@ import static junit.framework.Assert.fail;
  */
 public class DefaultManagementRegistryTest {
 
+  ServiceLocator serviceLocator = new ServiceLocator(new DefaultLifeCycleManager(), new DefaultAliasService());
+  
   @Test
   public void testRegisterOnlyWorksWhenStarted() throws Exception {
     DefaultManagementRegistry defaultManagementRegistry = new DefaultManagementRegistry();
@@ -35,7 +40,7 @@ public class DefaultManagementRegistryTest {
       // expected
     }
 
-    defaultManagementRegistry.start(null);
+    defaultManagementRegistry.start(serviceLocator);
 
     defaultManagementRegistry.register(Object.class, new Object());
 
@@ -60,9 +65,9 @@ public class DefaultManagementRegistryTest {
       // expected
     }
 
-    defaultManagementRegistry.start(null);
-    defaultManagementRegistry.start(null);
-    defaultManagementRegistry.start(null);
+    defaultManagementRegistry.start(serviceLocator);
+    defaultManagementRegistry.start(serviceLocator);
+    defaultManagementRegistry.start(serviceLocator);
 
     defaultManagementRegistry.register(Object.class, new Object());
 
@@ -84,7 +89,7 @@ public class DefaultManagementRegistryTest {
     defaultManagementRegistry.stop();
     defaultManagementRegistry.stop();
 
-    defaultManagementRegistry.start(null);
+    defaultManagementRegistry.start(serviceLocator);
     defaultManagementRegistry.register(Object.class, new Object());
     defaultManagementRegistry.stop();
 
@@ -94,7 +99,7 @@ public class DefaultManagementRegistryTest {
   public void testRestartingAfterStops() throws Exception {
     DefaultManagementRegistry defaultManagementRegistry = new DefaultManagementRegistry();
 
-    defaultManagementRegistry.start(null);
+    defaultManagementRegistry.start(serviceLocator);
 
     defaultManagementRegistry.register(Object.class, new Object());
 
@@ -109,7 +114,7 @@ public class DefaultManagementRegistryTest {
       // expected
     }
 
-    defaultManagementRegistry.start(null);
+    defaultManagementRegistry.start(serviceLocator);
     defaultManagementRegistry.register(Object.class, new Object());
     defaultManagementRegistry.stop();
   }


### PR DESCRIPTION
- PR for issue #545 
- Depends on Issue #540 (solved by PR #551)

The idea here is to provide a service, configurable by a user, which is responsible for naming the cache manager this service is used into.

The `NamingService` would thus be required by the management service, which need to have a cache manager name. Other services requiring a name would also be able to depend on this service. 

Naming a cache manager is optional, and just needed by some services.

Note:

This PR contains 2 commits from PR #551 and 1 commit for the NamingService (20969f2)