### PR TITLE
#734 - Added gradle task (gradlew createPom) to generate module pom.xml files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build/
 .nb-gradle-properties
 
 /classes
+
+pom.xml

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
   apply plugin: 'checkstyle'
   apply plugin: 'findbugs'
   apply plugin: 'jacoco'
+  apply plugin: 'maven'
 
   group = 'org.ehcache.modules'
   version = baseVersion
@@ -143,6 +144,28 @@ subprojects {
       csv.enabled false
     }
   }
+
+  afterEvaluate {
+
+    task createPom {
+      pom {
+        project {
+          groupId project.group
+          artifactId "ehcache-${project.name}"
+          version project.version
+          licenses {
+            license {
+              name 'The Apache Software License, Version 2.0'
+              url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+              distribution 'repo'
+            }
+          }
+        }
+      }.writeTo("pom.xml")
+    }
+
+  }
+
 }
 
 allprojects {


### PR DESCRIPTION
This allows to import directly ehcache snapshot modules in our IDE by using the standard maven dependency mechanism to handle dependencies across all opened projects and modules.

Note: the task is the same. But if I put it in the parent graddle build, the generated poms to not contain the project dependencies, but only external dependencies. I didn't find a way to have it in the parent file, but the task configuration resolved only at execution in sub modules.
