### PR TITLE
Issue 650

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
@@ -27,6 +27,7 @@ import org.terracotta.context.query.Matcher;
 import org.terracotta.context.query.Matchers;
 import org.terracotta.context.query.Query;
 import org.terracotta.management.stats.Sample;
+import org.terracotta.management.stats.Statistic;
 import org.terracotta.management.stats.sampled.SampledRatio;
 import org.terracotta.statistics.OperationStatistic;
 import org.terracotta.statistics.StatisticsManager;
@@ -142,24 +143,24 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
 
   @Override
   public float getAverageGetTime() {
-    Collection<SampledRatio> statistics = managementRegistry.collectStatistics(context, "StatisticsCapability", "AllCacheGetLatencyAverage");
-    return getMostRecentNotClearedValue(statistics);
+    Collection<Statistic<?>> statistics = managementRegistry.collectStatistics(context, "StatisticsCapability", "AllCacheGetLatencyAverage");
+    return getMostRecentNotClearedValue((SampledRatio) statistics.iterator().next());
   }
 
   @Override
   public float getAveragePutTime() {
-    Collection<SampledRatio> statistics = managementRegistry.collectStatistics(context, "StatisticsCapability", "AllCachePutLatencyAverage");
-    return getMostRecentNotClearedValue(statistics);
+    Collection<Statistic<?>> statistics = managementRegistry.collectStatistics(context, "StatisticsCapability", "AllCachePutLatencyAverage");
+    return getMostRecentNotClearedValue((SampledRatio) statistics.iterator().next());
   }
 
   @Override
   public float getAverageRemoveTime() {
-    Collection<SampledRatio> statistics = managementRegistry.collectStatistics(context, "StatisticsCapability", "AllCacheRemoveLatencyAverage");
-    return getMostRecentNotClearedValue(statistics);
+    Collection<Statistic<?>> statistics = managementRegistry.collectStatistics(context, "StatisticsCapability", "AllCacheRemoveLatencyAverage");
+    return getMostRecentNotClearedValue((SampledRatio) statistics.iterator().next());
   }
 
