### PR TITLE
Issue #369 Improve CompoundCachingTier.invalidate(K key)

### DIFF
--- a/core/src/main/java/org/ehcache/spi/cache/tiering/CachingTier.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/CachingTier.java
@@ -48,14 +48,6 @@ public interface CachingTier<K, V> extends ConfigurationChangeSupport {
   void invalidate(K key) throws CacheAccessException;
 
   /**
-   * Remove a mapping, then call a function under the same lock scope irrespectively of a mapping being there or not.
-   * @param key the key.
-   * @param function the function to call.
-   * @throws CacheAccessException
-   */
-  void invalidate(K key, NullaryFunction<K> function) throws CacheAccessException;
-
-  /**
    * Empty out the caching store.
    * @throws CacheAccessException
    */

--- a/core/src/main/java/org/ehcache/spi/cache/tiering/HigherCachingTier.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/HigherCachingTier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.cache.tiering;
+
+import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.function.Function;
+import org.ehcache.spi.cache.Store;
+
+/**
+ * HigherCachingTier
+ */
+public interface HigherCachingTier<K, V> extends CachingTier<K, V> {
+
+  /**
+   * Removes a mapping without firing an invalidation event, then calls the function under the same lock scope
+   * passing in the mapping or null if none was present.
+   *
+   * @param key the key.
+   * @param function the function to call.
+   * @throws CacheAccessException
+   */
+  void silentInvalidate(K key, Function<Store.ValueHolder<V>, Void> function) throws CacheAccessException;
+
+}

--- a/core/src/main/java/org/ehcache/spi/cache/tiering/HigherCachingTier.java
+++ b/core/src/main/java/org/ehcache/spi/cache/tiering/HigherCachingTier.java
@@ -19,6 +19,8 @@ package org.ehcache.spi.cache.tiering;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
 
 /**
  * HigherCachingTier
@@ -34,5 +36,13 @@ public interface HigherCachingTier<K, V> extends CachingTier<K, V> {
    * @throws CacheAccessException
    */
   void silentInvalidate(K key, Function<Store.ValueHolder<V>, Void> function) throws CacheAccessException;
+
+  interface Provider extends Service {
+    <K, V> HigherCachingTier<K, V> createHigherCachingTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs);
+
+    void releaseHigherCachingTier(HigherCachingTier<?, ?> resource);
+
+    void initHigherCachingTier(HigherCachingTier<?, ?> resource);
+  }
 
 }

--- a/impl/src/main/java/org/ehcache/internal/store/tiering/CacheStore.java
+++ b/impl/src/main/java/org/ehcache/internal/store/tiering/CacheStore.java
@@ -449,11 +449,6 @@ public class CacheStore<K, V> implements Store<K, V> {
     }
 
     @Override
-    public void invalidate(K key, NullaryFunction<K> function) throws CacheAccessException {
-      function.apply();
-    }
-
-    @Override
     public void clear() throws CacheAccessException {
       // noop
     }

--- a/impl/src/main/java/org/ehcache/internal/store/tiering/CompoundCachingTier.java
+++ b/impl/src/main/java/org/ehcache/internal/store/tiering/CompoundCachingTier.java
@@ -166,7 +166,7 @@ public class CompoundCachingTier<K, V> implements CachingTier<K, V> {
   @SupplementaryService
   public static class Provider implements CachingTier.Provider {
     private volatile ServiceProvider serviceProvider;
-    private final ConcurrentMap<CachingTier<?, ?>, Map.Entry<CachingTier.Provider, LowerCachingTier.Provider>> providersMap = new ConcurrentWeakIdentityHashMap<CachingTier<?, ?>, Map.Entry<CachingTier.Provider, LowerCachingTier.Provider>>();
+    private final ConcurrentMap<CachingTier<?, ?>, Map.Entry<HigherCachingTier.Provider, LowerCachingTier.Provider>> providersMap = new ConcurrentWeakIdentityHashMap<CachingTier<?, ?>, Map.Entry<HigherCachingTier.Provider, LowerCachingTier.Provider>>();
 
     @Override
     public <K, V> CachingTier<K, V> createCachingTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
@@ -179,14 +179,14 @@ public class CompoundCachingTier<K, V> implements CachingTier<K, V> {
         throw new IllegalArgumentException("Compound caching tier cannot be configured without explicit config");
       }
 
-      CachingTier.Provider higherProvider = serviceProvider.getService(compoundCachingTierServiceConfiguration.higherProvider());
-      HigherCachingTier<K, V> higherCachingTier = (HigherCachingTier<K, V>) higherProvider.createCachingTier(storeConfig, serviceConfigs);
+      HigherCachingTier.Provider higherProvider = serviceProvider.getService(compoundCachingTierServiceConfiguration.higherProvider());
+      HigherCachingTier<K, V> higherCachingTier = higherProvider.createHigherCachingTier(storeConfig, serviceConfigs);
 
       LowerCachingTier.Provider lowerProvider = serviceProvider.getService(compoundCachingTierServiceConfiguration.lowerProvider());
       LowerCachingTier<K, V> lowerCachingTier = lowerProvider.createCachingTier(storeConfig, serviceConfigs);
 
       CompoundCachingTier<K, V> compoundCachingTier = new CompoundCachingTier<K, V>(higherCachingTier, lowerCachingTier);
-      providersMap.put(compoundCachingTier, new AbstractMap.SimpleEntry<CachingTier.Provider, LowerCachingTier.Provider>(higherProvider, lowerProvider));
+      providersMap.put(compoundCachingTier, new AbstractMap.SimpleEntry<HigherCachingTier.Provider, LowerCachingTier.Provider>(higherProvider, lowerProvider));
       return compoundCachingTier;
     }
 
@@ -196,9 +196,9 @@ public class CompoundCachingTier<K, V> implements CachingTier<K, V> {
         throw new IllegalArgumentException("Given caching tier is not managed by this provider : " + resource);
       }
       CompoundCachingTier compoundCachingTier = (CompoundCachingTier) resource;
-      Map.Entry<CachingTier.Provider, LowerCachingTier.Provider> entry = providersMap.get(resource);
+      Map.Entry<HigherCachingTier.Provider, LowerCachingTier.Provider> entry = providersMap.get(resource);
 
-      entry.getKey().releaseCachingTier(compoundCachingTier.higher);
+      entry.getKey().releaseHigherCachingTier(compoundCachingTier.higher);
       entry.getValue().releaseCachingTier(compoundCachingTier.lower);
     }
 
