### PR TITLE
Properly close the Store in SPI tests tear down

### DIFF
--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
@@ -57,7 +57,7 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -59,7 +59,7 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreClearTest.java
@@ -51,7 +51,7 @@ public class StoreClearTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCloseTest.java
@@ -18,6 +18,7 @@ package org.ehcache.internal.store;
 
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.spi.cache.Store;
+import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.Before;
 import org.ehcache.spi.test.SPITest;
 import org.hamcrest.Matchers;
@@ -43,6 +44,13 @@ public class StoreCloseTest<K, V> extends SPIStoreTester<K, V> {
   @Before
   public void setUp() {
     kvStore = factory.newStore();
+  }
+
+  @After
+  public void tearDown() {
+    if (kvStore != null) {
+      kvStore = null;
+    }
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
@@ -41,11 +41,11 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfPresentTest.java
@@ -39,11 +39,11 @@ public class StoreComputeIfPresentTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
@@ -41,11 +41,11 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
@@ -45,11 +45,11 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEvictionEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEvictionEventListenerTest.java
@@ -59,7 +59,7 @@ public class StoreEvictionEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreExpiryEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreExpiryEventListenerTest.java
@@ -59,7 +59,7 @@ public class StoreExpiryEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -50,11 +50,11 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorHasNextTest.java
@@ -46,7 +46,7 @@ public class StoreIteratorHasNextTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
@@ -48,7 +48,7 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
@@ -55,7 +55,7 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -48,11 +48,11 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -47,11 +47,11 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
@@ -45,11 +45,11 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
@@ -45,11 +45,11 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -47,11 +47,11 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
@@ -48,11 +48,11 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
   @After
   public void tearDown() {
     if (kvStore != null) {
-//      kvStore.close();
+      factory.close(kvStore);
       kvStore = null;
     }
     if (kvStore2 != null) {
-//      kvStore2.close();
+      factory.close(kvStore2);
       kvStore2 = null;
     }
   }


### PR DESCRIPTION
I stumbled upon this when trying to understand failures in Cloudbees on Java 1.8