### PR TITLE
Issue #676 Remove Eviction.all() veto

### DIFF
--- a/api/src/main/java/org/ehcache/config/Eviction.java
+++ b/api/src/main/java/org/ehcache/config/Eviction.java
@@ -29,22 +29,6 @@ import java.util.concurrent.TimeUnit;
 public final class Eviction {
 
   /**
-   * Returns an {@link EvictionVeto} where all mappings are vetoed from eviction.
-   *
-   * @param <K> the key type on which this veto applies
-   * @param <V> the value type on whivh this veto applies
-   * @return a veto for all mappings
-   */
-  public static <K, V> EvictionVeto<K, V> all() {
-    return new EvictionVeto<K, V>() {
-      @Override
-      public boolean test(final Cache.Entry<K, V> argument) {
-        return Predicates.<Cache.Entry<K, V>>all().test(argument);
-      }
-    };
-  }
-
-  /**
    * Returns an {@link EvictionVeto} where no mappings are vetoed from eviction.
    *
    * @param <K> the key type on which this veto applies

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -46,7 +45,7 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
 
   @Before
   public void setUp() {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
   }
 
   @After

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.Before;
@@ -43,7 +42,7 @@ public class StoreCloseTest<K, V> extends SPIStoreTester<K, V> {
 
   @Before
   public void setUp() {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
@@ -15,7 +15,6 @@
  */
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.Function;
 import org.ehcache.spi.cache.Store;
@@ -54,7 +53,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongReturnValueType() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     if (factory.getValueType() == Object.class) {
       System.err.println("Warning, store uses Object as value type, cannot verify in this configuration");
@@ -88,7 +87,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    kvStore2 = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore2 = factory.newStore();
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
@@ -119,7 +118,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testComputePutsValueInStoreWhenKeyIsAbsent() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1);
     final V value = factory.createValue(1);
@@ -140,7 +139,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testFunctionNotInvokedWhenPresent() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1);
     final V value = factory.createValue(1);
@@ -163,7 +162,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testFunctionReturnsNull() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1L);;
 
@@ -187,7 +186,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testException() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1L);;
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
@@ -15,7 +15,6 @@
  */
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.BiFunction;
 import org.ehcache.spi.cache.Store;
@@ -52,7 +51,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongReturnValueType() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     if (factory.getValueType() == Object.class) {
       System.err.println("Warning, store uses Object as value type, cannot verify in this configuration");
@@ -88,7 +87,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    kvStore2 = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore2 = factory.newStore();
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
@@ -123,7 +122,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testNullReturnRemovesEntry() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1);
     final V value = factory.createValue(1);
@@ -146,7 +145,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testComputePutsValueInStoreWhenKeyIsPresent() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
     final K key = factory.createKey(1);
     final V value = factory.createValue(1);
     final V value2 = factory.createValue(2);
@@ -167,7 +166,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testFunctionNotCalledWhenAbsent() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
     final K key = factory.createKey(1L);
 
     try {
@@ -185,7 +184,7 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testException() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1);
     final V value = factory.createValue(1);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
@@ -15,7 +15,6 @@
  */
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.function.BiFunction;
 import org.ehcache.spi.cache.Store;
