### PR TITLE
Issue #369 OffHeapValueHolder with lazy deserialization

### DIFF
--- a/core/src/main/java/org/ehcache/spi/cache/tiering/BinaryValueHolder.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/BinaryValueHolder.java
@@ -31,4 +31,11 @@ public interface BinaryValueHolder {
    * @throws IllegalStateException If the ValueHolder cannot provide the binary form
    */
   ByteBuffer getBinaryValue() throws IllegalStateException;
+
+  /**
+   * Indicates whether the binary value can be accessed.
+   *
+   * @return {@code true} if the binary value is present and accessible, {@code false} otherwise
+   */
+  boolean isBinaryValueAvailable();
 }

--- a/core/src/main/java/org/ehcache/spi/cache/tiering/BinaryValueHolder.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/BinaryValueHolder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.cache.tiering;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Companion interface for {@link org.ehcache.spi.cache.Store.ValueHolder} to indicate that a binary representation
+ * of the value can be provided.
+ */
+public interface BinaryValueHolder {
+
+  /**
+   * Returns the {@link ByteBuffer} containing the value in binary form
+   *
+   * @return the binary form inside a ByteBuffer
+   * @throws IllegalStateException If the ValueHolder cannot provide the binary form
+   */
+  ByteBuffer getBinaryValue() throws IllegalStateException;
+}

--- a/core/src/main/java/org/ehcache/spi/cache/tiering/CachingTier.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/CachingTier.java
@@ -48,14 +48,6 @@ public interface CachingTier<K, V> extends ConfigurationChangeSupport {
   void invalidate(K key) throws CacheAccessException;
 
   /**
-   * Remove a mapping, then call a function under the same lock scope irrespectively of a mapping being there or not.
-   * @param key the key.
-   * @param function the function to call.
-   * @throws CacheAccessException
-   */
-  void invalidate(K key, NullaryFunction<K> function) throws CacheAccessException;
-
-  /**
    * Empty out the caching store.
    * @throws CacheAccessException
    */

--- a/core/src/main/java/org/ehcache/spi/cache/tiering/HigherCachingTier.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/HigherCachingTier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.cache.tiering;
+
+import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.function.Function;
+import org.ehcache.spi.cache.Store;
+
+/**
+ * HigherCachingTier
+ */
+public interface HigherCachingTier<K, V> extends CachingTier<K, V> {
+
+  /**
+   * Removes a mapping without firing an invalidation event, then calls the function under the same lock scope
+   * passing in the mapping or null if none was present.
+   *
+   * @param key the key.
+   * @param function the function to call.
+   * @throws CacheAccessException
+   */
+  void silentInvalidate(K key, Function<Store.ValueHolder<V>, Void> function) throws CacheAccessException;
+
+}

--- a/impl/src/main/java/org/ehcache/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCache.java
+++ b/impl/src/main/java/org/ehcache/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCache.java
@@ -59,6 +59,12 @@ public class EhcachePersistentConcurrentOffHeapClockCache<K, V> extends Abstract
   }
 
   @Override