-  private float getMostRecentNotClearedValue(Collection<SampledRatio> statistics) {
-    List<Sample<Double>> samples = statistics.iterator().next().getValue();
+  private float getMostRecentNotClearedValue(SampledRatio ratio) {
+    List<Sample<Double>> samples = ratio.getValue();
     for (int i=samples.size() - 1 ; i>=0 ; i--) {
       Sample<Double> doubleSample = samples.get(i);
       if (doubleSample.getTimestamp() >= compensatingCounters.timestamp) {

--- a/management/src/main/java/org/ehcache/management/CallQuery.java
+++ b/management/src/main/java/org/ehcache/management/CallQuery.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface CallQuery extends Query<ContextualResult> {
+
+  String getMethodName();
+
+  String[] getParameterClassNames();
+
+  Object[] getParameters();
+
+  interface Builder extends QueryBuilder<Builder, CallQuery> {
+
+  }
+}

--- a/management/src/main/java/org/ehcache/management/CapabilityBasedQuery.java
+++ b/management/src/main/java/org/ehcache/management/CapabilityBasedQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import java.util.Collection;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface CapabilityBasedQuery {
+
+  /**
+   * Create a query builder to collect statistics
+   *
+   * @param statisticName The statistic name to collec
+   * @return a builder for the query
+   */
+  StatisticQuery.Builder queryStatistic(String statisticName);
+
+  /**
+   * Create a query builder to collect statistics
+   *
+   * @param statisticNames The statistic names to collect
+   * @return a builder for the query
+   */
+
+  StatisticQuery.Builder queryStatistics(String... statisticNames);
+
+  /**
+   * Create a query builder to collect statistics
+   *
+   * @param statisticNames The statistic names to collect
+   * @return a builder for the query
+   */
+
+  StatisticQuery.Builder queryStatistics(Collection<String> statisticNames);
+
+  /**
+   * Call an action of a managed object's capability.
+   *
+   * @param methodName the action's method name.
+   * @param argClassNames the action method's argument class names.
+   * @param args the action method's arguments.
+   * @return the action method's return value.
+   */
+  CallQuery.Builder call(String methodName, String[] argClassNames, Object[] args);
+
+  /**
+   * Call an action of a managed object's capability with no aguments
+   *
+   * @param methodName the action's method name.
+   * @return the action method's return value.
+   */
+  CallQuery.Builder call(String methodName);
+}

--- a/management/src/main/java/org/ehcache/management/CapabilityManagement.java
+++ b/management/src/main/java/org/ehcache/management/CapabilityManagement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import org.ehcache.management.providers.ManagementProvider;
+
+import java.util.Collection;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface CapabilityManagement {
+
+  /**
+   * Query based on a capability of this management registry, such as collecting statistics or calling some actions
+   *
+   * @param capabilityName The capability to work with
+   * @return An intermediary class enabling the access of methods based on a capability
+   */
+  CapabilityBasedQuery withCapability(String capabilityName);
+
+  /**
+   * List all management providers installed for a specific capability across all cache managers
+   *
+   * @param capabilityName The capability name
+   * @return The list of management providers installed
+   */
+  Collection<ManagementProvider<?>> getManagementProvidersByCapability(String capabilityName);
+
+}

--- a/management/src/main/java/org/ehcache/management/ContextualResult.java
+++ b/management/src/main/java/org/ehcache/management/ContextualResult.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * This class holds the results of the calls on each context.
+ * <p/>
+ * If a call was not possible to make on a context, because the context was not supported or the capability not found,
+ * then the method {@link #hasResult()} will return false.
+ * <p/>
+ * You an call {@link #getResult(Class)} only if there has been a result, event if it is null.
+ *
+ * @author Mathieu Carbou
+ */
+public final class ContextualResult {
+
+  private static final Object NO_RESULT = new Object();
+
+  private final Object result;
+  private final Map<String, String> context;
+
+  private ContextualResult(Map<String, String> context, Object result) {
+    this.result = result;
+    this.context = Collections.unmodifiableMap(context);
+  }
+
+  public boolean hasResult() {
+    return result != NO_RESULT;
+  }
+
+  public <T> T getResult(Class<T> type) throws NoSuchElementException {
+    if (!hasResult()) {
+      throw new NoSuchElementException();
+    }
+    return type.cast(result);
+  }
+
+  public Map<String, String> getContext() {
+    return context;
+  }
+
+  public static ContextualResult result(Map<String, String> context, Object result) {
+    return new ContextualResult(context, result);
+  }
+
+  public static ContextualResult noResult(Map<String, String> context) {
+    return new ContextualResult(context, NO_RESULT);
+  }
+
+}

--- a/management/src/main/java/org/ehcache/management/ContextualStatistics.java
+++ b/management/src/main/java/org/ehcache/management/ContextualStatistics.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import org.terracotta.management.stats.Statistic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class holds the {@link Statistic} list queried from a specific context
+ *
+ * @author Mathieu Carbou
+ */
+public final class ContextualStatistics implements Iterable<Statistic<?>> {
+
+  private final List<Statistic<?>> statistics;
+  private final Map<String, String> context;
+
+  public ContextualStatistics(Map<String, String> context, List<Statistic<?>> statistics) {
+    this.statistics = Collections.unmodifiableList(statistics);
+    this.context = Collections.unmodifiableMap(context);
+  }
+
+  @Override
+  public Iterator<Statistic<?>> iterator() {
+    return statistics.iterator();
+  }
+
+  public List<Statistic<?>> getStatistics() {
+    return statistics;
+  }
+
+  public <T extends Statistic<?>> T getStatistic(int index, Class<T> type) {
+    return type.cast(statistics.get(index));
+  }
+
+  public <T extends Statistic<?>> List<T> getStatistics(Class<T> type) {
+    List<T> filtered = new ArrayList<T>();
+    for (Statistic<?> statistic : statistics) {
+      if (type.isInstance(statistic)) {
+        filtered.add(type.cast(statistic));
+      }
+    }
+    return filtered;
+  }
+
+  public Map<String, String> getContext() {
+    return context;
+  }
+
+}

--- a/management/src/main/java/org/ehcache/management/ContextualStatistics.java
+++ b/management/src/main/java/org/ehcache/management/ContextualStatistics.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This class holds the {@link Statistic} list queried from a specific context
+ * This class holds the {@link Statistic} list quered from a specific context
  *
  * @author Mathieu Carbou
  */
@@ -48,7 +48,11 @@ public final class ContextualStatistics implements Iterable<Statistic<?>> {
   }
 
   public <T extends Statistic<?>> T getStatistic(int index, Class<T> type) {
-    return type.cast(statistics.get(index));
+    Statistic<?> stat = statistics.get(index);
+    if (!type.isInstance(stat)) {
+      throw new IllegalArgumentException("Expected type " + type.getName() + " but got " + stat.getClass().getName());
+    }
+    return type.cast(stat);
   }
 
   public <T extends Statistic<?>> List<T> getStatistics(Class<T> type) {

--- a/management/src/main/java/org/ehcache/management/ManagementRegistry.java
+++ b/management/src/main/java/org/ehcache/management/ManagementRegistry.java
@@ -92,7 +92,7 @@ public interface ManagementRegistry extends Service {
    * @param statisticNames the statistic names.
    * @return a collection of statistics.
    */
-  <T extends Statistic<?>> Collection<T> collectStatistics(Map<String, String> context, String capabilityName, String... statisticNames);
+  Collection<Statistic<?>> collectStatistics(Map<String, String> context, String capabilityName, String... statisticNames);
 
   /**
    * Collect statistics from a managed object's capability and several contexts at once.
@@ -102,7 +102,7 @@ public interface ManagementRegistry extends Service {
    * @param statisticNames the statistic names.
    * @return a list of collection of statistics, in the same order and index of the context list
    */
-  <T extends Statistic<?>> List<Collection<T>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames);
+  List<Collection<Statistic<?>>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames);
 
   /**
    * Call an action of a managed object's capability.
@@ -112,9 +112,8 @@ public interface ManagementRegistry extends Service {
    * @param methodName the action's method name.
    * @param argClassNames the action method's argument class names.
    * @param args the action method's arguments.
-   * @param <T> the returned type.
    * @return the action method's return value.
    */
-  <T> T callAction(Map<String, String> context, String capabilityName, String methodName, String[] argClassNames, Object[] args);
+  Object callAction(Map<String, String> context, String capabilityName, String methodName, String[] argClassNames, Object[] args);
 
 }

--- a/management/src/main/java/org/ehcache/management/ManagementRegistry.java
+++ b/management/src/main/java/org/ehcache/management/ManagementRegistry.java
@@ -19,22 +19,19 @@ import org.ehcache.management.providers.ManagementProvider;
 import org.ehcache.spi.service.Service;
 import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.context.ContextContainer;
-import org.terracotta.management.stats.Statistic;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Repository of objects exposing capabilities via the
  * management and monitoring facilities.
  * <p/>
- * A ManagementRegistry manages one and only one cache manager. 
+ * A ManagementRegistry manages one and only one cache manager.
  * If you need to manage or monitor several cache managers at a time, you can use the {@link SharedManagementService} and register it into several cache managers.
  *
  * @author Ludovic Orban
  */
-public interface ManagementRegistry extends Service {
+public interface ManagementRegistry extends CapabilityManagement, Service {
 
   /**
    * @return This registry configuration
@@ -83,37 +80,5 @@ public interface ManagementRegistry extends Service {
    * @return a this management registry context.
    */
   ContextContainer getContext();
-
-  /**
-   * Collect statistics from a managed object's capability.
-   *
-   * @param context the capability's context.
-   * @param capabilityName the capability name.
-   * @param statisticNames the statistic names.
-   * @return a collection of statistics.
-   */
-  Collection<Statistic<?>> collectStatistics(Map<String, String> context, String capabilityName, String... statisticNames);
-
-  /**
-   * Collect statistics from a managed object's capability and several contexts at once.
-   *
-   * @param contextList the capability's context list.
-   * @param capabilityName the capability name.
-   * @param statisticNames the statistic names.
-   * @return a list of collection of statistics, in the same order and index of the context list
-   */
-  List<Collection<Statistic<?>>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames);
-
-  /**
-   * Call an action of a managed object's capability.
-   *
-   * @param context the capability's context.
-   * @param capabilityName the capability name.
-   * @param methodName the action's method name.
-   * @param argClassNames the action method's argument class names.
-   * @param args the action method's arguments.
-   * @return the action method's return value.
-   */
-  Object callAction(Map<String, String> context, String capabilityName, String methodName, String[] argClassNames, Object[] args);
 
 }

--- a/management/src/main/java/org/ehcache/management/Query.java
+++ b/management/src/main/java/org/ehcache/management/Query.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface Query<T> {
+
+  /**
+   * @return The capability name used for this query
+   */
+  String getCapabilityName();
+
+  /**
+   * @return The list of context targetted by this query
+   */
+  List<Map<String, String>> getContexts();
+
+  /**
+   * @return The list of results of this query against all contexts, in the same order and same position of the {@link #getContexts()} list
+   */
+  List<T> execute();
+
+}

--- a/management/src/main/java/org/ehcache/management/QueryBuilder.java
+++ b/management/src/main/java/org/ehcache/management/QueryBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface QueryBuilder<B, T> {
+
+  /**
+   * Adds a context to run this query against
+   *
+   * @param context The management registry context
+   * @return this builder
+   */
+  B on(Map<String, String> context);
+
+  /**
+   * Adds some contexts to run this query against.
+   * The order is important and kept: if teh query is ran on several contexts, then the order of results will match the order of the contexts
+   *
+   * @param contexts The management registry contexts
+   * @return this builder
+   */
+  B on(List<Map<String, String>> contexts);
+
+  T build();
+
+}

--- a/management/src/main/java/org/ehcache/management/SharedManagementService.java
+++ b/management/src/main/java/org/ehcache/management/SharedManagementService.java
@@ -18,10 +18,8 @@ package org.ehcache.management;
 import org.ehcache.spi.service.Service;
 import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.context.ContextContainer;
-import org.terracotta.management.stats.Statistic;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,7 +29,7 @@ import java.util.Map;
  *
  * @author Mathieu Carbou
  */
-public interface SharedManagementService extends Service {
+public interface SharedManagementService extends CapabilityManagement, Service {
 
   /**
    * Get the management contexts required to make use of the
@@ -42,32 +40,10 @@ public interface SharedManagementService extends Service {
   Collection<ContextContainer> getContexts();
 
   /**
-   * Get the management capabilities of the registered objects across several cache managers.
+   * Get the management capabilities of all the registered objects across several cache managers.
    *
    * @return a map of capabilities, where the key is the alias of the cache manager
    */
   Map<String, Collection<Capability>> getCapabilities();
-
-  /**
-   * Collect statistics from a managed object's capability and several contexts at once.
-   *
-   * @param contextList    the capability's context list.
-   * @param capabilityName the capability name.
-   * @param statisticNames the statistic names.
-   * @return a list of collection of statistics, with the same order and indexes of the context list
-   */
-  List<Collection<Statistic<?>>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames);
-
-  /**
-   * Call an action on several managed object's capability, based on the contexts.
-   *
-   * @param contextList    a list of the capability's context.
-   * @param capabilityName the capability name.
-   * @param methodName     the action's method name.
-   * @param argClassNames  the action method's argument class names.
-   * @param args           the action method's arguments.
-   * @return the list of action method's return value for each context passed, in same order and with same indexes.
-   */
-  List<Object> callAction(List<Map<String, String>> contextList, String capabilityName, String methodName, String[] argClassNames, Object[] args);
 
 }

--- a/management/src/main/java/org/ehcache/management/SharedManagementService.java
+++ b/management/src/main/java/org/ehcache/management/SharedManagementService.java
@@ -56,7 +56,7 @@ public interface SharedManagementService extends Service {
    * @param statisticNames the statistic names.
    * @return a list of collection of statistics, with the same order and indexes of the context list
    */
-  <T extends Statistic<?>> List<Collection<T>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames);
+  List<Collection<Statistic<?>>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames);
 
   /**
    * Call an action on several managed object's capability, based on the contexts.
@@ -66,9 +66,8 @@ public interface SharedManagementService extends Service {
    * @param methodName     the action's method name.
    * @param argClassNames  the action method's argument class names.
    * @param args           the action method's arguments.
-   * @param <T>            the returned type.
    * @return the list of action method's return value for each context passed, in same order and with same indexes.
    */
-  <T> List<T> callAction(List<Map<String, String>> contextList, String capabilityName, String methodName, String[] argClassNames, Object[] args);
+  List<Object> callAction(List<Map<String, String>> contextList, String capabilityName, String methodName, String[] argClassNames, Object[] args);
 
 }

--- a/management/src/main/java/org/ehcache/management/StatisticQuery.java
+++ b/management/src/main/java/org/ehcache/management/StatisticQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management;
+
+import java.util.Collection;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface StatisticQuery extends Query<ContextualStatistics> {
+
+  /**
+   * @return The list of statistic queried
+   */
+  Collection<String> getStatisticNames();
+
+  /**
+   * The query will only collect statistics computed since this time.
+   * This allows for example to filter out the list of returned values within some {@link org.terracotta.statistics.Statistic}
+   * such as {@link org.terracotta.management.stats.sampled.SampledRate}
+   *
+   * @return A unix timestamp
+   */
+  long getSince();
+
+  interface Builder extends QueryBuilder<Builder, StatisticQuery> {
+
+    /**
+     * The query will only collect statistics computed since this time.
+     * This allows for example to filter out the list of returned values within some {@link org.terracotta.statistics.Statistic}
+     * such as {@link org.terracotta.management.stats.sampled.SampledRate}
+     *
+     * @param unixTimestampMs The unix timestamp
+     * @return this builder
+     */
+    Builder since(long unixTimestampMs);
+
+  }
+
+}

--- a/management/src/main/java/org/ehcache/management/providers/CacheBindingManagementProviderSkeleton.java
+++ b/management/src/main/java/org/ehcache/management/providers/CacheBindingManagementProviderSkeleton.java
@@ -18,7 +18,6 @@ package org.ehcache.management.providers;
 import org.ehcache.internal.concurrent.ConcurrentHashMap;
 import org.ehcache.management.annotations.Named;
 import org.ehcache.management.registry.CacheBinding;
-import org.ehcache.util.ConcurrentWeakIdentityHashMap;
 import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.capabilities.context.CapabilityContext;
 import org.terracotta.management.capabilities.descriptors.Descriptor;
@@ -108,7 +107,7 @@ public abstract class CacheBindingManagementProviderSkeleton<V> implements Manag
   }
 
   @Override
-  public <T extends Statistic<?>> Collection<T> collectStatistics(Map<String, String> context, String[] statisticNames) {
+  public Collection<Statistic<?>> collectStatistics(Map<String, String> context, String[] statisticNames) {
     throw new UnsupportedOperationException("Not a statistics provider : " + getCapabilityName());
   }
 

--- a/management/src/main/java/org/ehcache/management/providers/CacheBindingManagementProviderSkeleton.java
+++ b/management/src/main/java/org/ehcache/management/providers/CacheBindingManagementProviderSkeleton.java
@@ -25,6 +25,7 @@ import org.terracotta.management.stats.Statistic;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
@@ -107,7 +108,7 @@ public abstract class CacheBindingManagementProviderSkeleton<V> implements Manag
   }
 
   @Override
-  public Collection<Statistic<?>> collectStatistics(Map<String, String> context, String[] statisticNames) {
+  public List<Statistic<?>> collectStatistics(Map<String, String> context, Collection<String> statisticNames, long since) {
     throw new UnsupportedOperationException("Not a statistics provider : " + getCapabilityName());
   }
 
@@ -126,11 +127,6 @@ public abstract class CacheBindingManagementProviderSkeleton<V> implements Manag
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append("{");
-    sb.append("cacheManagerAlias='").append(cacheManagerAlias).append('\'');
-    sb.append(", name='").append(name).append('\'');
-    sb.append(", managedObjects=").append(managedObjects.keySet());
-    sb.append('}');
-    return sb.toString();
+    return "{" + "cacheManagerAlias='" + cacheManagerAlias + '\'' + ", name='" + name + '\'' + ", managedObjects=" + managedObjects.keySet() + '}';
   }
 }

--- a/management/src/main/java/org/ehcache/management/providers/ManagementProvider.java
+++ b/management/src/main/java/org/ehcache/management/providers/ManagementProvider.java
@@ -22,7 +22,6 @@ import org.terracotta.management.stats.Statistic;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Interface to a provider of management capabilities for certain object class.
@@ -83,7 +82,7 @@ public interface ManagementProvider<T> {
    * @param statisticNames the statistic names to collect.
    * @return the statistic values.
    */
-  <T extends Statistic<?>> Collection<T> collectStatistics(Map<String, String> context, String... statisticNames);
+  Collection<Statistic<?>> collectStatistics(Map<String, String> context, String... statisticNames);
 
   /**
    * Call an action, if the provider supports this.

--- a/management/src/main/java/org/ehcache/management/providers/ManagementProvider.java
+++ b/management/src/main/java/org/ehcache/management/providers/ManagementProvider.java
@@ -21,6 +21,7 @@ import org.terracotta.management.capabilities.descriptors.Descriptor;
 import org.terracotta.management.stats.Statistic;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -80,9 +81,10 @@ public interface ManagementProvider<T> {
    *
    * @param context the context.
    * @param statisticNames the statistic names to collect.
+   * @param since The unix time in ms from where to return the statistics for statistics based on samples.
    * @return the statistic values.
    */
-  Collection<Statistic<?>> collectStatistics(Map<String, String> context, String... statisticNames);
+  List<Statistic<?>> collectStatistics(Map<String, String> context, Collection<String> statisticNames, long since);
 
   /**
    * Call an action, if the provider supports this.

--- a/management/src/main/java/org/ehcache/management/providers/actions/EhcacheActionWrapper.java
+++ b/management/src/main/java/org/ehcache/management/providers/actions/EhcacheActionWrapper.java
@@ -16,7 +16,6 @@
 package org.ehcache.management.providers.actions;
 
 import org.ehcache.Cache;
-import org.ehcache.Ehcache;
 import org.ehcache.management.annotations.Exposed;
 import org.ehcache.management.annotations.Named;
 

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
@@ -55,7 +55,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static org.terracotta.context.query.Matchers.attributes;
 import static org.terracotta.context.query.Matchers.context;
@@ -101,7 +100,7 @@ class EhcacheStatistics {
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends Statistic<?>> Collection<T> queryStatistic(String statisticName) {
+  public Collection<? extends Statistic<?>> queryStatistic(String statisticName) {
     Collection<ExposedStatistic> registrations = statisticsRegistry.getRegistrations();
     for (ExposedStatistic registration : registrations) {
       Object type = registration.getProperties().get("type");
@@ -112,19 +111,19 @@ class EhcacheStatistics {
 
         if ((name + "Count").equals(statisticName)) {
           SampledStatistic<Long> count = result.count();
-          return (Collection<T>) Collections.singleton(new SampledCounter(statisticName, buildSamples(count)));
+          return Collections.singleton(new SampledCounter(statisticName, buildSamples(count)));
         } else if ((name + "Rate").equals(statisticName)) {
           SampledStatistic<Double> rate = result.rate();
-          return (Collection<T>) Collections.singleton(new SampledRate(statisticName, buildSamples(rate), configuration.historyIntervalUnit()));
+          return Collections.singleton(new SampledRate(statisticName, buildSamples(rate), configuration.historyIntervalUnit()));
         } else if ((name + "LatencyMinimum").equals(statisticName)) {
           SampledStatistic<Long> minimum = result.latency().minimum();
-          return (Collection<T>) Collections.singleton(new SampledDuration(statisticName, buildSamples(minimum), configuration.historyIntervalUnit()));
+          return Collections.singleton(new SampledDuration(statisticName, buildSamples(minimum), configuration.historyIntervalUnit()));
         } else if ((name + "LatencyMaximum").equals(statisticName)) {
           SampledStatistic<Long> maximum = result.latency().maximum();
-          return (Collection<T>) Collections.singleton(new SampledDuration(statisticName, buildSamples(maximum), configuration.historyIntervalUnit()));
+          return Collections.singleton(new SampledDuration(statisticName, buildSamples(maximum), configuration.historyIntervalUnit()));
         } else if ((name + "LatencyAverage").equals(statisticName)) {
           SampledStatistic<Double> average = result.latency().average();
-          return (Collection<T>) Collections.singleton(new SampledRatio(statisticName, buildSamples(average)));
+          return Collections.singleton(new SampledRatio(statisticName, buildSamples(average)));
         } else if (name.equals(statisticName)) {
           Collection<Statistic<?>> resultStats = new ArrayList<Statistic<?>>();
           resultStats.add(new SampledCounter(statisticName + "Count", buildSamples(result.count())));
@@ -132,12 +131,12 @@ class EhcacheStatistics {
           resultStats.add(new SampledDuration(statisticName + "LatencyMinimum", buildSamples(result.latency().minimum()), configuration.historyIntervalUnit()));
           resultStats.add(new SampledDuration(statisticName + "LatencyMaximum", buildSamples(result.latency().maximum()), configuration.historyIntervalUnit()));
           resultStats.add(new SampledRatio(statisticName + "LatencyAverage", buildSamples(result.latency().average())));
-          return (Collection<T>) resultStats;
+          return resultStats;
         }
       } else if ("Ratio".equals(type)) {
         if ((name + "Ratio").equals(statisticName)) {
           SampledStatistic<Double> ratio = (SampledStatistic) registration.getStat();
-          return (Collection<T>) Collections.singleton(new SampledRatio(statisticName, buildSamples(ratio)));
+          return Collections.singleton(new SampledRatio(statisticName, buildSamples(ratio)));
         }
       }
     }

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
@@ -100,7 +100,7 @@ class EhcacheStatistics {
   }
 
   @SuppressWarnings("unchecked")
-  public Collection<? extends Statistic<?>> queryStatistic(String statisticName) {
+  public List<? extends Statistic<?>> queryStatistic(String statisticName, long since) {
     Collection<ExposedStatistic> registrations = statisticsRegistry.getRegistrations();
     for (ExposedStatistic registration : registrations) {
       Object type = registration.getProperties().get("type");
@@ -111,21 +111,21 @@ class EhcacheStatistics {
 
         if ((name + "Count").equals(statisticName)) {
           SampledStatistic<Long> count = result.count();
-          return Collections.singleton(new SampledCounter(statisticName, buildSamples(count)));
+          return Collections.singletonList(new SampledCounter(statisticName, buildSamples(count)));
         } else if ((name + "Rate").equals(statisticName)) {
           SampledStatistic<Double> rate = result.rate();
-          return Collections.singleton(new SampledRate(statisticName, buildSamples(rate), configuration.historyIntervalUnit()));
+          return Collections.singletonList(new SampledRate(statisticName, buildSamples(rate), configuration.historyIntervalUnit()));
         } else if ((name + "LatencyMinimum").equals(statisticName)) {
           SampledStatistic<Long> minimum = result.latency().minimum();
-          return Collections.singleton(new SampledDuration(statisticName, buildSamples(minimum), configuration.historyIntervalUnit()));
+          return Collections.singletonList(new SampledDuration(statisticName, buildSamples(minimum), configuration.historyIntervalUnit()));
         } else if ((name + "LatencyMaximum").equals(statisticName)) {
           SampledStatistic<Long> maximum = result.latency().maximum();
-          return Collections.singleton(new SampledDuration(statisticName, buildSamples(maximum), configuration.historyIntervalUnit()));
+          return Collections.singletonList(new SampledDuration(statisticName, buildSamples(maximum), configuration.historyIntervalUnit()));
         } else if ((name + "LatencyAverage").equals(statisticName)) {
           SampledStatistic<Double> average = result.latency().average();
-          return Collections.singleton(new SampledRatio(statisticName, buildSamples(average)));
+          return Collections.singletonList(new SampledRatio(statisticName, buildSamples(average)));
         } else if (name.equals(statisticName)) {
-          Collection<Statistic<?>> resultStats = new ArrayList<Statistic<?>>();
+          List<Statistic<?>> resultStats = new ArrayList<Statistic<?>>();
           resultStats.add(new SampledCounter(statisticName + "Count", buildSamples(result.count())));
           resultStats.add(new SampledRate(statisticName + "Rate", buildSamples(result.rate()), configuration.historyIntervalUnit()));
           resultStats.add(new SampledDuration(statisticName + "LatencyMinimum", buildSamples(result.latency().minimum()), configuration.historyIntervalUnit()));
@@ -136,7 +136,7 @@ class EhcacheStatistics {
       } else if ("Ratio".equals(type)) {
         if ((name + "Ratio").equals(statisticName)) {
           SampledStatistic<Double> ratio = (SampledStatistic) registration.getStat();
-          return Collections.singleton(new SampledRatio(statisticName, buildSamples(ratio)));
+          return Collections.singletonList(new SampledRatio(statisticName, buildSamples(ratio)));
         }
       }
     }
@@ -160,7 +160,7 @@ class EhcacheStatistics {
 
         Object setting = attributes.get("Setting");
         if (setting != null && setting.equals(statisticName)) {
-          return (Collection) Collections.singleton(new Setting<String>(statisticName, (String) treeNode.getContext().attributes().get(statisticName)));
+          return Collections.singletonList(new Setting<String>(statisticName, (String) treeNode.getContext().attributes().get(statisticName)));
         }
       }
     }
@@ -168,7 +168,7 @@ class EhcacheStatistics {
     OperationStatistic<?> operationStatistic = operationStatistics.get(statisticName);
     if (operationStatistic != null) {
       long sum = operationStatistic.sum();
-      return (Collection) Collections.singleton(new Counter(statisticName, sum));
+      return Collections.singletonList(new Counter(statisticName, sum));
     }
 
     throw new IllegalArgumentException("Unknown statistic name : " + statisticName);

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatisticsProvider.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatisticsProvider.java
@@ -28,6 +28,7 @@ import org.terracotta.management.stats.Statistic;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -75,12 +76,12 @@ public class EhcacheStatisticsProvider extends CacheBindingManagementProviderSke
   }
 
   @Override
-  public Collection<Statistic<?>> collectStatistics(Map<String, String> context, String... statisticNames) {
-    Collection<Statistic<?>> statistics = new ArrayList<Statistic<?>>();
+  public List<Statistic<?>> collectStatistics(Map<String, String> context, Collection<String> statisticNames, long since) {
+    List<Statistic<?>> statistics = new ArrayList<Statistic<?>>();
     Map.Entry<CacheBinding, EhcacheStatistics> entry = findManagedObject(context);
     if (entry != null) {
       for (String statisticName : statisticNames) {
-        statistics.addAll(entry.getValue().queryStatistic(statisticName));
+        statistics.addAll(entry.getValue().queryStatistic(statisticName, since));
       }
     }
     return statistics;

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatisticsProvider.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatisticsProvider.java
@@ -75,12 +75,12 @@ public class EhcacheStatisticsProvider extends CacheBindingManagementProviderSke
   }
 
   @Override
-  public <T extends Statistic<?>> Collection<T> collectStatistics(Map<String, String> context, String... statisticNames) {
-    Collection<T> statistics = new ArrayList<T>();
+  public Collection<Statistic<?>> collectStatistics(Map<String, String> context, String... statisticNames) {
+    Collection<Statistic<?>> statistics = new ArrayList<Statistic<?>>();
     Map.Entry<CacheBinding, EhcacheStatistics> entry = findManagedObject(context);
     if (entry != null) {
       for (String statisticName : statisticNames) {
-        statistics.addAll(entry.getValue().<T>queryStatistic(statisticName));
+        statistics.addAll(entry.getValue().queryStatistic(statisticName));
       }
     }
     return statistics;

--- a/management/src/main/java/org/ehcache/management/registry/DefaultCapabilityBasedQuery.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultCapabilityBasedQuery.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.registry;
+
+import org.ehcache.management.CallQuery;
+import org.ehcache.management.CapabilityBasedQuery;
+import org.ehcache.management.CapabilityManagement;
+import org.ehcache.management.ContextualResult;
+import org.ehcache.management.ContextualStatistics;
+import org.ehcache.management.StatisticQuery;
+import org.ehcache.management.providers.ManagementProvider;
+import org.terracotta.management.stats.Statistic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mathieu Carbou
+ */
+final class DefaultCapabilityBasedQuery implements CapabilityBasedQuery {
+
+  private final String capabilityName;
+  private final CapabilityManagement capabilityManagement;
+
+  DefaultCapabilityBasedQuery(CapabilityManagement capabilityManagement, String capabilityName) {
+    this.capabilityManagement = capabilityManagement;
+    this.capabilityName = capabilityName;
+  }
+
+  @Override
+  public StatisticQuery.Builder queryStatistic(String statisticName) {
+    return new StatisticQueryBuilder(capabilityManagement, capabilityName, Collections.singletonList(statisticName));
+  }
+
+  @Override
+  public StatisticQuery.Builder queryStatistics(String... statisticNames) {
+    return new StatisticQueryBuilder(capabilityManagement, capabilityName, Arrays.asList(statisticNames));
+  }
+
+  @Override
+  public StatisticQuery.Builder queryStatistics(Collection<String> statisticNames) {
+    return new StatisticQueryBuilder(capabilityManagement, capabilityName, statisticNames);
+  }
+
+  @Override
+  public CallQuery.Builder call(String methodName, String[] argClassNames, Object[] args) {
+    return new CallQueryBuilder(capabilityManagement, capabilityName, methodName, argClassNames, args);
+  }
+
+  @Override
+  public CallQuery.Builder call(String methodName) {
+    return call(methodName, new String[0], new Object[0]);
+  }
+
+  static class StatisticQueryBuilder implements StatisticQuery, StatisticQuery.Builder {
+
+    private final CapabilityManagement capabilityManagement;
+    private final String capabilityName;
+    private final Collection<String> statisticNames;
+    private final List<Map<String, String>> contexts = new ArrayList<Map<String, String>>();
+    private volatile long since = 0;
+
+    StatisticQueryBuilder(CapabilityManagement capabilityManagement, String capabilityName, Collection<String> statisticNames) {
+      this.capabilityManagement = capabilityManagement;
+      this.capabilityName = capabilityName;
+      this.statisticNames = Collections.unmodifiableCollection(new LinkedHashSet<String>(statisticNames));
+    }
+
+    @Override
+    public StatisticQuery build() {
+      return this;
+    }
+
+    @Override
+    public StatisticQuery.Builder on(Map<String, String> context) {
+      this.contexts.add(Collections.unmodifiableMap(context));
+      return this;
+    }
+
+    @Override
+    public Builder on(List<Map<String, String>> contexts) {
+      for (Map<String, String> context : contexts) {
+        on(context);
+      }
+      return this;
+    }
+
+    @Override
+    public StatisticQuery.Builder since(long unixTimestampMs) {
+      this.since = unixTimestampMs;
+      return this;
+    }
+
+    @Override
+    public String getCapabilityName() {
+      return capabilityName;
+    }
+
+    @Override
+    public List<Map<String, String>> getContexts() {
+      return Collections.unmodifiableList(contexts);
+    }
+
+    @Override
+    public Collection<String> getStatisticNames() {
+      return statisticNames;
+    }
+
+    @Override
+    public long getSince() {
+      return since;
+    }
+
+    @Override
+    public List<ContextualStatistics> execute() {
+      // pre-validation
+      for (Map<String, String> context : contexts) {
+        if (context.get("cacheManagerName") == null) {
+          throw new IllegalArgumentException("Missing cache manager name from context " + context + " in context list " + contexts);
+        }
+      }
+
+      List<ContextualStatistics> contextualStatistics = new ArrayList<ContextualStatistics>(contexts.size());
+      Collection<ManagementProvider<?>> managementProviders = capabilityManagement.getManagementProvidersByCapability(capabilityName);
+
+      for (Map<String, String> context : contexts) {
+        List<Statistic<?>> statistics = new ArrayList<Statistic<?>>();
+        for (ManagementProvider<?> managementProvider : managementProviders) {
+          if (managementProvider.supports(context)) {
+            statistics.addAll(managementProvider.collectStatistics(context, statisticNames, since));
+          }
+        }
+        contextualStatistics.add(new ContextualStatistics(context, statistics));
+      }
+
+      return contextualStatistics;
+    }
+
+  }
+
+  static class CallQueryBuilder implements CallQuery, CallQuery.Builder {
+
+    private final CapabilityManagement capabilityManagement;
+    private final String capabilityName;
+    private final String methodName;
+    private final String[] argClassNames;
+    private final Object[] args;
+    private final List<Map<String, String>> contexts = new ArrayList<Map<String, String>>();
+
+    CallQueryBuilder(CapabilityManagement capabilityManagement, String capabilityName, String methodName, String[] argClassNames, Object[] args) {
+      this.capabilityManagement = capabilityManagement;
+      this.capabilityName = capabilityName;
+      this.methodName = methodName;
+      this.argClassNames = argClassNames;
+      this.args = args;
+    }
+
+    @Override
+    public CallQuery build() {
+      return this;
+    }
+
+    @Override
+    public CallQuery.Builder on(Map<String, String> context) {
+      this.contexts.add(Collections.unmodifiableMap(context));
+      return this;
+    }
+
+    @Override
+    public Builder on(List<Map<String, String>> contexts) {
+      for (Map<String, String> context : contexts) {
+        on(context);
+      }
+      return this;
+    }
+
+    @Override
+    public String getCapabilityName() {
+      return capabilityName;
+    }
+
+    @Override
+    public List<Map<String, String>> getContexts() {
+      return Collections.unmodifiableList(contexts);
+    }
+
+    @Override
+    public String getMethodName() {
+      return methodName;
+    }
+
+    @Override
+    public String[] getParameterClassNames() {
+      return argClassNames;
+    }
+
+    @Override
+    public Object[] getParameters() {
+      return args;
+    }
+
+    @Override
+    public List<ContextualResult> execute() {
+      // pre-validation
+      for (Map<String, String> context : contexts) {
+        if (context.get("cacheManagerName") == null) {
+          throw new IllegalArgumentException("Missing cache manager name from context " + context + " in context list " + contexts);
+        }
+      }
+
+      List<ContextualResult> contextualResults = new ArrayList<ContextualResult>(contexts.size());
+      Collection<ManagementProvider<?>> managementProviders = capabilityManagement.getManagementProvidersByCapability(capabilityName);
+
+      for (Map<String, String> context : contexts) {
+        ContextualResult result = ContextualResult.noResult(context);
+        for (ManagementProvider<?> managementProvider : managementProviders) {
+          if (managementProvider.supports(context)) {
+            // just suppose there is only one manager handling calls - should be
+            result = ContextualResult.result(context, managementProvider.callAction(context, methodName, argClassNames, args));
+            break;
+          }
+        }
+        contextualResults.add(result);
+      }
+
+      return contextualResults;
+    }
+
+  }
+}

--- a/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistry.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistry.java
@@ -213,19 +213,19 @@ public class DefaultManagementRegistry implements ManagementRegistry, CacheManag
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T extends Statistic<?>> Collection<T> collectStatistics(Map<String, String> context, String capabilityName, String... statisticNames) {
-    return this.<T>collectStatistics(Collections.singletonList(context), capabilityName, statisticNames).get(0);
+  public Collection<Statistic<?>> collectStatistics(Map<String, String> context, String capabilityName, String... statisticNames) {
+    return collectStatistics(Collections.singletonList(context), capabilityName, statisticNames).get(0);
   }
 
   @Override
-  public <T extends Statistic<?>> List<Collection<T>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames) {
-    List<Collection<T>> list = new ArrayList<Collection<T>>(contextList.size());
+  public List<Collection<Statistic<?>>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames) {
+    List<Collection<Statistic<?>>> list = new ArrayList<Collection<Statistic<?>>>(contextList.size());
     for (ManagementProvider<?> managementProvider : getManagementProvidersByCapability(capabilityName)) {
       for (Map<String, String> context : contextList) {
         if (managementProvider.supports(context)) {
-          list.add(managementProvider.<T>collectStatistics(context, statisticNames));
+          list.add(managementProvider.collectStatistics(context, statisticNames));
         } else {
-          list.add(Collections.<T>emptyList());
+          list.add(Collections.<Statistic<?>>emptyList());
         }
       }
     }
@@ -234,23 +234,23 @@ public class DefaultManagementRegistry implements ManagementRegistry, CacheManag
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T callAction(Map<String, String> context, String capabilityName, String methodName, String[] argClassNames, Object[] args) {
+  public Object callAction(Map<String, String> context, String capabilityName, String methodName, String[] argClassNames, Object[] args) {
     for (ManagementProvider<?> managementProvider : getManagementProvidersByCapability(capabilityName)) {
       if (managementProvider.supports(context)) {
-        return (T) managementProvider.callAction(context, methodName, argClassNames, args);
+        return managementProvider.callAction(context, methodName, argClassNames, args);
       }
     }
     throw new IllegalArgumentException("No such capability registered or context supported for : " + capabilityName + " / " + context);
   }
 
   private List<ManagementProvider<?>> getManagementProvidersByCapability(String capabilityName) {
-    List<ManagementProvider<?>> allproviders = new ArrayList<ManagementProvider<?>>();
+    List<ManagementProvider<?>> allProviders = new ArrayList<ManagementProvider<?>>();
     for (ManagementProvider<?> provider : managementProviders) {
       if (provider.getCapabilityName().equals(capabilityName)) {
-        allproviders.add(provider);
+        allProviders.add(provider);
       }
     }
-    return allproviders;
+    return allProviders;
   }
 
   private static final class EhcacheStatsSetting {

--- a/management/src/main/java/org/ehcache/management/registry/DefaultSharedManagementService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultSharedManagementService.java
@@ -99,40 +99,40 @@ public class DefaultSharedManagementService implements SharedManagementService {
   }
 
   @Override
-  public <T extends Statistic<?>> List<Collection<T>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames) {
+  public List<Collection<Statistic<?>>> collectStatistics(List<Map<String, String>> contextList, String capabilityName, String... statisticNames) {
     // pre-validation
     for (Map<String, String> ctx : contextList) {
       if (ctx.get("cacheManagerName") == null) {
         throw new IllegalArgumentException("Missing cache manager name from context : " + ctx + " in context list " + contextList);
       }
     }
-    List<Collection<T>> statistics = new ArrayList<Collection<T>>(contextList.size());
+    List<Collection<Statistic<?>>> statistics = new ArrayList<Collection<Statistic<?>>>(contextList.size());
     for (Map<String, String> context : contextList) {
       ManagementRegistry registry = delegates.get(context.get("cacheManagerName"));
       if (registry == null) {
-        statistics.add(Collections.<T>emptyList());
+        statistics.add(Collections.<Statistic<?>>emptyList());
       } else {
-        statistics.add(registry.<T>collectStatistics(context, capabilityName, statisticNames));
+        statistics.add(registry.collectStatistics(context, capabilityName, statisticNames));
       }
     }
     return statistics;
   }
 
   @Override
-  public <T> List<T> callAction(List<Map<String, String>> contextList, String capabilityName, String methodName, String[] argClassNames, Object[] args) {
+  public List<Object> callAction(List<Map<String, String>> contextList, String capabilityName, String methodName, String[] argClassNames, Object[] args) {
     // pre-validation
     for (Map<String, String> ctx : contextList) {
       if (ctx.get("cacheManagerName") == null) {
         throw new IllegalArgumentException("Missing cache manager name from context : " + ctx + " in context list " + contextList);
       }
     }
-    List<T> returns = new ArrayList<T>();
+    List<Object> returns = new ArrayList<Object>();
     for (Map<String, String> context : contextList) {
       ManagementRegistry registry = delegates.get(context.get("cacheManagerName"));
       if (registry == null) {
         returns.add(null);
       } else {
-        returns.add(registry.<T>callAction(context, capabilityName, methodName, argClassNames, args));
+        returns.add(registry.callAction(context, capabilityName, methodName, argClassNames, args));
       }
     }
     return returns;

--- a/management/src/test/java/org/ehcache/docs/ManagementTest.java
+++ b/management/src/test/java/org/ehcache/docs/ManagementTest.java
@@ -34,6 +34,7 @@ import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.capabilities.context.CapabilityContext;
 import org.terracotta.management.capabilities.descriptors.Descriptor;
 import org.terracotta.management.context.ContextContainer;
+import org.terracotta.management.stats.Statistic;
 import org.terracotta.management.stats.primitive.Counter;
 
 import java.util.Arrays;
@@ -71,9 +72,9 @@ public class ManagementTest {
 
     Map<String, String> context = createContext(managementRegistry); // <5>
 
-    Collection<Counter> counters = managementRegistry.collectStatistics(context, "StatisticsCapability", "GetCounter"); // <6>
+    Collection<Statistic<?>> counters = managementRegistry.collectStatistics(context, "StatisticsCapability", "GetCounter"); // <6>
     Assert.assertThat(counters.size(), Matchers.is(1));
-    Counter getCounter = counters.iterator().next();
+    Counter getCounter = (Counter) counters.iterator().next();
 
     Assert.assertThat(getCounter.getValue(), Matchers.equalTo(3L)); // <7>
 
@@ -175,7 +176,7 @@ public class ManagementTest {
     context.put("cacheManagerName", "myCacheManager");
     context.put("cacheName", "aCache");
 
-    List<Collection<Counter>> counters = sharedManagementService.collectStatistics(Arrays.asList(context), "StatisticsCapability", "GetCounter");
+    List<Collection<Statistic<?>>> counters = sharedManagementService.collectStatistics(Arrays.asList(context), "StatisticsCapability", "GetCounter");
 
     cacheManager2.close();
     cacheManager1.close();

--- a/management/src/test/java/org/ehcache/management/providers/actions/EhcacheActionProviderTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/actions/EhcacheActionProviderTest.java
@@ -89,7 +89,7 @@ public class EhcacheActionProviderTest {
     EhcacheActionProvider ehcacheActionProvider = new EhcacheActionProvider("myCacheManagerName");
 
     try {
-      ehcacheActionProvider.collectStatistics(null, null);
+      ehcacheActionProvider.collectStatistics(null, null, System.currentTimeMillis());
       fail("expected UnsupportedOperationException");
     } catch (UnsupportedOperationException uoe) {
       // expected

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryTest.java
@@ -25,7 +25,7 @@ import org.ehcache.management.ManagementRegistry;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.terracotta.management.capabilities.Capability;
-import org.terracotta.management.stats.primitive.Counter;
+import org.terracotta.management.stats.Statistic;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -121,18 +121,18 @@ public class DefaultManagementRegistryTest {
     cacheManager1.getCache("aCache2", Long.class, String.class).put(4L, "4");
     cacheManager1.getCache("aCache2", Long.class, String.class).put(5L, "5");
 
-    Collection<Counter> counters = managementRegistry.collectStatistics(context1, "StatisticsCapability", "PutCounter");
+    Collection<Statistic<?>> counters = managementRegistry.collectStatistics(context1, "StatisticsCapability", "PutCounter");
 
     assertThat(counters, hasSize(1));
-    assertThat(counters.iterator().next().getValue(), equalTo(2L));
+    assertThat((Long) counters.iterator().next().getValue(), equalTo(2L));
 
-    List<Collection<Counter>> allCounters = managementRegistry.collectStatistics(Arrays.asList(context1, context2), "StatisticsCapability", "PutCounter");
+    List<Collection<Statistic<?>>> allCounters = managementRegistry.collectStatistics(Arrays.asList(context1, context2), "StatisticsCapability", "PutCounter");
 
     assertThat(allCounters, hasSize(2));
     assertThat(allCounters.get(0), hasSize(1));
     assertThat(allCounters.get(1), hasSize(1));
-    assertThat(allCounters.get(0).iterator().next().getValue(), equalTo(2L));
-    assertThat(allCounters.get(1).iterator().next().getValue(), equalTo(3L));
+    assertThat((Long) allCounters.get(0).iterator().next().getValue(), equalTo(2L));
+    assertThat((Long) allCounters.get(1).iterator().next().getValue(), equalTo(3L));
 
     cacheManager1.close();
   }

--- a/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.context.ContextContainer;
-import org.terracotta.management.stats.primitive.Counter;
+import org.terracotta.management.stats.Statistic;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -150,7 +150,7 @@ public class DefaultSharedManagementServiceTest {
     cacheManager2.getCache("aCache2", Long.class, String.class).put(2L, "2");
     cacheManager2.getCache("aCache3", Long.class, String.class).put(3L, "3");
 
-    List<Collection<Counter>> allCounters = service.collectStatistics(contextList, "StatisticsCapability", "PutCounter");
+    List<Collection<Statistic<?>>> allCounters = service.collectStatistics(contextList, "StatisticsCapability", "PutCounter");
 
     assertThat(allCounters, hasSize(3));
 
@@ -158,9 +158,9 @@ public class DefaultSharedManagementServiceTest {
     assertThat(allCounters.get(1), hasSize(1));
     assertThat(allCounters.get(2), hasSize(1));
 
-    assertThat(allCounters.get(0).iterator().next().getValue(), equalTo(1L));
-    assertThat(allCounters.get(1).iterator().next().getValue(), equalTo(1L));
-    assertThat(allCounters.get(2).iterator().next().getValue(), equalTo(1L));
+    assertThat((Long) allCounters.get(0).iterator().next().getValue(), equalTo(1L));
+    assertThat((Long) allCounters.get(1).iterator().next().getValue(), equalTo(1L));
+    assertThat((Long) allCounters.get(2).iterator().next().getValue(), equalTo(1L));
   }
 
   @Test

--- a/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
@@ -21,6 +21,8 @@ import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.CacheConfigurationBuilder;
 import org.ehcache.config.ResourcePoolsBuilder;
 import org.ehcache.config.units.EntryUnit;
+import org.ehcache.management.ContextualResult;
+import org.ehcache.management.ContextualStatistics;
 import org.ehcache.management.SharedManagementService;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -30,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.context.ContextContainer;
-import org.terracotta.management.stats.Statistic;
+import org.terracotta.management.stats.primitive.Counter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,14 +40,17 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * @author Mathieu Carbou
@@ -150,17 +155,21 @@ public class DefaultSharedManagementServiceTest {
     cacheManager2.getCache("aCache2", Long.class, String.class).put(2L, "2");
     cacheManager2.getCache("aCache3", Long.class, String.class).put(3L, "3");
 
-    List<Collection<Statistic<?>>> allCounters = service.collectStatistics(contextList, "StatisticsCapability", "PutCounter");
+    List<ContextualStatistics> allCounters = service.withCapability("StatisticsCapability")
+        .queryStatistic("PutCounter")
+        .on(contextList)
+        .build()
+        .execute();
 
     assertThat(allCounters, hasSize(3));
 
-    assertThat(allCounters.get(0), hasSize(1));
-    assertThat(allCounters.get(1), hasSize(1));
-    assertThat(allCounters.get(2), hasSize(1));
+    assertThat(allCounters.get(0).getStatistics(), hasSize(1));
+    assertThat(allCounters.get(1).getStatistics(), hasSize(1));
+    assertThat(allCounters.get(2).getStatistics(), hasSize(1));
 
-    assertThat((Long) allCounters.get(0).iterator().next().getValue(), equalTo(1L));
-    assertThat((Long) allCounters.get(1).iterator().next().getValue(), equalTo(1L));
-    assertThat((Long) allCounters.get(2).iterator().next().getValue(), equalTo(1L));
+    assertThat(allCounters.get(0).getStatistic(0, Counter.class).getValue(), equalTo(1L));
+    assertThat(allCounters.get(1).getStatistic(0, Counter.class).getValue(), equalTo(1L));
+    assertThat(allCounters.get(2).getStatistic(0, Counter.class).getValue(), equalTo(1L));
   }
 
   @Test
@@ -177,6 +186,11 @@ public class DefaultSharedManagementServiceTest {
         new HashMap<String, String>() {{
           put("cacheManagerName", "myCM2");
           put("cacheName", "aCache2");
+        }},
+        // inexisting context
+        new HashMap<String, String>() {{
+          put("cacheManagerName", "myCM55");
+          put("cacheName", "aCache55");
         }}
     );
 
@@ -194,11 +208,29 @@ public class DefaultSharedManagementServiceTest {
     cacheManager1.getCache("aCache4", Long.class, String.class).put(4L, "4");
     assertThat(cacheManager1.getCache("aCache4", Long.class, String.class).get(4L), equalTo("4"));
 
-    List<Object> results = service.callAction(contextList, "ActionsCapability", "clear", new String[0], new Object[0]);
-    assertThat(results, hasSize(3));
-    assertThat(results.get(0), is(nullValue()));
-    assertThat(results.get(1), is(nullValue()));
-    assertThat(results.get(2), is(nullValue()));
+    List<ContextualResult> results = service.withCapability("ActionsCapability")
+        .call("clear")
+        .on(contextList)
+        .build()
+        .execute();
+
+    assertThat(results, hasSize(4));
+
+    assertThat(results.get(0).hasResult(), is(true));
+    assertThat(results.get(1).hasResult(), is(true));
+    assertThat(results.get(2).hasResult(), is(true));
+    assertThat(results.get(3).hasResult(), is(false));
+
+    assertThat(results.get(0).getResult(Object.class), is(nullValue()));
+    assertThat(results.get(1).getResult(Object.class), is(nullValue()));
+    assertThat(results.get(2).getResult(Object.class), is(nullValue()));
+
+    try {
+      results.get(3).getResult(Object.class);
+      fail();
+    } catch (Exception e) {
+      assertThat(e, instanceOf(NoSuchElementException.class));
+    }
 
     assertThat(cacheManager1.getCache("aCache1", Long.class, String.class).get(1L), is(Matchers.nullValue()));
     assertThat(cacheManager2.getCache("aCache2", Long.class, String.class).get(2L), is(Matchers.nullValue()));


### PR DESCRIPTION
Review ManagementRegistry's collectStatistics method to:

- add a parameter (since) to reduce history size of samples based on a last called timestamp passed by the client to the api (seen with @lorban )
- change the parameters to a DSL or builder: because much easier, enables to add further parameters easily (such as since Timestamp above), and remove duplicated methods (good suggestion from @chrisdennis)
- fix generic returns of the the collectStatistics method to remove the type (@chrisdennis)

I added a test, but the asserted statistic values should be reviewed because I am not sure they are right (`since` is working fine but i have questions about the returned values)

`DefaultManagementRegistryTest.testCanGetStatsSinceTime()`