@@ -208,10 +208,10 @@ public class CompoundCachingTier<K, V> implements CachingTier<K, V> {
         throw new IllegalArgumentException("Given caching tier is not managed by this provider : " + resource);
       }
       CompoundCachingTier compoundCachingTier = (CompoundCachingTier) resource;
-      Map.Entry<CachingTier.Provider, LowerCachingTier.Provider> entry = providersMap.get(resource);
+      Map.Entry<HigherCachingTier.Provider, LowerCachingTier.Provider> entry = providersMap.get(resource);
 
       entry.getValue().initCachingTier(compoundCachingTier.lower);
-      entry.getKey().initCachingTier(compoundCachingTier.higher);
+      entry.getKey().initHigherCachingTier(compoundCachingTier.higher);
     }
 
     @Override

--- a/impl/src/main/java/org/ehcache/internal/store/tiering/CompoundCachingTierServiceConfiguration.java
+++ b/impl/src/main/java/org/ehcache/internal/store/tiering/CompoundCachingTierServiceConfiguration.java
@@ -16,6 +16,7 @@
 package org.ehcache.internal.store.tiering;
 
 import org.ehcache.spi.cache.tiering.CachingTier;
+import org.ehcache.spi.cache.tiering.HigherCachingTier;
 import org.ehcache.spi.cache.tiering.LowerCachingTier;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -24,14 +25,14 @@ import org.ehcache.spi.service.ServiceConfiguration;
  */
 public class CompoundCachingTierServiceConfiguration implements ServiceConfiguration<CompoundCachingTier.Provider> {
 
-  private Class<? extends CachingTier.Provider> higherProvider;
+  private Class<? extends HigherCachingTier.Provider> higherProvider;
   private Class<? extends LowerCachingTier.Provider> lowerProvider;
 
-  public Class<? extends CachingTier.Provider> higherProvider() {
+  public Class<? extends HigherCachingTier.Provider> higherProvider() {
     return higherProvider;
   }
 
-  public CompoundCachingTierServiceConfiguration higherProvider(Class<? extends CachingTier.Provider> higherProvider) {
+  public CompoundCachingTierServiceConfiguration higherProvider(Class<? extends HigherCachingTier.Provider> higherProvider) {
     this.higherProvider = higherProvider;
     return this;
   }

--- a/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
@@ -20,6 +20,7 @@ import org.ehcache.Cache;
 import org.ehcache.CacheManager;
 import org.ehcache.config.copy.CopierConfiguration;
 import org.ehcache.config.copy.DefaultCopierConfiguration;
+import org.ehcache.config.persistence.CacheManagerPersistenceConfiguration;
 import org.ehcache.config.serializer.DefaultSerializationProviderConfiguration;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
@@ -27,9 +28,12 @@ import org.ehcache.exceptions.SerializerException;
 import org.ehcache.internal.copy.SerializingCopier;
 import org.ehcache.internal.serialization.JavaSerializer;
 import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.service.FileBasedPersistenceContext;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -52,9 +56,14 @@ public class SerializerCountingTest {
 
   private CacheManager cacheManager;
 
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
   @Before
   public void setUp() {
-    cacheManager = newCacheManagerBuilder().using(new DefaultSerializationProviderConfiguration().addSerializerFor(Serializable.class, (Class) CountingSerializer.class))
+    cacheManager = newCacheManagerBuilder()
+        .using(new DefaultSerializationProviderConfiguration().addSerializerFor(Serializable.class, (Class) CountingSerializer.class))
+        .with(new CacheManagerPersistenceConfiguration(folder.getRoot()))
         .build(true);
   }
 
@@ -66,7 +75,7 @@ public class SerializerCountingTest {
   }
 
   @Test
-  public void testSerializerOnHeapPutGet() {
+  public void testOnHeapPutGet() {
 
     Cache<Long, String> cache = cacheManager.createCache("onHeap", newCacheConfigurationBuilder()
                 .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
@@ -86,7 +95,7 @@ public class SerializerCountingTest {
   }
 
   @Test
-  public void testSerializerOffHeapPutGet() {
+  public void testOffHeapPutGet() {
     Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
             .buildConfig(Long.class, String.class)
@@ -108,7 +117,7 @@ public class SerializerCountingTest {
   }
 
   @Test
-  public void testSerializerOffHeapOnHeapCopyPutGet() {
+  public void testOffHeapOnHeapCopyPutGet() {
     Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
             .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
@@ -118,17 +127,42 @@ public class SerializerCountingTest {
 
     cache.put(42L, "TheAnswer");
     assertCounters(1, 0, 0, 1, 0, 0);
-    printSerializationCounters("Put Offheap");
+    printSerializationCounters("Put OffheapOnHeapCopy");
     cache.get(42L);
     assertCounters(1, 1, 2, 1, 2, 0);
-    printSerializationCounters("Get Offheap fault");
+    printSerializationCounters("Get OffheapOnHeapCopy fault");
     cache.get(42L);
     assertCounters(0, 0, 0, 0, 2, 0);
-    printSerializationCounters("Get Offheap faulted");
+    printSerializationCounters("Get OffheapOnHeapCopy faulted");
 
     cache.put(42L, "Wrong ...");
     assertCounters(1, 0, 3, 1, 2, 0);
-    printSerializationCounters("Put OffHeap (update faulted)");
+    printSerializationCounters("Put OffheapOnHeapCopy (update faulted)");
+  }
+
+  @Test
+  public void testDiskOffHeapOnHeapCopyPutGet() {
+    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
+            .withResourcePools(newResourcePoolsBuilder().heap(2, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB).disk(100, MemoryUnit.MB))
+            .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
+            .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.VALUE))
+            .buildConfig(Long.class, String.class)
+    );
+
+
+    cache.put(42L, "TheAnswer");
+    assertCounters(2, 1, 0, 1, 0, 0);
+    printSerializationCounters("Put DiskOffHeapOnHeapCopy");
+    cache.get(42L);
+    assertCounters(1, 1, 2, 1, 2, 0);
+    printSerializationCounters("Get DiskOffHeapOnHeapCopy fault");
+    cache.get(42L);
+    assertCounters(0, 0, 0, 0, 2, 0);
+    printSerializationCounters("Get DiskOffHeapOnHeapCopy faulted");
+
+    cache.put(42L, "Wrong ...");
+    assertCounters(2, 1, 3, 1, 2, 0);
+    printSerializationCounters("Put DiskOffHeapOnHeapCopy (update faulted)");
   }
 
   private void printSerializationCounters(String operation) {
@@ -164,6 +198,10 @@ public class SerializerCountingTest {
     private final JavaSerializer<T> serializer;
 
     public CountingSerializer(ClassLoader classLoader) {
+      serializer = new JavaSerializer<T>(classLoader);
+    }
+
+    public CountingSerializer(ClassLoader classLoader, FileBasedPersistenceContext persistenceContext) {
       serializer = new JavaSerializer<T>(classLoader);
     }
 

--- a/impl/src/test/java/org/ehcache/internal/store/tiering/CompoundCachingTierTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/tiering/CompoundCachingTierTest.java
@@ -375,7 +375,7 @@ public class CompoundCachingTierTest {
     }
   }
 
-  static class FakeProvider implements CachingTier.Provider {
+  static class FakeProvider implements HigherCachingTier.Provider {
 
     @Override
     public void start(ServiceProvider serviceProvider) {
@@ -386,17 +386,17 @@ public class CompoundCachingTierTest {
     }
 
     @Override
-    public <K, V> CachingTier<K, V> createCachingTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
+    public <K, V> HigherCachingTier<K, V> createHigherCachingTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       assertThat(serviceConfigs.length, is(2));
       return mock(HigherCachingTier.class);
     }
 
     @Override
-    public void releaseCachingTier(CachingTier<?, ?> resource) {
+    public void releaseHigherCachingTier(HigherCachingTier<?, ?> resource) {
     }
 
     @Override
-    public void initCachingTier(CachingTier<?, ?> resource) {
+    public void initHigherCachingTier(HigherCachingTier<?, ?> resource) {
     }
   }
 


### PR DESCRIPTION
* Skip pushing down to lower tier and flush to authority directly instead
* Rename and move invalidate variant taking a function to HigherCachingTier