+  public V computeIfPresentAndPin(K key, BiFunction<K, V, V> mappingFunction) {
+    EhcachePersistentSegmentFactory.EhcachePersistentSegment<K, V> segment = (EhcachePersistentSegmentFactory.EhcachePersistentSegment) segmentFor(key);
+    return segment.computeIfPresentAndPin(key, mappingFunction);
+  }
+
+  @Override
   public boolean computeIfPinned(final K key, final BiFunction<K,V,V> remappingFunction, final Function<V,Boolean> pinningFunction) {
     EhcachePersistentSegmentFactory.EhcachePersistentSegment<K, V> segment = (EhcachePersistentSegmentFactory.EhcachePersistentSegment) segmentFor(key);
     return segment.computeIfPinned(key, remappingFunction, pinningFunction);

--- a/impl/src/main/java/org/ehcache/internal/store/heap/holders/SerializedOnHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/internal/store/heap/holders/SerializedOnHeapValueHolder.java
@@ -52,6 +52,14 @@ public class SerializedOnHeapValueHolder<V> extends OnHeapValueHolder<V> {
     this.accessed(now, expiration);
   }
 
+  public SerializedOnHeapValueHolder(Store.ValueHolder<V> valueHolder, ByteBuffer binaryValue, Serializer<V> serializer, long now, Duration expiration) {
+    super(valueHolder.getId(), valueHolder.creationTime(TIME_UNIT), valueHolder.expirationTime(TIME_UNIT));
+    this.buffer = binaryValue;
+    this.serializer = serializer;
+    this.setHits(valueHolder.hits());
+    this.accessed(now, expiration);
+  }
+
   @Override
   public final V value() {
     try {

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/AbstractOffHeapStore.java
@@ -375,10 +375,10 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
 
   @Override
   public ValueHolder<V> computeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction) throws CacheAccessException {
-    return internalComputeIfAbsent(key, mappingFunction, false);
+    return internalComputeIfAbsent(key, mappingFunction, false, false);
   }
 
-  private Store.ValueHolder<V> internalComputeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction, boolean fault) throws CacheAccessException {
+  private Store.ValueHolder<V> internalComputeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction, boolean fault, final boolean delayedDeserialization) throws CacheAccessException {
     checkKey(key);
 
     BiFunction<K, OffHeapValueHolder<V>, OffHeapValueHolder<V>> computeFunction = new BiFunction<K, OffHeapValueHolder<V>, OffHeapValueHolder<V>>() {
@@ -397,6 +397,9 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
             return newCreateValueHolder(mappedKey, computedValue, now);
           }
         } else {
+          if (delayedDeserialization) {
+            mappedValue.prepareForDelayedDeserialization();
+          }
           setAccessTimeAndExpiry(mappedKey, mappedValue, now);
           return mappedValue;
         }
@@ -552,7 +555,7 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
 
   @Override
   public ValueHolder<V> computeIfAbsentAndFault(K key, Function<? super K, ? extends V> mappingFunction) throws CacheAccessException {
-    return internalComputeIfAbsent(key, mappingFunction, true);
+    return internalComputeIfAbsent(key, mappingFunction, true, true);
   }
 
   @Override

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/EhcacheConcurrentOffHeapClockCache.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/EhcacheConcurrentOffHeapClockCache.java
@@ -54,6 +54,12 @@ public class EhcacheConcurrentOffHeapClockCache<K, V> extends AbstractConcurrent
   }
 
   @Override