@@ -54,7 +53,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongReturnValueType() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     if (factory.getValueType() == Object.class) {
       Assert.fail("Warning, store uses Object as value type, cannot verify in this configuration");
@@ -86,7 +85,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongKeyType() throws Exception {
-    kvStore2 = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore2 = factory.newStore();
 
     if (factory.getKeyType() == Object.class) {
       System.err.println("Warning, store uses Object as key type, cannot verify in this configuration");
@@ -117,7 +116,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testComputePutsValueInStore() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(14);
     final V value = factory.createValue(153);
@@ -137,7 +136,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testOverwriteExitingValue() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(151);
     final V value = factory.createValue(1525);
@@ -161,7 +160,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testNullReturnRemovesEntry() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(1535603985);
     final V value = factory.createValue(15920835);
@@ -182,7 +181,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void testException() throws Exception {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     final K key = factory.createKey(520928098);
     final V value = factory.createValue(15098209865L);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -58,7 +57,7 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void storeContainsKey()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -63,7 +62,7 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void existingKeyMappedInStoreReturnsValueHolder()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
@@ -94,7 +93,7 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void existingKeyMappedInStoreReturnsCorrectValueHolder()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
@@ -17,7 +17,6 @@
 package org.ehcache.internal.store;
 
 import org.ehcache.Cache;
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -55,7 +54,7 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void hasNext()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     int nbElements = 3;
     for (int i = 0; i < nbElements; i++) {
@@ -72,7 +71,7 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void hasNextReturnsFalseIfNoElement()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     Store.Iterator<Cache.Entry<K, Store.ValueHolder<V>>> iterator = kvStore.iterator();
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
@@ -17,7 +17,6 @@
 package org.ehcache.internal.store;
 
 import org.ehcache.Cache;
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -57,7 +56,7 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void nextReturnsNextElement()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
@@ -77,7 +76,7 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void noMoreElementThrowsException()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     kvStore.put(factory.createKey(1), factory.createValue(1));
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -61,7 +60,7 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void mapsKeyToValueWhenMappingDoesntExist()
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
@@ -76,7 +75,7 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void doesntMapKeyToValueWhenMappingExists()
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -96,7 +95,7 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void valueHolderCanBeRetrievedWithEqualKey()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -58,7 +57,7 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void removeKeyAndValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
@@ -79,7 +78,7 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void removeKeyAndValueDoesNothingWhenKeyIsNotMapped()
       throws IllegalAccessException, InstantiationException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -58,7 +57,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void removeEntryForKeyIfMappedToValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1L);
     V value = factory.createValue(1L);
@@ -83,7 +82,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void doNothingForKeyNotMappedToValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
@@ -101,7 +100,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void doNothingForWrongValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1L);
@@ -122,7 +121,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void returnTrueIfValueWasRemoved()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
@@ -141,7 +140,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void returnFalseIfValueWasNotRemoved()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = factory.createValue(1);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -60,7 +59,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void replaceKeyAndValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V originalValue = factory.createValue(1L);
@@ -81,7 +80,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void replaceReturnsOldValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V originalValue = factory.createValue(1);
@@ -100,7 +99,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void replaceKeyNotMappedReturnsNull()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.internal.store;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.test.After;
@@ -61,7 +60,7 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void replaceCorrectKeyAndValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V originalValue = factory.createValue(1);
@@ -82,7 +81,7 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void replaceCorrectKeyAndWrongValue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1L);
     V originalValue = factory.createValue(1L);
@@ -104,7 +103,7 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void successfulReplaceReturnsTrue()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V originalValue = factory.createValue(1);
@@ -123,7 +122,7 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @SPITest
   public void unsuccessfulReplaceReturnsFalse()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
-    kvStore = factory.newStoreWithEvictionVeto(Eviction.<K, V>all());
+    kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V originalValue = factory.createValue(1L);

--- a/impl/src/test/java/org/ehcache/internal/store/heap/BaseOnHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/heap/BaseOnHeapStoreTest.java
@@ -15,6 +15,7 @@
  */
 package org.ehcache.internal.store.heap;
 
+import org.ehcache.Cache;
 import org.ehcache.Cache.Entry;
 import org.ehcache.CacheConfigurationChangeEvent;
 import org.ehcache.CacheConfigurationChangeListener;
@@ -95,7 +96,12 @@ public abstract class BaseOnHeapStoreTest {
 
   @Test
   public void testEvictWithFullVetoDoesEvict() throws Exception {
-    OnHeapStore<String, String> store = newStore(Eviction.all());
+    OnHeapStore<String, String> store = newStore(new EvictionVeto<String, String>() {
+      @Override
+      public boolean test(Entry<String, String> argument) {
+        return true;
+      }
+    });
     StoreEventListener<String, String> listener = addListener(store);
     for (int i = 0; i < 100; i++) {
       store.put(Integer.toString(i), Integer.toString(i));


### PR DESCRIPTION
Since vetoing everything is equivalent to vetoing nothing while
taking a performance hit, decision has been made to remove this.
And clearly some of our Store SPI test where using it, most likely
misunderstanding what it does.