### PR TITLE
Issue #468 bulk ops statistics

### DIFF
--- a/107/src/main/java/org/ehcache/EhcacheHackAccessor.java
+++ b/107/src/main/java/org/ehcache/EhcacheHackAccessor.java
@@ -17,9 +17,9 @@ package org.ehcache;
 
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.statistics.BulkOps;
+import org.terracotta.statistics.jsr166e.LongAdder;
 
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Map;
 
 /**
  * EhcacheHackAccessor
@@ -38,7 +38,7 @@ public final class EhcacheHackAccessor {
     return ehcache.getJsr107Cache();
   }
 
-  public static ConcurrentMap<BulkOps, AtomicLong> getBulkMethodEntries(Ehcache<?, ?> ehcache) {
+  public static Map<BulkOps, LongAdder> getBulkMethodEntries(Ehcache<?, ?> ehcache) {
     return ehcache.getBulkMethodEntries();
   }
 

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
@@ -92,7 +92,7 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
 
   @Override
   public long getCacheHits() {
-    return normalize(getHits() - compensatingCounters.cacheHits);
+    return normalize(getHits() - compensatingCounters.cacheHits - compensatingCounters.bulkGetHits);
   }
 
   @Override
@@ -103,7 +103,7 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
 
   @Override
   public long getCacheMisses() {
-    return normalize(getMisses() - compensatingCounters.cacheMisses);
+    return normalize(getMisses() - compensatingCounters.cacheMisses - compensatingCounters.bulkGetMiss);
   }
 
   @Override
@@ -114,8 +114,10 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
 
   @Override
   public long getCacheGets() {
-    return normalize(getBulkCount(BulkOps.GET_ALL) - compensatingCounters.bulkGets +
-        getHits() + getMisses() - compensatingCounters.cacheGets);
+    return normalize(getHits() + getMisses()
+                     - compensatingCounters.cacheGets
+                     - compensatingCounters.bulkGetHits
+                     - compensatingCounters.bulkGetMiss);
   }
 
   @Override
@@ -170,14 +172,16 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
   }
 
   private long getMisses() {
-    return get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER, CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER)) +
+    return getBulkCount(BulkOps.GET_ALL_MISS) +
+        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER, CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER)) +
         putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
         replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.MISS_NOT_PRESENT)) +
         conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
   }
 
   private long getHits() {
-    return get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER, CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER)) +
+    return getBulkCount(BulkOps.GET_ALL_HITS) +
+        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER, CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER)) +
         putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
         replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT, CacheOperationOutcomes.ReplaceOutcome.MISS_PRESENT)) +
         conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS, CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));
@@ -279,7 +283,8 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
     volatile long cacheHits;
     volatile long cacheMisses;
     volatile long cacheGets;
-    volatile long bulkGets;
+    volatile long bulkGetHits;
+    volatile long bulkGetMiss;
     volatile long cachePuts;
     volatile long bulkPuts;
     volatile long cacheRemovals;
@@ -291,7 +296,8 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
       cacheHits += Eh107CacheStatisticsMXBean.this.getCacheHits();
       cacheMisses += Eh107CacheStatisticsMXBean.this.getCacheMisses();
       cacheGets += Eh107CacheStatisticsMXBean.this.getCacheGets();
-      bulkGets += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.GET_ALL);
+      bulkGetHits += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.GET_ALL_HITS);
+      bulkGetMiss += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.GET_ALL_MISS);
       cachePuts += Eh107CacheStatisticsMXBean.this.getCachePuts();
       bulkPuts += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.PUT_ALL);
       cacheRemovals += Eh107CacheStatisticsMXBean.this.getCacheRemovals();

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
@@ -31,6 +31,7 @@ import org.terracotta.management.stats.Sample;
 import org.terracotta.management.stats.sampled.SampledRatio;
 import org.terracotta.statistics.OperationStatistic;
 import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.jsr166e.LongAdder;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,8 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.terracotta.context.query.Matchers.attributes;
 import static org.terracotta.context.query.Matchers.context;
@@ -63,7 +62,7 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
   private final OperationStatistic<StoreOperationOutcomes.EvictionOutcome> authorityEviction;
   private final ManagementRegistry managementRegistry;
   private final Map<String, String> context;
-  private final ConcurrentMap<BulkOps, AtomicLong> bulkMethodEntries;
+  private final Map<BulkOps, LongAdder> bulkMethodEntries;
 
   Eh107CacheStatisticsMXBean(String cacheName, Eh107CacheManager cacheManager, Cache<?, ?> cache, ManagementRegistry managementRegistry) {
     super(cacheName, cacheManager, "CacheStatistics");
@@ -188,8 +187,7 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
   }
 
   private long getBulkCount(BulkOps bulkOps) {
-    AtomicLong counter = bulkMethodEntries.get(bulkOps);
-    return counter == null ? 0L : counter.get();
+    return bulkMethodEntries.get(bulkOps).longValue();
   }
 
   private static long normalize(long value) {

--- a/107/src/test/java/org/ehcache/jsr107/StatisticsTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/StatisticsTest.java
@@ -26,6 +26,7 @@ import javax.cache.Caching;
 import javax.cache.configuration.MutableConfiguration;
 import javax.cache.spi.CachingProvider;
 
+import java.util.HashSet;
 import java.util.concurrent.Callable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -130,6 +131,21 @@ public class StatisticsTest {
     heapCache.get("key");
 
     assertThat(heapStatistics.getCacheMisses(), is(5L));
+  }
+
+  @Test
+  public void test_getCacheHitsAndMisses() {
+    heapCache.put("key1", "value1");
+    heapCache.put("key3", "value3");
+    heapCache.put("key5", "value5");
+
+    HashSet<String> keys = new HashSet<String>(5);
+    for (int i = 1; i <= 5; i++) {
+      keys.add("key" + i);
+    }
+    heapCache.getAll(keys);
+    assertThat(heapStatistics.getCacheHits(), is(3L));
+    assertThat(heapStatistics.getCacheMisses(), is(2L));
   }
 
   @Test

--- a/api/src/main/java/org/ehcache/statistics/BulkOps.java
+++ b/api/src/main/java/org/ehcache/statistics/BulkOps.java
@@ -23,7 +23,12 @@ public enum BulkOps {
   /**
    * The "get all" bulk operation
    */
