### PR TITLE
Issue #369 Ignore introduced findbugs warning

### DIFF
--- a/impl/src/main/java/org/ehcache/internal/store/heap/holders/LookupOnlyOnHeapKey.java
+++ b/impl/src/main/java/org/ehcache/internal/store/heap/holders/LookupOnlyOnHeapKey.java
@@ -16,6 +16,8 @@
 
 package org.ehcache.internal.store.heap.holders;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class LookupOnlyOnHeapKey<K> extends BaseOnHeapKey<K> {
 
   private final K actualKeyObject;
@@ -30,6 +32,7 @@ public class LookupOnlyOnHeapKey<K> extends BaseOnHeapKey<K> {
     return actualKeyObject;
   }
 
+  @SuppressFBWarnings("EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS")
   @Override
   public boolean equals(Object other) {
     if (other instanceof CopiedOnHeapKey) {


### PR DESCRIPTION
* As wrapper objects, comparing OnHeapKey subclasses fully delegates to getting a hold of their key reference