### PR TITLE
Introduce a resource releaser method for SerializationProvider as a precursor to the real fix for #635

### DIFF
--- a/107/src/test/java/org/ehcache/jsr107/LongSerializer.java
+++ b/107/src/test/java/org/ehcache/jsr107/LongSerializer.java
@@ -44,9 +44,4 @@ public class LongSerializer implements Serializer<Long> {
   public boolean equals(Long object, ByteBuffer binary) {
     return object.equals(read(binary));
   }
-
-  @Override
-  public void close() {
-    //nothing
-  }
 }

--- a/107/src/test/java/org/ehcache/jsr107/StringSerializer.java
+++ b/107/src/test/java/org/ehcache/jsr107/StringSerializer.java
@@ -49,9 +49,4 @@ public class StringSerializer implements Serializer<String> {
   public boolean equals(String object, ByteBuffer binary) {
     return object.equals(read(binary));
   }
-
-  @Override
-  public void close() {
-    //nothing
-  }
 }

--- a/api/src/main/java/org/ehcache/event/CacheEventListenerProvider.java
+++ b/api/src/main/java/org/ehcache/event/CacheEventListenerProvider.java
@@ -40,7 +40,8 @@ public interface CacheEventListenerProvider extends Service {
    * Releases a given {@link org.ehcache.event.CacheEventListener}
    *
    * @param cacheEventListener the CacheEventListener to release
+   * @throws Exception when the release fails
    */
-  void releaseEventListener(CacheEventListener<?, ?> cacheEventListener);
+  void releaseEventListener(CacheEventListener<?, ?> cacheEventListener) throws Exception;
 
 }

--- a/api/src/main/java/org/ehcache/spi/loaderwriter/CacheLoaderWriterProvider.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/CacheLoaderWriterProvider.java
@@ -48,7 +48,8 @@ public interface CacheLoaderWriterProvider extends Service {
    * Invoked by {@link org.ehcache.CacheManager} when a {@link org.ehcache.Cache} is being removed from it.
    * @param cacheLoaderWriter the {@link CacheLoaderWriter} that was initially associated with
    *                    the {@link org.ehcache.Cache} being removed
+   * @throws Exception when the release fails
    */
-  void releaseCacheLoaderWriter(CacheLoaderWriter<?, ?> cacheLoaderWriter);
+  void releaseCacheLoaderWriter(CacheLoaderWriter<?, ?> cacheLoaderWriter) throws Exception;
 
 }

--- a/api/src/main/java/org/ehcache/spi/serialization/SerializationProvider.java
+++ b/api/src/main/java/org/ehcache/spi/serialization/SerializationProvider.java
@@ -53,6 +53,7 @@ public interface SerializationProvider extends Service {
    * Releases the given {@link Serializer} instance
    * 
    * @param serializer the serializer to be released
+   * @throws Exception when the release fails
    */
-  void releaseSerializer(Serializer<?> serializer);
+  void releaseSerializer(Serializer<?> serializer) throws Exception;
 }

--- a/api/src/main/java/org/ehcache/spi/serialization/SerializationProvider.java
+++ b/api/src/main/java/org/ehcache/spi/serialization/SerializationProvider.java
@@ -49,4 +49,10 @@ public interface SerializationProvider extends Service {
    */
   <T> Serializer<T> createValueSerializer(Class<T> clazz, ClassLoader classLoader, ServiceConfiguration<?>... configs) throws UnsupportedTypeException;
 
+  /**
+   * Releases the given {@link Serializer} instance
+   * 
+   * @param serializer the serializer to be released
+   */
+  void releaseSerializer(Serializer<?> serializer);
 }

--- a/api/src/main/java/org/ehcache/spi/serialization/Serializer.java
+++ b/api/src/main/java/org/ehcache/spi/serialization/Serializer.java
@@ -40,7 +40,7 @@ import org.ehcache.exceptions.SerializerException;
  *
  * @author cdennis
  */
