### PR TITLE
Incorrect checkstyle config path

### DIFF
--- a/impl/config/checkstyle-suppressions.xml
+++ b/impl/config/checkstyle-suppressions.xml
@@ -6,6 +6,6 @@
 
 <suppressions>
   <suppress files="ConcurrentHashMapV8.java" checks="Header"/>
-  <suppress files="src[\\/]main[\\/]java[\\/]org/ehcache[\\/]internal[\\/]classes[\\/]commonslang[\\/].*$" checks="Header"/>
+  <suppress files="src[\\/]main[\\/]java[\\/]org[\\/]ehcache[\\/]internal[\\/]classes[\\/]commonslang[\\/].*$" checks="Header"/>
   <suppress files="^((?!.*test[\\/]java[\\/]org[\\/]ehcache[\\/]docs[\\/].*).)*$" checks="AvoidStaticImport"/>
 </suppressions>


### PR DESCRIPTION
Compilation fails on windows with checkstyle errors as the config has incorrect path