-  GET_ALL,
+  GET_ALL_HITS,
+
+  /**
+   * The "get all" missed bulk operation
+   */
+  GET_ALL_MISS,
 
   /**
    * The "put all" bulk operation

--- a/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
@@ -40,6 +40,14 @@ public interface CacheOperationOutcomes {
   };
 
   /**
+   * Outcomes for cache getAll operation
+   */
+  enum GetAllOutcome implements  CacheOperationOutcomes {
+    SUCCESS,
+    FAILURE
+  }
+
+  /**
    * The outcomes for Put Outcomes.
    */
   enum PutOutcome implements CacheOperationOutcomes {

--- a/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
@@ -60,6 +60,14 @@ public interface CacheOperationOutcomes {
   };
 
   /**
+   * Outcomes for cache putAll operation
+   */
+  enum PutAllOutcome implements CacheOperationOutcomes {
+    SUCCESS,
+    FAILURE
+  }
+
+  /**
    * The outcomes for remove operations.
    */
   enum RemoveOutcome implements CacheOperationOutcomes {

--- a/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/statistics/CacheOperationOutcomes.java
@@ -80,6 +80,14 @@ public interface CacheOperationOutcomes {
   };
 
   /**
+   * Outcomes for cache removeAll operation
+   */
+  enum RemoveAllOutcome implements CacheOperationOutcomes {
+    SUCCESS,
+    FAILURE
+  }
+
+  /**
    * The outcomes for conditional remove operations.
    */
   enum ConditionalRemoveOutcome implements CacheOperationOutcomes {


### PR DESCRIPTION
* Added `OperationObserver` for getAll, putAll and removeAll
* Added counter for `getAll` miss
* Replace `AtomicLong` with `LongAdder` for bulk counters