-public interface Serializer<T> extends Closeable {
+public interface Serializer<T> {
 
   /**
    * Transforms the given instance into its serial form.

--- a/core/src/main/java/org/ehcache/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/EhcacheManager.java
@@ -364,7 +364,7 @@ public class EhcacheManager implements PersistentCacheManager {
       if (loaderWriter != null) {
         lifeCycledList.add(new LifeCycledAdapter() {
           @Override
-          public void close() {
+          public void close() throws Exception {
             cacheLoaderWriterProvider.releaseCacheLoaderWriter(loaderWriter);
           }
         });
@@ -403,7 +403,7 @@ public class EhcacheManager implements PersistentCacheManager {
             }
 
             @Override
-            public void close() {
+            public void close() throws Exception {
               evntLsnrFactory.releaseEventListener(lsnr);
             }
           });

--- a/core/src/test/java/org/ehcache/EhcacheManagerTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheManagerTest.java
@@ -318,7 +318,7 @@ public class EhcacheManagerTest {
   }
 
   @Test
-  public void testLifeCyclesCacheLoaders() {
+  public void testLifeCyclesCacheLoaders() throws Exception {
 
     ResourcePools resourcePools = ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10L, EntryUnit.ENTRIES).build();
 

--- a/impl/src/main/java/org/ehcache/internal/classes/ClassInstanceProvider.java
+++ b/impl/src/main/java/org/ehcache/internal/classes/ClassInstanceProvider.java
@@ -99,17 +99,12 @@ public class ClassInstanceProvider<K, T> {
     }
   }
 
-  protected void releaseInstance(T instance) {
-    if(!created.contains(instance)) {
+  protected void releaseInstance(T instance) throws IOException {
+    if(!created.remove(instance)) {
       throw new IllegalArgumentException("Given instance of " + instance.getClass().getName() + " is not managed by this provider");
     }
     if(instance instanceof Closeable) {
-      try {
-        ((Closeable)instance).close();
-        created.remove(instance);
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to close the instance of " + instance.getClass().getName(), e);
-      }
+      ((Closeable)instance).close();
     }
   }
   

--- a/impl/src/main/java/org/ehcache/internal/serialization/CompactJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/CompactJavaSerializer.java
@@ -150,6 +150,11 @@ public class CompactJavaSerializer<T> implements Serializer<T> {
     }
   }
 
+  public void close() {
+    readLookup.clear();
+    writeLookup.clear();
+  }
+
   class OOS extends ObjectOutputStream {
 
     public OOS(OutputStream out) throws IOException {

--- a/impl/src/main/java/org/ehcache/internal/serialization/CompactJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/CompactJavaSerializer.java
@@ -17,6 +17,7 @@ package org.ehcache.internal.serialization;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -48,7 +49,7 @@ import org.ehcache.spi.serialization.Serializer;
  *
  * @author Chris Dennis
  */
-public class CompactJavaSerializer<T> implements Serializer<T> {
+public class CompactJavaSerializer<T> implements Serializer<T>, Closeable {
 
   private final AtomicInteger nextStreamIndex = new AtomicInteger(0);
   
@@ -150,6 +151,7 @@ public class CompactJavaSerializer<T> implements Serializer<T> {
     }
   }
 
+  @Override
   public void close() {
     readLookup.clear();
     writeLookup.clear();

--- a/impl/src/main/java/org/ehcache/internal/serialization/CompactJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/CompactJavaSerializer.java
@@ -150,12 +150,6 @@ public class CompactJavaSerializer<T> implements Serializer<T> {
     }
   }
 
-  @Override
-  public void close() {
-    readLookup.clear();
-    writeLookup.clear();
-  }
-
   class OOS extends ObjectOutputStream {
 
     public OOS(OutputStream out) throws IOException {

--- a/impl/src/main/java/org/ehcache/internal/serialization/CompactPersistentJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/CompactPersistentJavaSerializer.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.internal.serialization;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -34,7 +35,7 @@ import org.ehcache.spi.service.FileBasedPersistenceContext;
  *
  * @author cdennis
  */
-public class CompactPersistentJavaSerializer<T> implements Serializer<T> {
+public class CompactPersistentJavaSerializer<T> implements Serializer<T>, Closeable {
 
   private final File stateFile;
   private final CompactJavaSerializer<T> serializer;
@@ -48,11 +49,10 @@ public class CompactPersistentJavaSerializer<T> implements Serializer<T> {
     }
   }
 
-  public void close() {
+  @Override
+  public final void close() throws IOException {
     try {
       writeSerializationMappings(stateFile, serializer.getSerializationMappings());
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to persist the state of this serializer", e);
     } finally {
       serializer.close();
     }

--- a/impl/src/main/java/org/ehcache/internal/serialization/CompactPersistentJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/CompactPersistentJavaSerializer.java
@@ -48,8 +48,14 @@ public class CompactPersistentJavaSerializer<T> implements Serializer<T> {
     }
   }
 
-  public void close() throws IOException {
-    writeSerializationMappings(stateFile, serializer.getSerializationMappings());
+  public void close() {
+    try {
+      writeSerializationMappings(stateFile, serializer.getSerializationMappings());
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to persist the state of this serializer", e);
+    } finally {
+      serializer.close();
+    }
   }
 
   private static Map<Integer, ObjectStreamClass> readSerializationMappings(File stateFile) throws IOException, ClassNotFoundException {

--- a/impl/src/main/java/org/ehcache/internal/serialization/CompactPersistentJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/internal/serialization/CompactPersistentJavaSerializer.java
@@ -20,13 +20,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.ObjectInput;
 import java.io.ObjectInputStream;
-import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import org.ehcache.exceptions.SerializerException;
@@ -51,13 +48,8 @@ public class CompactPersistentJavaSerializer<T> implements Serializer<T> {
     }
   }
 
-  @Override
-  public final void close() throws IOException {
-    try {
-      writeSerializationMappings(stateFile, serializer.getSerializationMappings());
-    } finally {
-      serializer.close();
-    }
+  public void close() throws IOException {
+    writeSerializationMappings(stateFile, serializer.getSerializationMappings());
   }
 
   private static Map<Integer, ObjectStreamClass> readSerializationMappings(File stateFile) throws IOException, ClassNotFoundException {

--- a/impl/src/main/java/org/ehcache/spi/event/DefaultCacheEventListenerProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/event/DefaultCacheEventListenerProvider.java
@@ -40,6 +40,6 @@ public class DefaultCacheEventListenerProvider extends ClassInstanceProvider<Str
 
   @Override
   public void releaseEventListener(CacheEventListener<?, ?> cacheEventListener) {
-    //noop
+    releaseInstance(cacheEventListener);
   }
 }

--- a/impl/src/main/java/org/ehcache/spi/event/DefaultCacheEventListenerProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/event/DefaultCacheEventListenerProvider.java
@@ -39,7 +39,7 @@ public class DefaultCacheEventListenerProvider extends ClassInstanceProvider<Str
   }
 
   @Override
-  public void releaseEventListener(CacheEventListener<?, ?> cacheEventListener) {
+  public void releaseEventListener(CacheEventListener<?, ?> cacheEventListener) throws Exception {
     releaseInstance(cacheEventListener);
   }
 }

--- a/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProvider.java
@@ -38,6 +38,6 @@ public class DefaultCacheLoaderWriterProvider extends ClassInstanceProvider<Stri
 
   @Override
   public void releaseCacheLoaderWriter(final CacheLoaderWriter<?, ?> cacheLoaderWriter) {
-    // noop
+    releaseInstance(cacheLoaderWriter);
   }
 }

--- a/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProvider.java
@@ -37,7 +37,7 @@ public class DefaultCacheLoaderWriterProvider extends ClassInstanceProvider<Stri
   }
 
   @Override
-  public void releaseCacheLoaderWriter(final CacheLoaderWriter<?, ?> cacheLoaderWriter) {
+  public void releaseCacheLoaderWriter(final CacheLoaderWriter<?, ?> cacheLoaderWriter) throws Exception {
     releaseInstance(cacheLoaderWriter);
   }
 }

--- a/impl/src/main/java/org/ehcache/spi/serialization/DefaultSerializationProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/serialization/DefaultSerializationProvider.java
@@ -72,7 +72,7 @@ public class DefaultSerializationProvider implements SerializationProvider {
   public <T> Serializer<T> createKeySerializer(Class<T> clazz, ClassLoader classLoader, ServiceConfiguration<?>... configs) throws UnsupportedTypeException {
     Serializer<T> serializer;
     if (findSingletonAmongst(PersistenceSpaceIdentifier.class, (Object[]) configs) == null) {
-      serializer = transientProvider.createKeySerializer(clazz, classLoader, configs); 
+      serializer = transientProvider.createKeySerializer(clazz, classLoader, configs);
     } else {
       serializer = persistentProvider.createKeySerializer(clazz, classLoader, configs);
     }
@@ -93,17 +93,12 @@ public class DefaultSerializationProvider implements SerializationProvider {
   }
 
   @Override
-  public void releaseSerializer(final Serializer<?> serializer) {
-    if (!created.contains(serializer)) {
+  public void releaseSerializer(final Serializer<?> serializer) throws IOException {
+    if (!created.remove(serializer)) {
       throw new IllegalArgumentException("Given serializer: " + serializer.getClass().getName() + " is not managed by this provider");
     }
     if(serializer instanceof Closeable) {
-      try {
-        ((Closeable)serializer).close();
-        created.remove(serializer);
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to close the serializer: " + serializer.getClass().getName(), e);
-      }
+      ((Closeable)serializer).close();
     }
   }
   

--- a/impl/src/main/java/org/ehcache/spi/serialization/DefaultSerializationProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/serialization/DefaultSerializationProvider.java
@@ -29,7 +29,6 @@ import org.ehcache.spi.service.ServiceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -96,12 +95,10 @@ public class DefaultSerializationProvider implements SerializationProvider {
     if (!created.remove(serializer)) {
       throw new IllegalArgumentException("Given serializer: " + serializer.getClass().getName() + " is not managed by this provider");
     }
-    if(serializer instanceof CompactPersistentJavaSerializer) {
-      try {
-        ((CompactPersistentJavaSerializer)serializer).close();
-      } catch (IOException e) {
-        throw new RuntimeException("Unable to close the serializer: " + serializer.getClass().getName());
-      }
+    if(serializer instanceof CompactJavaSerializer) {
+      ((CompactJavaSerializer)serializer).close();
+    } else if(serializer instanceof CompactPersistentJavaSerializer) {
+      ((CompactPersistentJavaSerializer)serializer).close();
     }
   }
   

--- a/impl/src/main/java/org/ehcache/spi/serialization/DefaultSerializationProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/serialization/DefaultSerializationProvider.java
@@ -29,13 +29,17 @@ import org.ehcache.spi.service.ServiceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+
 import org.ehcache.internal.serialization.CompactJavaSerializer;
 import org.ehcache.internal.serialization.CompactPersistentJavaSerializer;
 
@@ -51,6 +55,8 @@ public class DefaultSerializationProvider implements SerializationProvider {
   private final TransientProvider transientProvider;
   private final PersistentProvider persistentProvider;
   
+  final Set<Serializer<?>> created = new HashSet<Serializer<?>>();
+  
   public DefaultSerializationProvider(DefaultSerializationProviderConfiguration configuration) {
     if (configuration != null) {
       transientProvider = new TransientProvider(configuration.getTransientSerializers());
@@ -63,22 +69,42 @@ public class DefaultSerializationProvider implements SerializationProvider {
 
   @Override
   public <T> Serializer<T> createKeySerializer(Class<T> clazz, ClassLoader classLoader, ServiceConfiguration<?>... configs) throws UnsupportedTypeException {
+    Serializer<T> serializer;
     if (findSingletonAmongst(PersistenceSpaceIdentifier.class, (Object[]) configs) == null) {
-      return transientProvider.createKeySerializer(clazz, classLoader, configs);
+      serializer = transientProvider.createKeySerializer(clazz, classLoader, configs); 
     } else {
-      return persistentProvider.createKeySerializer(clazz, classLoader, configs);
+      serializer = persistentProvider.createKeySerializer(clazz, classLoader, configs);
     }
+    created.add(serializer);
+    return serializer;
   }
 
   @Override
   public <T> Serializer<T> createValueSerializer(Class<T> clazz, ClassLoader classLoader, ServiceConfiguration<?>... configs) throws UnsupportedTypeException {
+    Serializer<T> serializer;
     if (findSingletonAmongst(PersistenceSpaceIdentifier.class, (Object[]) configs) == null) {
-      return transientProvider.createValueSerializer(clazz, classLoader, configs);
+      serializer = transientProvider.createValueSerializer(clazz, classLoader, configs);
     } else {
-      return persistentProvider.createValueSerializer(clazz, classLoader, configs);
+      serializer = persistentProvider.createValueSerializer(clazz, classLoader, configs);
     }
+    created.add(serializer);
+    return serializer;
   }
 
+  @Override
+  public void releaseSerializer(final Serializer<?> serializer) {
+    if (!created.remove(serializer)) {
+      throw new IllegalArgumentException("Given serializer: " + serializer.getClass().getName() + " is not managed by this provider");
+    }
+    if(serializer instanceof CompactPersistentJavaSerializer) {
+      try {
+        ((CompactPersistentJavaSerializer)serializer).close();
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to close the serializer: " + serializer.getClass().getName());
+      }
+    }
+  }
+  
   @Override
   public void start(ServiceProvider serviceProvider) {
     transientProvider.start(serviceProvider);
@@ -210,7 +236,10 @@ public class DefaultSerializationProvider implements SerializationProvider {
       // no-op
     }
 
-    
+    @Override
+    public void releaseSerializer(final Serializer<?> serializer) {
+      // no-op
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/impl/src/test/java/org/ehcache/config/serializer/DefaultSerializationProviderConfigurationTest.java
+++ b/impl/src/test/java/org/ehcache/config/serializer/DefaultSerializationProviderConfigurationTest.java
@@ -83,11 +83,6 @@ public class DefaultSerializationProviderConfigurationTest {
     public boolean equals(final Long object, final ByteBuffer binary) throws ClassNotFoundException, SerializerException {
       throw new UnsupportedOperationException("Implement me!");
     }
-
-    @Override
-    public void close() throws IOException {
-      throw new UnsupportedOperationException("Implement me!");
-    }
   }
 
   private static class PersistentSerializer implements Serializer<Long> {
@@ -107,11 +102,6 @@ public class DefaultSerializationProviderConfigurationTest {
 
     @Override
     public boolean equals(final Long object, final ByteBuffer binary) throws ClassNotFoundException, SerializerException {
-      throw new UnsupportedOperationException("Implement me!");
-    }
-
-    @Override
-    public void close() throws IOException {
       throw new UnsupportedOperationException("Implement me!");
     }
   }
@@ -138,11 +128,6 @@ public class DefaultSerializationProviderConfigurationTest {
     public boolean equals(final Long object, final ByteBuffer binary) throws ClassNotFoundException, SerializerException {
       throw new UnsupportedOperationException("Implement me!");
     }
-
-    @Override
-    public void close() throws IOException {
-      throw new UnsupportedOperationException("Implement me!");
-    }
   }
 
   private static class UnusableSerializer implements Serializer<Long> {
@@ -159,11 +144,6 @@ public class DefaultSerializationProviderConfigurationTest {
 
     @Override
     public boolean equals(final Long object, final ByteBuffer binary) throws ClassNotFoundException, SerializerException {
-      throw new UnsupportedOperationException("Implement me!");
-    }
-
-    @Override
-    public void close() throws IOException {
       throw new UnsupportedOperationException("Implement me!");
     }
   }

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -603,11 +603,6 @@ public class GettingStarted {
     public boolean equals(String object, ByteBuffer binary) throws ClassNotFoundException {
       return object.equals(read(binary));
     }
-
-    @Override
-    public void close() {
-      //nothing
-    }
   }
 
   public static class LongSerializer implements Serializer<Long> {
@@ -635,11 +630,6 @@ public class GettingStarted {
     @Override
     public boolean equals(Long object, ByteBuffer binary) throws ClassNotFoundException {
       return object.equals(read(binary));
-    }
-
-    @Override
-    public void close() {
-      //nothing
     }
   }
 
@@ -670,11 +660,6 @@ public class GettingStarted {
     @Override
     public boolean equals(CharSequence object, ByteBuffer binary) throws ClassNotFoundException {
       return object.equals(read(binary));
-    }
-
-    @Override
-    public void close() {
-      //nothing
     }
   }
 

--- a/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
@@ -244,10 +244,5 @@ public class SerializerCountingTest {
       }
       return serializer.equals(object, binary);
     }
-
-    @Override
-    public void close() throws IOException {
-      // no-op
-    }
   }
 }

--- a/impl/src/test/java/org/ehcache/internal/classes/ClassInstanceProviderTest.java
+++ b/impl/src/test/java/org/ehcache/internal/classes/ClassInstanceProviderTest.java
@@ -96,7 +96,7 @@ public class ClassInstanceProviderTest {
     verify(closeable).close();
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test(expected = IOException.class)
   public void testReleaseCloseableInstanceThrows() throws Exception {
     ClassInstanceProvider<String, Closeable> classInstanceProvider = new ClassInstanceProvider<String, Closeable>(null, null);
     Closeable closeable = mock(Closeable.class);

--- a/impl/src/test/java/org/ehcache/internal/serialization/JavaSerializer.java
+++ b/impl/src/test/java/org/ehcache/internal/serialization/JavaSerializer.java
@@ -87,11 +87,6 @@ public class JavaSerializer<T> implements Serializer<T> {
     return object.equals(read(binary));
   }
 
-  @Override
-  public void close() {
-    //no-op
-  }
-
   private static class OIS extends ObjectInputStream {
 
     private final ClassLoader classLoader;

--- a/impl/src/test/java/org/ehcache/internal/store/heap/holders/SerializedOnHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/heap/holders/SerializedOnHeapValueHolderTest.java
@@ -128,11 +128,6 @@ public class SerializedOnHeapValueHolderTest {
     public boolean equals(String object, ByteBuffer binary) throws ClassNotFoundException {
       throw new UnsupportedOperationException("TODO Implement me!");
     }
-
-    @Override
-    public void close() {
-      //nothing
-    }
   }
 
   private static <V extends Serializable> ValueHolder<V> newValueHolder(V value) {

--- a/impl/src/test/java/org/ehcache/spi/serialization/DefaultSerializationProviderTest.java
+++ b/impl/src/test/java/org/ehcache/spi/serialization/DefaultSerializationProviderTest.java
@@ -130,6 +130,16 @@ public class DefaultSerializationProviderTest {
     verify(serializer).close();
   }
 
+  @Test
+  public void testReleaseSerializerWithCompactJavaSerializer() throws Exception {
+    DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
+    CompactJavaSerializer<?> serializer = mock(CompactJavaSerializer.class);
+    provider.created.add(serializer);
+
+    provider.releaseSerializer(serializer);
+    verify(serializer).close();
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testReleaseSerializerByAnotherProvider() throws Exception {
     DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
@@ -137,15 +147,6 @@ public class DefaultSerializationProviderTest {
     provider.releaseSerializer(serializer);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testReleaseSerializerThrowsOnCompactPersistentJavaSerializerClose() throws Exception {
-    DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
-    CompactPersistentJavaSerializer<?> serializer = mock(CompactPersistentJavaSerializer.class);
-    doThrow(IOException.class).when(serializer).close();
-    provider.created.add(serializer);
-
-    provider.releaseSerializer(serializer);
-  }
   public static class TestSerializer<T> implements Serializer<T> {
     public TestSerializer(ClassLoader classLoader) {
     }

--- a/impl/src/test/java/org/ehcache/spi/serialization/DefaultSerializationProviderTest.java
+++ b/impl/src/test/java/org/ehcache/spi/serialization/DefaultSerializationProviderTest.java
@@ -121,17 +121,7 @@ public class DefaultSerializationProviderTest {
   }
 
   @Test
-  public void testReleaseSerializerWithCompactPersistentJavaSerializer() throws Exception {
-    DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
-    CompactPersistentJavaSerializer<?> serializer = mock(CompactPersistentJavaSerializer.class);
-    provider.created.add(serializer);
-    
-    provider.releaseSerializer(serializer);
-    verify(serializer).close();
-  }
-
-  @Test
-  public void testReleaseSerializerWithCompactJavaSerializer() throws Exception {
+  public void testReleaseSerializerWithCloseableSerializer() throws Exception {
     DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
     CompactJavaSerializer<?> serializer = mock(CompactJavaSerializer.class);
     provider.created.add(serializer);

--- a/impl/src/test/java/org/ehcache/spi/serialization/DefaultSerializationProviderTest.java
+++ b/impl/src/test/java/org/ehcache/spi/serialization/DefaultSerializationProviderTest.java
@@ -15,11 +15,13 @@
  */
 package org.ehcache.spi.serialization;
 
+import java.io.IOException;
 import java.io.Serializable;
 import static java.lang.ClassLoader.getSystemClassLoader;
 import org.ehcache.config.serializer.DefaultSerializerConfiguration;
 import org.ehcache.config.serializer.DefaultSerializationProviderConfiguration;
 import org.ehcache.internal.serialization.CompactJavaSerializer;
+import org.ehcache.internal.serialization.CompactPersistentJavaSerializer;
 import org.ehcache.spi.ServiceProvider;
 import org.junit.Test;
 
@@ -31,7 +33,11 @@ import static org.hamcrest.Matchers.instanceOf;
 import org.hamcrest.core.IsInstanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Ludovic Orban
@@ -114,6 +120,32 @@ public class DefaultSerializationProviderTest {
     assertThat(serializationProvider.createKeySerializer(String.class, getSystemClassLoader()), instanceOf(TestSerializer.class));
   }
 
+  @Test
+  public void testReleaseSerializerWithCompactPersistentJavaSerializer() throws Exception {
+    DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
+    CompactPersistentJavaSerializer<?> serializer = mock(CompactPersistentJavaSerializer.class);
+    provider.created.add(serializer);
+    
+    provider.releaseSerializer(serializer);
+    verify(serializer).close();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReleaseSerializerByAnotherProvider() throws Exception {
+    DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
+    Serializer<?> serializer = mock(Serializer.class);
+    provider.releaseSerializer(serializer);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testReleaseSerializerThrowsOnCompactPersistentJavaSerializerClose() throws Exception {
+    DefaultSerializationProvider provider = new DefaultSerializationProvider(null);
+    CompactPersistentJavaSerializer<?> serializer = mock(CompactPersistentJavaSerializer.class);
+    doThrow(IOException.class).when(serializer).close();
+    provider.created.add(serializer);
+
+    provider.releaseSerializer(serializer);
+  }
   public static class TestSerializer<T> implements Serializer<T> {
     public TestSerializer(ClassLoader classLoader) {
     }
@@ -128,11 +160,6 @@ public class DefaultSerializationProviderTest {
     @Override
     public boolean equals(T object, ByteBuffer binary) {
       return false;
-    }
-
-    @Override
-    public void close() {
-      //no-op
     }
   }
 

--- a/integration-test/src/test/java/org/ehcache/integration/CacheCopierTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/CacheCopierTest.java
@@ -323,11 +323,6 @@ public class CacheCopierTest {
     public boolean equals(final Person object, final ByteBuffer binary) throws ClassNotFoundException, SerializerException {
       return object.equals(read(binary));
     }
-
-    @Override
-    public void close() throws IOException {
-      //Nothing
-    }
   }
 
 }

--- a/transactions/src/main/java/org/ehcache/transactions/xa/SoftLockSerializer.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/SoftLockSerializer.java
@@ -88,11 +88,6 @@ public class SoftLockSerializer implements Serializer<SoftLock> {
     return object.equals(read(binary));
   }
 
-  @Override
-  public void close() {
-    //no-op
-  }
-
   private static class OIS extends ObjectInputStream {
 
     private final ClassLoader classLoader;

--- a/transactions/src/main/java/org/ehcache/transactions/xa/SoftLockSerializer.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/SoftLockSerializer.java
@@ -35,7 +35,7 @@ import java.util.Map;
  *
  * @author Ludovic Orban
  */
-public class SoftLockSerializer implements Serializer<SoftLock> {
+class SoftLockSerializer implements Serializer<SoftLock> {
 
   private final ClassLoader classLoader;
 

--- a/transactions/src/main/java/org/ehcache/transactions/xa/SoftLockValueCombinedSerializer.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/SoftLockValueCombinedSerializer.java
@@ -53,9 +53,4 @@ public class SoftLockValueCombinedSerializer<T> implements Serializer<SoftLock<T
   public boolean equals(SoftLock<T> object, ByteBuffer binary) throws ClassNotFoundException, SerializerException {
     return object.equals(read(binary));
   }
-
-  @Override
-  public void close() throws IOException {
-    throw new AssertionError("SoftLock and value serializers should be closed independently");
-  }
 }

--- a/transactions/src/main/java/org/ehcache/transactions/xa/XAStore.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/XAStore.java
@@ -33,6 +33,8 @@ import org.ehcache.internal.TimeSource;
 import org.ehcache.internal.TimeSourceService;
 import org.ehcache.internal.concurrent.ConcurrentHashMap;
 import org.ehcache.internal.copy.SerializingCopier;
+import org.ehcache.internal.serialization.CompactJavaSerializer;
+import org.ehcache.internal.serialization.CompactPersistentJavaSerializer;
 import org.ehcache.internal.store.DefaultStoreProvider;
 import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
@@ -841,8 +843,10 @@ public class XAStore<K, V> implements Store<K, V> {
         underlyingStoreProvider.releaseStore(xaStore.underlyingStore);
         try {
           Serializer<?> serializer = helper.softLockSerializerRef.getAndSet(null);
-          if(serializer instanceof Closeable) {
-            ((Closeable)serializer).close();
+          if(serializer instanceof CompactJavaSerializer) {
+            ((CompactJavaSerializer)serializer).close();
+          } else if(serializer instanceof CompactPersistentJavaSerializer) {
+            ((CompactPersistentJavaSerializer)serializer).close();
           }
           xaStore.journal.close();
         } catch (IOException ioe) {

--- a/transactions/src/test/java/org/ehcache/transactions/xa/utils/JavaSerializer.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/utils/JavaSerializer.java
@@ -87,11 +87,6 @@ public class JavaSerializer<T> implements Serializer<T> {
     return object.equals(read(binary));
   }
 
-  @Override
-  public void close() {
-    //no-op
-  }
-
   private static class OIS extends ObjectInputStream {
 
     private final ClassLoader classLoader;

--- a/xml/src/test/java/com/pany/ehcache/serializer/TestSerializer.java
+++ b/xml/src/test/java/com/pany/ehcache/serializer/TestSerializer.java
@@ -44,9 +44,4 @@ public class TestSerializer<T> implements Serializer<T> {
   public boolean equals(T object, ByteBuffer binary) throws SerializerException, ClassNotFoundException {
     return serializer.equals(object, binary);
   }
-
-  @Override
-  public void close() throws IOException {
-    serializer.close();
-  }
 }


### PR DESCRIPTION
1. The responsibility of closing a persistent serializer has been moved to the SerializationProvider via the releaseSerializer method. This way we achieve consistency in handling the life cycle of the provided objects.
2. Serializers are not Closeable anymore. So caches or rather the serialization provider won't be closing the serializers when they are closed.