### PR TITLE
Test changes to reduce memory footprint

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip

--- a/impl/src/test/java/org/ehcache/internal/store/disk/OffHeapDiskStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/disk/OffHeapDiskStoreSPITest.java
@@ -120,7 +120,7 @@ public class OffHeapDiskStoreSPITest extends AuthoritativeTierSPITest<String, St
 
       private ResourcePools getDiskResourcePool(Comparable<Long> capacityConstraint) {
         if (capacityConstraint == null) {
-          capacityConstraint = 32L;
+          capacityConstraint = 10L;
         }
         return ResourcePoolsBuilder.newResourcePoolsBuilder().disk((Long) capacityConstraint, MemoryUnit.MB).build();
       }

--- a/impl/src/test/java/org/ehcache/internal/store/offheap/OffHeapStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/offheap/OffHeapStoreSPITest.java
@@ -88,7 +88,7 @@ public class OffHeapStoreSPITest extends AuthoritativeTierSPITest<String, String
 
       private ResourcePools getOffHeapResourcePool(Comparable<Long> capacityConstraint) {
         if (capacityConstraint == null) {
-          capacityConstraint = 32L;
+          capacityConstraint = 10L;
         }
         return ResourcePoolsBuilder.newResourcePoolsBuilder().offheap((Long)capacityConstraint, MemoryUnit.MB).build();
       }


### PR DESCRIPTION
The motivation is our cloudbees build showing that executors are out
of memory and paging just before the gradle test tasks exits.
Also bumped the gradle version to 2.9