+  public V computeIfPresentAndPin(K key, BiFunction<K, V, V> mappingFunction) {
+    EhcacheSegmentFactory.EhcacheSegment<K, V> segment = (EhcacheSegmentFactory.EhcacheSegment) segmentFor(key);
+    return segment.computeIfPresentAndPin(key, mappingFunction);
+  }
+
+  @Override
   public boolean computeIfPinned(final K key, final BiFunction<K,V,V> remappingFunction, final Function<V,Boolean> pinningFunction) {
     EhcacheSegmentFactory.EhcacheSegment<K, V> segment = (EhcacheSegmentFactory.EhcacheSegment) segmentFor(key);
     return segment.computeIfPinned(key, remappingFunction, pinningFunction);

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/EhcacheOffHeapBackingMap.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/EhcacheOffHeapBackingMap.java
@@ -30,6 +30,8 @@ public interface EhcacheOffHeapBackingMap<K, V> extends ConcurrentMap<K, V> {
   V computeIfPresent(K key, BiFunction<K, V, V> mappingFunction);
 
   boolean computeIfPinned(K key, BiFunction<K,V,V> remappingFunction, Function<V,Boolean> pinningFunction);
+
+  V computeIfPresentAndPin(K key, BiFunction<K, V, V> mappingFunction);
   
   long nextIdFor(K key);
 

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/OffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/OffHeapValueHolder.java
@@ -16,38 +16,68 @@
 
 package org.ehcache.internal.store.offheap;
 
+import org.ehcache.exceptions.SerializerException;
 import org.ehcache.internal.store.offheap.portability.OffHeapValueHolderPortability;
 import org.ehcache.spi.cache.AbstractValueHolder;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.cache.tiering.BinaryValueHolder;
+import org.ehcache.spi.serialization.Serializer;
 import org.terracotta.offheapstore.storage.portability.WriteContext;
+import org.terracotta.offheapstore.util.FindbugsSuppressWarnings;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 /**
 * OffHeapValueHolder
 */
-public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> {
+@FindbugsSuppressWarnings("SE_NO_SERIALVERSIONID")
+public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> implements BinaryValueHolder {
 
   public static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
-  private final V value;
-  private final WriteContext writeContext;
+  private Mode mode;
+  private transient ByteBuffer binaryValue;
+  private transient Serializer<V> valueSerializer;
+  private V value;
+  private transient final WriteContext writeContext;
 
   public OffHeapValueHolder(long id, V value, long creationTime, long expireTime) {
-    this(id, value, creationTime, expireTime, 0, 0, null);
+    this(id, value, creationTime, expireTime, 0, 0);
   }
 
-  public OffHeapValueHolder(long id, V value, long creationTime, long expireTime, long lastAccessTime, long hits, WriteContext writeContext) {
+  public OffHeapValueHolder(long id, V value, long creationTime, long expireTime, long lastAccessTime, long hits) {
     super(id, creationTime, expireTime);
     setLastAccessTime(lastAccessTime, TIME_UNIT);
     this.value = value;
     this.setHits(hits);
+    this.writeContext = null;
+    this.mode = Mode.VALUE;
+  }
+
+  public OffHeapValueHolder(long id, ByteBuffer binaryValue, Serializer<V> serializer, long creationTime, long expireTime, long lastAccessTime, long hits, WriteContext writeContext) {
+    super(id, creationTime, expireTime);
+    setLastAccessTime(lastAccessTime, TIME_UNIT);
+    this.binaryValue = binaryValue;
+    this.valueSerializer = serializer;
+    this.setHits(hits);
     this.writeContext = writeContext;
+    this.mode = Mode.BINARY;
   }
 
   @Override
   public V value() {
+    forceDeserialization();
     return value;
+  }
+
+  @Override
+  public ByteBuffer getBinaryValue() throws IllegalStateException {
+    if (mode != Mode.BOTH) {
+      throw new IllegalStateException("This OffHeapValueHolder has not been prepared to hand off its binary form");
+    }
+    return binaryValue;
   }
 
   @Override
@@ -58,9 +88,8 @@ public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> {
     OffHeapValueHolder that = (OffHeapValueHolder)other;
 
     if (!super.equals(that)) return false;
-    if (!value.equals(that.value)) return false;
+    return value().equals(that.value());
 
-    return true;
   }
 
   @Override
@@ -70,17 +99,11 @@ public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> {
 
   @Override
   public int hashCode() {
+    forceDeserialization();
     int result = 1;
     result = 31 * result + value.hashCode();
     result = 31 * result + super.hashCode();
     return result;
-  }
-
-  public void writeBack() {
-    writeContext.setLong(OffHeapValueHolderPortability.ACCESS_TIME_OFFSET, lastAccessTime(TimeUnit.MILLISECONDS));
-    writeContext.setLong(OffHeapValueHolderPortability.EXPIRE_TIME_OFFSET, expirationTime(TimeUnit.MILLISECONDS));
-    writeContext.setLong(OffHeapValueHolderPortability.HITS_OFFSET, hits());
-    writeContext.flush();
   }
 
   public void updateMetadata(final Store.ValueHolder<V> valueFlushed) {
@@ -91,4 +114,47 @@ public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> {
     this.setExpirationTime(valueFlushed.expirationTime(OffHeapValueHolder.TIME_UNIT), OffHeapValueHolder.TIME_UNIT);
     this.setHits(valueFlushed.hits());
   }
+
+  void writeBack() {
+    writeContext.setLong(OffHeapValueHolderPortability.ACCESS_TIME_OFFSET, lastAccessTime(TimeUnit.MILLISECONDS));
+    writeContext.setLong(OffHeapValueHolderPortability.EXPIRE_TIME_OFFSET, expirationTime(TimeUnit.MILLISECONDS));
+    writeContext.setLong(OffHeapValueHolderPortability.HITS_OFFSET, hits());
+    writeContext.flush();
+  }
+
+  void forceDeserialization() {
+    if (value == null && mode != Mode.VALUE) {
+      try {
+        value = valueSerializer.read(binaryValue.duplicate());
+      } catch (ClassNotFoundException e) {
+        throw new SerializerException(e);
+      } finally {
+        if (mode == Mode.BINARY) {
+          binaryValue = null;
+          valueSerializer = null;
+          mode = Mode.VALUE;
+        }
+      }
+    }
+  }
+
+  void prepareForDelayedDeserialization() {
+    if (mode == Mode.BINARY) {
+      byte[] bytes = new byte[binaryValue.remaining()];
+      binaryValue.get(bytes);
+      binaryValue = ByteBuffer.wrap(bytes);
+      mode = Mode.BOTH;
+    } else {
+      throw new IllegalStateException("OffHeapValueHolder in mode " + mode + " cannot be prepared for delayed deserialization");
+    }
+  }
+
+  private enum Mode {
+    VALUE, BINARY, BOTH
+  }
+
+  private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    throw new UnsupportedOperationException("This subclass of AbstractValueHolder is NOT serializable");
+  }
+
 }

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/OffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/OffHeapValueHolder.java
@@ -81,6 +81,11 @@ public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> implemen
   }
 
   @Override
+  public boolean isBinaryValueAvailable() {
+    return mode == Mode.BOTH;
+  }
+
+  @Override
   public boolean equals(Object other) {
     if (this == other) return true;
     if (other == null || getClass() != other.getClass()) return false;

--- a/impl/src/main/java/org/ehcache/internal/store/offheap/portability/OffHeapValueHolderPortability.java
+++ b/impl/src/main/java/org/ehcache/internal/store/offheap/portability/OffHeapValueHolderPortability.java
@@ -22,9 +22,7 @@ import org.ehcache.spi.serialization.Serializer;
 import org.terracotta.offheapstore.storage.portability.WriteBackPortability;
 import org.terracotta.offheapstore.storage.portability.WriteContext;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.ehcache.exceptions.SerializerException;
 
 /**
  * OffHeapValueHolderPortability
@@ -70,16 +68,12 @@ public class OffHeapValueHolderPortability<V> implements WriteBackPortability<Of
 
   @Override
   public OffHeapValueHolder<V> decode(ByteBuffer byteBuffer, WriteContext writeContext) {
-    try {
-      long id = byteBuffer.getLong();
-      long creationTime = byteBuffer.getLong();
-      long lastAccessTime = byteBuffer.getLong();
-      long expireTime = byteBuffer.getLong();
-      long hits = byteBuffer.getLong();
-      OffHeapValueHolder<V> valueHolder = new OffHeapValueHolder<V>(id, serializer.read(byteBuffer), creationTime, expireTime, lastAccessTime, hits, writeContext);
-      return valueHolder;
-    } catch (ClassNotFoundException e) {
-      throw new SerializerException(e);
-    }
+    long id = byteBuffer.getLong();
+    long creationTime = byteBuffer.getLong();
+    long lastAccessTime = byteBuffer.getLong();
+    long expireTime = byteBuffer.getLong();
+    long hits = byteBuffer.getLong();
+    OffHeapValueHolder<V> valueHolder = new OffHeapValueHolder<V>(id, byteBuffer.slice(), serializer, creationTime, expireTime, lastAccessTime, hits, writeContext);
+    return valueHolder;
   }
 }

--- a/impl/src/main/java/org/ehcache/internal/store/tiering/CacheStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/tiering/CacheStore.java
@@ -449,11 +449,6 @@ public class CacheStore<K, V> implements Store<K, V> {
     }
 
     @Override
-    public void invalidate(K key, NullaryFunction<K> function) throws CacheAccessException {
-      function.apply();
-    }
-
-    @Override
     public void clear() throws CacheAccessException {
       // noop
     }

--- a/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
@@ -129,7 +129,7 @@ public class SerializerCountingTest {
     assertCounters(1, 0, 0, 1, 0, 0);
     printSerializationCounters("Put OffheapOnHeapCopy");
     cache.get(42L);
-    assertCounters(1, 1, 2, 1, 2, 0);
+    assertCounters(1, 1, 2, 0, 2, 0);
     printSerializationCounters("Get OffheapOnHeapCopy fault");
     cache.get(42L);
     assertCounters(0, 0, 0, 0, 2, 0);
@@ -151,13 +151,17 @@ public class SerializerCountingTest {
 
 
     cache.put(42L, "TheAnswer");
+    assertCounters(2, 1, 0, 1, 0, 0);
     printSerializationCounters("Put DiskOffHeapOnHeapCopy");
     cache.get(42L);
+    assertCounters(1, 1, 2, 0, 2, 0);
     printSerializationCounters("Get DiskOffHeapOnHeapCopy fault");
     cache.get(42L);
+    assertCounters(0, 0, 0, 0, 2, 0);
     printSerializationCounters("Get DiskOffHeapOnHeapCopy faulted");
 
     cache.put(42L, "Wrong ...");
+    assertCounters(2, 1, 3, 1, 1, 0);
     printSerializationCounters("Put DiskOffHeapOnHeapCopy (update faulted)");
   }
 

--- a/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
@@ -20,6 +20,7 @@ import org.ehcache.Cache;
 import org.ehcache.CacheManager;
 import org.ehcache.config.copy.CopierConfiguration;
 import org.ehcache.config.copy.DefaultCopierConfiguration;
+import org.ehcache.config.persistence.CacheManagerPersistenceConfiguration;
 import org.ehcache.config.serializer.DefaultSerializationProviderConfiguration;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
@@ -27,9 +28,12 @@ import org.ehcache.exceptions.SerializerException;
 import org.ehcache.internal.copy.SerializingCopier;
 import org.ehcache.internal.serialization.JavaSerializer;
 import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.service.FileBasedPersistenceContext;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -48,13 +52,18 @@ import static org.junit.Assert.assertThat;
  */
 public class SerializerCountingTest {
 
-  private static final boolean PRINT_STACK_TRACES = false;
+  private static final boolean PRINT_STACK_TRACES = true;
 
   private CacheManager cacheManager;
 
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
   @Before
   public void setUp() {
-    cacheManager = newCacheManagerBuilder().using(new DefaultSerializationProviderConfiguration().addSerializerFor(Serializable.class, (Class) CountingSerializer.class))
+    cacheManager = newCacheManagerBuilder()
+        .using(new DefaultSerializationProviderConfiguration().addSerializerFor(Serializable.class, (Class) CountingSerializer.class))
+        .with(new CacheManagerPersistenceConfiguration(folder.getRoot()))
         .build(true);
   }
 
@@ -66,7 +75,7 @@ public class SerializerCountingTest {
   }
 
   @Test
-  public void testSerializerOnHeapPutGet() {
+  public void testOnHeapPutGet() {
 
     Cache<Long, String> cache = cacheManager.createCache("onHeap", newCacheConfigurationBuilder()
                 .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
@@ -86,7 +95,7 @@ public class SerializerCountingTest {
   }
 
   @Test
-  public void testSerializerOffHeapPutGet() {
+  public void testOffHeapPutGet() {
     Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
             .buildConfig(Long.class, String.class)
@@ -103,12 +112,12 @@ public class SerializerCountingTest {
     printSerializationCounters("Get Offheap faulted");
 
     cache.put(42L, "Wrong ...");
-    assertCounters(1, 0, 3, 1, 2, 0);
+    assertCounters(1, 0, 3, 1, 1, 0);
     printSerializationCounters("Put OffHeap (update faulted)");
   }
 
   @Test
-  public void testSerializerOffHeapOnHeapCopyPutGet() {
+  public void testOffHeapOnHeapCopyPutGet() {
     Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
             .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
@@ -118,17 +127,38 @@ public class SerializerCountingTest {
 
     cache.put(42L, "TheAnswer");
     assertCounters(1, 0, 0, 1, 0, 0);
-    printSerializationCounters("Put Offheap");
+    printSerializationCounters("Put OffheapOnHeapCopy");
     cache.get(42L);
     assertCounters(1, 1, 2, 1, 2, 0);
-    printSerializationCounters("Get Offheap fault");
+    printSerializationCounters("Get OffheapOnHeapCopy fault");
     cache.get(42L);
     assertCounters(0, 0, 0, 0, 2, 0);
-    printSerializationCounters("Get Offheap faulted");
+    printSerializationCounters("Get OffheapOnHeapCopy faulted");
 
     cache.put(42L, "Wrong ...");
-    assertCounters(1, 0, 3, 1, 2, 0);
-    printSerializationCounters("Put OffHeap (update faulted)");
+    assertCounters(1, 0, 3, 1, 1, 0);
+    printSerializationCounters("Put OffheapOnHeapCopy (update faulted)");
+  }
+
+  @Test
+  public void testDiskOffHeapOnHeapCopyPutGet() {
+    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
+            .withResourcePools(newResourcePoolsBuilder().heap(2, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB).disk(100, MemoryUnit.MB))
+            .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
+            .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.VALUE))
+            .buildConfig(Long.class, String.class)
+    );
+
+
+    cache.put(42L, "TheAnswer");
+    printSerializationCounters("Put DiskOffHeapOnHeapCopy");
+    cache.get(42L);
+    printSerializationCounters("Get DiskOffHeapOnHeapCopy fault");
+    cache.get(42L);
+    printSerializationCounters("Get DiskOffHeapOnHeapCopy faulted");
+
+    cache.put(42L, "Wrong ...");
+    printSerializationCounters("Put DiskOffHeapOnHeapCopy (update faulted)");
   }
 
   private void printSerializationCounters(String operation) {
@@ -164,6 +194,10 @@ public class SerializerCountingTest {
     private final JavaSerializer<T> serializer;
 
     public CountingSerializer(ClassLoader classLoader) {
+      serializer = new JavaSerializer<T>(classLoader);
+    }
+
+    public CountingSerializer(ClassLoader classLoader, FileBasedPersistenceContext persistenceContext) {
       serializer = new JavaSerializer<T>(classLoader);
     }
 

--- a/impl/src/test/java/org/ehcache/internal/store/offheap/OffHeapValueHolderPortabilityTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/offheap/OffHeapValueHolderPortabilityTest.java
@@ -48,7 +48,7 @@ public class OffHeapValueHolderPortabilityTest {
     valueHolderPortability = new OffHeapValueHolderPortability<String>(provider
         .createValueSerializer(String.class, getClass().getClassLoader()));
 
-    originalValue = new OffHeapValueHolder<String>(-1, "aValue", 1L, 2L, 3L, 0, null);
+    originalValue = new OffHeapValueHolder<String>(-1, "aValue", 1L, 2L, 3L, 0);
 
   }
 

--- a/impl/src/test/java/org/ehcache/internal/store/offheap/OffHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/offheap/OffHeapValueHolderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.internal.store.offheap;
+
+import org.ehcache.internal.serialization.JavaSerializer;
+import org.junit.Test;
+import org.terracotta.offheapstore.storage.portability.WriteContext;
+
+import java.nio.ByteBuffer;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+/**
+ * OffHeapValueHolderTest
+ */
+public class OffHeapValueHolderTest {
+
+  @Test
+  public void testDelayedDeserialization() {
+    JavaSerializer<String> serializer = new JavaSerializer<String>(getClass().getClassLoader());
+    String testValue = "Let's get binary!";
+    ByteBuffer serialized = serializer.serialize(testValue);
+    OffHeapValueHolder<String> valueHolder = new OffHeapValueHolder<String>(1L, serialized, serializer, 10L, 20L, 15L, 3, mock(WriteContext.class));
+
+    valueHolder.prepareForDelayedDeserialization();
+    serialized.clear();
+    assertThat(valueHolder.value(), is(testValue));
+  }
+
+  @Test
+  public void testCanAccessBinaryValue() throws ClassNotFoundException {
+    JavaSerializer<String> serializer = new JavaSerializer<String>(getClass().getClassLoader());
+    String testValue = "Let's get binary!";
+    ByteBuffer serialized = serializer.serialize(testValue);
+    OffHeapValueHolder<String> valueHolder = new OffHeapValueHolder<String>(1L, serialized, serializer, 10L, 20L, 15L, 3, mock(WriteContext.class));
+
+    valueHolder.prepareForDelayedDeserialization();
+
+    ByteBuffer binaryValue = valueHolder.getBinaryValue();
+    assertThat(serializer.read(binaryValue), is(testValue));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testPreventAccessToBinaryValueInValueMode() {
+    new OffHeapValueHolder<String>(-1L, "aValue", 10L, 20L).getBinaryValue();
+  }
+
+  @Test
+  public void testPreventAccessToBinaryValueIfNotPrepared() {
+    JavaSerializer<String> serializer = new JavaSerializer<String>(getClass().getClassLoader());
+    String testValue = "Let's get binary!";
+    ByteBuffer serialized = serializer.serialize(testValue);
+    OffHeapValueHolder<String> valueHolder = new OffHeapValueHolder<String>(1L, serialized, serializer, 10L, 20L, 15L, 3, mock(WriteContext.class));
+
+    try {
+      valueHolder.getBinaryValue();
+      fail("IllegalStateException expected");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString("has not been prepared"));
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testPreventPreparationForDelayedSerializationInValueMode() {
+    new OffHeapValueHolder<String>(-1L, "aValue", 10L, 20L).prepareForDelayedDeserialization();
+  }
+
+  @Test
+  public void testCannotBePreparedForDelayedIfAlreadyDeserialized() {
+    JavaSerializer<String> serializer = new JavaSerializer<String>(getClass().getClassLoader());
+    String testValue = "Let's get binary!";
+    ByteBuffer serialized = serializer.serialize(testValue);
+    OffHeapValueHolder<String> valueHolder = new OffHeapValueHolder<String>(1L, serialized, serializer, 10L, 20L, 15L, 3, mock(WriteContext.class));
+
+    valueHolder.value();
+
+    try {
+      valueHolder.prepareForDelayedDeserialization();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString("VALUE"));
+    }
+  }
+
+}


### PR DESCRIPTION
This PR pushes further the reduction of serialization / deserialisation required between tiers.

It reaches that goal by doing the following:
* Improve invalidation in the `CompoundCacheStore` by introducing a `HigherCachingTier` interface and a specific method for cross tiers invalidation.
* Makes `OffHeapValueHolder` have different modes - `BINARY`, `VALUE` and `BOTH` - that are used depending on context inside `AbstractOffHeapStore`, it also extends a new interface `BinaryValueHolder`
* Improves faulting on-heap when the faulted `ValueHolder` implements `BinaryValueHolder`

The second change is what enables the third one and probably others. However, I am looking for opinions on whether the changes done inside `AbstractOffHeapStore` and `OffHeapValueHolder` to reach this are considered worth it.

This PR can be merged but does not close #369.