### PR TITLE
Issue #611 Fix JSR-107 + template + default copiers

### DIFF
--- a/107/src/test/java/com/pany/domain/Client.java
+++ b/107/src/test/java/com/pany/domain/Client.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pany.domain;
+
+/**
+ * Client
+ */
+public class Client {
+
+  private final String name;
+  private final long creditLine;
+
+  public Client(String name, long creditLine) {
+    this.name = name;
+    this.creditLine = creditLine;
+  }
+
+  public Client(Client toCopy) {
+    this.name = toCopy.getName();
+    this.creditLine = toCopy.getCreditLine();
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public long getCreditLine() {
+    return creditLine;
+  }
+}

--- a/107/src/test/java/com/pany/ehcache/ClientCopier.java
+++ b/107/src/test/java/com/pany/ehcache/ClientCopier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pany.ehcache;
+
+import org.ehcache.internal.copy.ReadWriteCopier;
+
+import com.pany.domain.Client;
+
+/**
+ * ClientCopier
+ */
+public class ClientCopier extends ReadWriteCopier<Client> {
+  @Override
+  public Client copy(Client obj) {
+    return new Client(obj);
+  }
+}

--- a/107/src/test/java/org/ehcache/jsr107/Eh107XmlIntegrationTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/Eh107XmlIntegrationTest.java
@@ -19,6 +19,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.pany.domain.Client;
 import com.pany.domain.Customer;
 import com.pany.domain.Product;
 import com.pany.ehcache.Test107CacheEntryListener;
@@ -56,7 +57,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 
@@ -201,6 +201,21 @@ public class Eh107XmlIntegrationTest {
     Customer customer = new Customer(1L);
     customerCache.put(1L, customer);
     assertThat(customerCache.get(1L).getId(), equalTo(customer.getId()));
+  }
+
+  @Test
+  public void testCopierAtServiceLevel() throws Exception {
+    CacheManager cacheManager = cachingProvider.getCacheManager(
+        getClass().getResource("/ehcache-107-default-copiers.xml").toURI(),
+        getClass().getClassLoader());
+
+    MutableConfiguration<Long, Client> config = new MutableConfiguration<Long, Client>();
+    config.setTypes(Long.class, Client.class);
+    Cache<Long, Client> bar = cacheManager.createCache("bar", config);
+    Client client = new Client("tc", 1000000L);
+    long key = 42L;
+    bar.put(key, client);
+    assertThat(bar.get(key), not(sameInstance(client)));
   }
 
   static class DumbCacheLoader implements CacheLoader<Long, Product> {

--- a/107/src/test/resources/ehcache-107-default-copiers.xml
+++ b/107/src/test/resources/ehcache-107-default-copiers.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ehcache:config
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns:ehcache='http://www.ehcache.org/v3'
+    xmlns:jsr107='http://www.ehcache.org/v3/jsr107'>
+
+  <ehcache:service>
+      <jsr107:defaults>
+        <jsr107:cache name="bar" template="bartemplate"/>
+      </jsr107:defaults>
+    </ehcache:service>
+
+  <ehcache:service>
+    <ehcache:default-copiers>
+      <ehcache:copier type="com.pany.domain.Client">com.pany.ehcache.ClientCopier</ehcache:copier>
+    </ehcache:default-copiers>
+  </ehcache:service>
+
+  <ehcache:cache-template name="bartemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>com.pany.domain.Client</ehcache:value-type>
+    <ehcache:heap size="10"/>
+  </ehcache:cache-template>
+
+</ehcache:config>


### PR DESCRIPTION
The ConfigurationMerger was not taking into account the CacheManager
level settings, which can contain default copier configurations.