### PR TITLE
Issue #684 Shade offheap and management jars in

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -36,8 +36,8 @@ configurations {
 
 dependencies {
   projectsToInclude.each {compile it}
-  shadow "org.slf4j:slf4j-api:$parent.slf4jVersion", "org.terracotta:offheap-store:$parent.offheapVersion"
-  shadowProvided 'javax.transaction:jta:1.1', 'org.codehaus.btm:btm:2.1.4', "org.terracotta:management-model:$parent.managementVersion"
+  shadow "org.slf4j:slf4j-api:$parent.slf4jVersion"
+  shadowProvided 'javax.transaction:jta:1.1', 'org.codehaus.btm:btm:2.1.4'
 }
 
 // Skip a number of defaults for this aggregation project
@@ -58,6 +58,8 @@ shadowJar {
   projectNamesToInclude.each {projName -> dependencies {include(project(projName))}}
   dependencies {
     include(dependency('org.terracotta:statistics:1.1.0'))
+    include(dependency("org.terracotta:offheap-store:$parent.offheapVersion"))
+    include(dependency("org.terracotta:management-model:$parent.managementVersion"))
   }
 
   mergeServiceFiles()
@@ -83,12 +85,11 @@ task osgiShadowJar(type: Jar, dependsOn: 'unzipShadowJarClasses') {
     instruction 'Bundle-Vendor', 'Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.'
     instruction 'Bundle-RequiredExecutionEnvironment', 'JavaSE-1.6'
 
-    instruction 'Export-Package', '!org.ehcache.jsr107.tck', '*'
+    instruction 'Export-Package', '!org.ehcache.jsr107.tck', '!org.terracotta.offheapstore.*', '*'
 
     // Optional packages
     instruction 'Import-Package', 'bitronix.tm.*;resolution:=optional', 'javax.cache.*;resolution:=optional',
-            'javax.transaction.*;resolution:=optional', 'org.terracotta.offheapstore.*;resolution:=optional',
-            'org.terracotta.management.*;resolution:=optional'
+            'javax.transaction.*;resolution:=optional'
     // Ignored packages
     instruction 'Import-Package', '!sun.misc', '!sun.security.action', '!com.sun.jmx.mbeanserver', '*'
     classesDir = new File("$buildDir/tmp/osgiShadowJar-classes")

--- a/osgi-test/build.gradle
+++ b/osgi-test/build.gradle
@@ -30,9 +30,7 @@ dependencies {
   testRuntime "org.slf4j:slf4j-simple:$parent.slf4jVersion",
           "org.ops4j.pax.exam:pax-exam-container-native:$paxExamVersion",
           "org.ops4j.pax.exam:pax-exam-link-mvn:$paxExamVersion",
-          "org.ops4j.pax.url:pax-url-aether:$urlVersion",
-          "org.terracotta:management-model:$parent.managementVersion",
-          "org.terracotta:offheap-store:$parent.offheapVersion"
+          "org.ops4j.pax.url:pax-url-aether:$urlVersion"
 
 
 }
@@ -47,9 +45,7 @@ sourceSets {
 
 test {
   systemProperty 'ehcache.osgi.jar', project(':dist').osgiShadowJar.archivePath.getPath()
-  systemProperty 'ehcache.osgi.offheap.version', parent.offheapVersion
   systemProperty 'ehcache.osgi.jcache.version', parent.jcacheVersion
-  systemProperty 'ehcache.osgi.management.version', parent.managementVersion
   systemProperty 'ehcache.osgi.slf4j.version', parent.slf4jVersion
 }
 

--- a/osgi-test/src/test/java/org/ehcache/osgi/Jsr107OsgiTest.java
+++ b/osgi-test/src/test/java/org/ehcache/osgi/Jsr107OsgiTest.java
@@ -50,7 +50,6 @@ public class Jsr107OsgiTest {
         mavenBundle("org.slf4j", "slf4j-simple", System.getProperty("ehcache.osgi.slf4j.version")).noStart(),
         bundle("file:" + System.getProperty("ehcache.osgi.jar")),
         mavenBundle("javax.cache", "cache-api", System.getProperty("ehcache.osgi.jcache.version")),
-        mavenBundle("org.terracotta", "management-model", System.getProperty("ehcache.osgi.management.version")),
         junitBundles()
     );
   }

--- a/osgi-test/src/test/java/org/ehcache/osgi/OffHeapOsgiTest.java
+++ b/osgi-test/src/test/java/org/ehcache/osgi/OffHeapOsgiTest.java
@@ -53,7 +53,6 @@ public class OffHeapOsgiTest {
         mavenBundle("org.slf4j", "slf4j-api", System.getProperty("ehcache.osgi.slf4j.version")),
         mavenBundle("org.slf4j", "slf4j-simple", System.getProperty("ehcache.osgi.slf4j.version")).noStart(),
         bundle("file:" + System.getProperty("ehcache.osgi.jar")),
-        mavenBundle("org.terracotta", "offheap-store", System.getProperty("ehcache.osgi.offheap.version")),
         junitBundles()
     );
   }


### PR DESCRIPTION
Up to now, offheap and management-model dependencies were left as
external and so needed to be picked by users when needed.
This changeset now changes that so they are shaded inside the
main ehcache jar produced.