### PR TITLE
Issue 704

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/ConfigurationMerger.java
+++ b/107/src/main/java/org/ehcache/jsr107/ConfigurationMerger.java
@@ -24,17 +24,11 @@ import org.ehcache.config.copy.DefaultCopyProviderConfiguration;
 import org.ehcache.config.loaderwriter.DefaultCacheLoaderWriterConfiguration;
 import org.ehcache.config.xml.XmlConfiguration;
 import org.ehcache.internal.classes.ClassInstanceConfiguration;
-import org.ehcache.internal.copy.IdentityCopier;
 import org.ehcache.internal.copy.SerializingCopier;
 import org.ehcache.spi.copy.Copier;
-import org.ehcache.spi.copy.CopyProvider;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
-import org.ehcache.spi.service.ServiceCreationConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;
@@ -42,6 +36,8 @@ import javax.cache.configuration.Configuration;
 import javax.cache.configuration.Factory;
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheWriter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.ehcache.config.CacheConfigurationBuilder.newCacheConfigurationBuilder;
 import static org.ehcache.spi.ServiceLocator.findSingletonAmongst;
@@ -73,7 +69,7 @@ class ConfigurationMerger {
     Eh107Expiry<K, V> expiryPolicy = null;
     CacheLoaderWriter<? super K, V> loaderWriter = null;
     try {
-      CacheConfigurationBuilder<K, V> builder = newCacheConfigurationBuilder();
+      CacheConfigurationBuilder<K, V> builder = newCacheConfigurationBuilder(configuration.getKeyType(), configuration.getValueType());
       String templateName = jsr107Service.getTemplateNameForCache(cacheName);
       if (xmlConfiguration != null && templateName != null) {
         CacheConfigurationBuilder<K, V> templateBuilder = xmlConfiguration.newCacheConfigurationBuilderFromTemplate(templateName,
@@ -111,7 +107,7 @@ class ConfigurationMerger {
         LOG.info("Cache {} will use loader/writer configuration from template {}", cacheName, templateName);
       }
 
-      CacheConfiguration<K, V> cacheConfiguration = builder.buildConfig(jsr107Configuration.getKeyType(), jsr107Configuration.getValueType());
+      CacheConfiguration<K, V> cacheConfiguration = builder.build();
 
       if (!useJsr107Expiry) {
         expiryPolicy = new EhcacheExpiryWrapper<K, V>(cacheConfiguration.getExpiry());

--- a/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
+++ b/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
@@ -111,8 +111,8 @@ public class EhCache107ConfigurationIntegrationDocTest {
   @Test
   public void testUsingEhcacheConfiguration() throws Exception {
     // tag::ehcacheBasedConfigurationExample[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
-        .buildConfig(Long.class, String.class); // <1>
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+        .build(); // <1>
 
     Cache<Long, String> cache = cacheManager.createCache("myCache",
         Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfiguration)); // <2>

--- a/107/src/test/java/org/ehcache/jsr107/ConfigurationMergerTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/ConfigurationMergerTest.java
@@ -157,7 +157,7 @@ public class ConfigurationMergerTest {
   public void jsr107ExpiryGetsOverriddenByTemplate() throws Exception {
     when(jsr107Service.getTemplateNameForCache("cache")).thenReturn("cacheTemplate");
     when(xmlConfiguration.newCacheConfigurationBuilderFromTemplate("cacheTemplate", Object.class, Object.class)).thenReturn(
-        newCacheConfigurationBuilder().withExpiry(Expirations.timeToLiveExpiration(new Duration(5, TimeUnit.MINUTES)))
+        newCacheConfigurationBuilder(Object.class, Object.class).withExpiry(Expirations.timeToLiveExpiration(new Duration(5, TimeUnit.MINUTES)))
     );
 
     MutableConfiguration<Object, Object> configuration = new MutableConfiguration<Object, Object>();
@@ -178,7 +178,7 @@ public class ConfigurationMergerTest {
   public void jsr107LoaderGetsOverriddenByTemplate() throws Exception {
     when(jsr107Service.getTemplateNameForCache("cache")).thenReturn("cacheTemplate");
     when(xmlConfiguration.newCacheConfigurationBuilderFromTemplate("cacheTemplate", Object.class, Object.class)).thenReturn(
-        newCacheConfigurationBuilder().add(new DefaultCacheLoaderWriterConfiguration((Class)null))
+        newCacheConfigurationBuilder(Object.class, Object.class).add(new DefaultCacheLoaderWriterConfiguration((Class)null))
     );
 
     MutableConfiguration<Object, Object> configuration = new MutableConfiguration<Object, Object>();
@@ -194,7 +194,7 @@ public class ConfigurationMergerTest {
 
   @Test
   public void jsr107StoreByValueGetsOverriddenByTemplate() throws Exception {
-    CacheConfigurationBuilder<Object, Object> builder = newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Object, Object> builder = newCacheConfigurationBuilder(Object.class, Object.class)
         .add(new DefaultCopierConfiguration<Object>((Class)IdentityCopier.class, CopierConfiguration.Type.KEY))
         .add(new DefaultCopierConfiguration<Object>((Class)IdentityCopier.class, CopierConfiguration.Type.VALUE));
     

--- a/core/src/main/java/org/ehcache/config/BaseCacheConfiguration.java
+++ b/core/src/main/java/org/ehcache/config/BaseCacheConfiguration.java
@@ -29,15 +29,15 @@ import org.ehcache.spi.service.ServiceConfiguration;
  */
 public class BaseCacheConfiguration<K, V> implements CacheConfiguration<K,V> {
 
-  private final Class<K> keyType;
-  private final Class<V> valueType;
+  private final Class<? super K> keyType;
+  private final Class<? super V> valueType;
   private final EvictionVeto<? super K, ? super V> evictionVeto;
   private final Collection<ServiceConfiguration<?>> serviceConfigurations;
   private final ClassLoader classLoader;
   private final Expiry<? super K, ? super V> expiry;
   private final ResourcePools resourcePools;
 
-  public BaseCacheConfiguration(Class<K> keyType, Class<V> valueType,
+  public BaseCacheConfiguration(Class<? super K> keyType, Class<? super V> valueType,
           EvictionVeto<? super K, ? super V> evictionVeto,
           ClassLoader classLoader, Expiry<? super K, ? super V> expiry,
           ResourcePools resourcePools, ServiceConfiguration<?>... serviceConfigurations) {
@@ -61,12 +61,12 @@ public class BaseCacheConfiguration<K, V> implements CacheConfiguration<K,V> {
 
   @Override
   public Class<K> getKeyType() {
-    return keyType;
+    return (Class) keyType;
   }
 
   @Override
   public Class<V> getValueType() {
-    return valueType;
+    return (Class) valueType;
   }
 
   @Override

--- a/docs/src/docs/asciidoc/user/getting-started.adoc
+++ b/docs/src/docs/asciidoc/user/getting-started.adoc
@@ -33,8 +33,9 @@ include::{sourcedir}/impl/src/test/java/org/ehcache/docs/GettingStarted.java[tag
     The first `String` argument is the alias used to interact with the `Cache` through the `CacheManager`; the second
     argument is `org.ehcache.config.CacheConfiguration` to configure the `Cache`. We use the static
     `.newCacheConfigurationBuilder()` method on `org.ehcache.config.CacheConfigurationBuilder` to create a default config;
-<3> Finally, invoking `.build(bool)` returns a fully instantiated, possibly initialized, `CacheManager` we can use;
-<4> Before you start to use the `CacheManager` it needs to be `init()`, which can be done for you by the builder by passing `true` to `build(bool)`;
+<3> Finally, invoking `.build()` returns a fully instantiated, but uninitialized, `CacheManager` we can use;
+<4> Before you start to use the `CacheManager` it needs to be `init()`, which can be done for you by the builder by passing
+    `true` to `build(boolean)`;
 <5> We can retrieve the `preConfigured` aliased `Cache` we declared in step 2. For type-safety, we ask for both key and
     value types to be passed in. If these differ from the ones we expect, the `CacheManager` throws a `ClassCastException`
     early in the application's lifecycle. It also guards the `Cache` from being polluted by random types.

--- a/docs/src/docs/asciidoc/user/getting-started.adoc
+++ b/docs/src/docs/asciidoc/user/getting-started.adoc
@@ -236,7 +236,9 @@ include::{sourcedir}/impl/src/test/java/org/ehcache/docs/GettingStarted.java[tag
 ----
 
 <1> Configure the key's serializer.
-<2> Configure the value's serializer.
+<2> Configure the value's serializer. Note that the casting is required as the serializer's type does not exactly match
+    the configured value type. This is okay as long as the serializer guarantees that the deserialized class will be
+    exactly the serialized class.
 
 Serializer instances are created per cache for keys and values separately.
 By default, serializers are automatically used by tiers that require them (off-heap and disk) but the on-heap tier, while it can

--- a/impl/src/main/java/org/ehcache/CacheManagerBuilder.java
+++ b/impl/src/main/java/org/ehcache/CacheManagerBuilder.java
@@ -16,7 +16,9 @@
 
 package org.ehcache;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.CacheConfigurationBuilder;
 import org.ehcache.config.CacheManagerConfiguration;
 import org.ehcache.config.Configuration;
 import org.ehcache.config.ConfigurationBuilder;
@@ -41,7 +43,7 @@ import static org.ehcache.config.ConfigurationBuilder.newConfigurationBuilder;
 /**
  * @author Alex Snaps
  */
-public class CacheManagerBuilder<T extends CacheManager> {
+public class CacheManagerBuilder<T extends CacheManager> implements Builder<T> {
 
   private final ConfigurationBuilder configBuilder;
   private final Set<Service> services;
@@ -52,6 +54,11 @@ public class CacheManagerBuilder<T extends CacheManager> {
       cacheManager.init();
     }
     return cacheManager;
+  }
+
+  @Override
+  public T build() {
+    return build(false);
   }
 
   private CacheManagerBuilder() {
@@ -85,6 +92,10 @@ public class CacheManagerBuilder<T extends CacheManager> {
   
   public <K, V> CacheManagerBuilder<T> withCache(String alias, CacheConfiguration<K, V> configuration) {
     return new CacheManagerBuilder<T>(this, configBuilder.addCache(alias, configuration));
+  }
+
+  public <K, V> CacheManagerBuilder<T> withCache(String alias, CacheConfigurationBuilder<K, V> configurationBuilder) {
+    return withCache(alias, configurationBuilder.build());
   }
 
   public <N extends T> CacheManagerBuilder<N> with(CacheManagerConfiguration<N> cfg) {

--- a/impl/src/main/java/org/ehcache/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/UserManagedCacheBuilder.java
@@ -17,6 +17,7 @@
 package org.ehcache;
 
 import org.ehcache.config.BaseCacheConfiguration;
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePools;
@@ -66,7 +67,7 @@ import static org.ehcache.config.ResourceType.Core.OFFHEAP;
 /**
  * @author Alex Snaps
  */
-public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> {
+public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> implements Builder<T> {
 
   @ServiceDependencies(Store.Provider.class)
   private static class ServiceDeps {
@@ -278,6 +279,11 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> {
       build.init();
     }
     return build;
+  }
+
+  @Override
+  public T build() {
+    return build(false);
   }
 
   public final <N extends T> UserManagedCacheBuilder<K, V, N> with(UserManagedCacheConfiguration<K, V, N> cfg) {

--- a/impl/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
@@ -36,22 +36,28 @@ import static org.ehcache.config.ResourcePoolsBuilder.newResourcePoolsBuilder;
 /**
  * @author Alex Snaps
  */
-public class CacheConfigurationBuilder<K, V> {
+public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfiguration<K, V>> {
 
   private final Collection<ServiceConfiguration<?>> serviceConfigurations = new HashSet<ServiceConfiguration<?>>();
   private Expiry<? super K, ? super V> expiry;
   private ClassLoader classLoader = null;
   private EvictionVeto<? super K, ? super V> evictionVeto;
   private ResourcePools resourcePools = newResourcePoolsBuilder().heap(Long.MAX_VALUE, EntryUnit.ENTRIES).build();
+  private Class<? super K> keyType;
+  private Class<? super V> valueType;
 
-  private CacheConfigurationBuilder() {
+  public static <K, V> CacheConfigurationBuilder<K, V> newCacheConfigurationBuilder(Class<K> keyType, Class<V> valueType) {
+    return new CacheConfigurationBuilder<K, V>(keyType, valueType);
   }
 
-  public static <K, V> CacheConfigurationBuilder<K, V> newCacheConfigurationBuilder() {
-    return new CacheConfigurationBuilder<K, V>();
+  private CacheConfigurationBuilder(Class<K> keyType, Class<V> valueType) {
+    this.keyType = keyType;
+    this.valueType = valueType;
   }
 
   private CacheConfigurationBuilder(CacheConfigurationBuilder<? super K, ? super V> other) {
+    this.keyType = other.keyType;
+    this.valueType = other.valueType;
     this.expiry = other.expiry;
     this.classLoader = other.classLoader;
     this.evictionVeto = other.evictionVeto;
@@ -96,19 +102,6 @@ public class CacheConfigurationBuilder<K, V> {
     return null;
   }
 
-  public <CK extends K, CV extends V> CacheConfiguration<CK, CV> buildConfig(Class<CK> keyType, Class<CV> valueType) {
-    return new BaseCacheConfiguration<CK, CV>(keyType, valueType, evictionVeto,
-        classLoader, expiry, resourcePools,
-        serviceConfigurations.toArray(new ServiceConfiguration<?>[serviceConfigurations.size()]));
-  }
-
-  public <CK extends K, CV extends V> CacheConfiguration<CK, CV> buildConfig(Class<CK> keyType, Class<CV> valueType,
-                                                     EvictionVeto<? super CK, ? super CV> evictionVeto) {
-    return new BaseCacheConfiguration<CK, CV>(keyType, valueType, evictionVeto,
-        classLoader, expiry, resourcePools,
-        serviceConfigurations.toArray(new ServiceConfiguration<?>[serviceConfigurations.size()]));
-  }
-  
   public CacheConfigurationBuilder<K, V> withClassLoader(ClassLoader classLoader) {
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
     otherBuilder.classLoader = classLoader;
@@ -246,4 +239,11 @@ public class CacheConfigurationBuilder<K, V> {
     return otherBuilder;
   }
 
+  @Override
+  public CacheConfiguration<K, V> build() {
+    return new BaseCacheConfiguration<K, V>(keyType, valueType, evictionVeto,
+        classLoader, expiry, resourcePools,
+        serviceConfigurations.toArray(new ServiceConfiguration<?>[serviceConfigurations.size()]));
+
+  }
 }

--- a/impl/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
@@ -167,16 +167,16 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withKeyCopier(Copier<K> keyCopier) {
+  public CacheConfigurationBuilder<K, V> withKeyCopier(Copier<? super K> keyCopier) {
     if (keyCopier == null) {
       throw new NullPointerException("Null key copier");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<K>(keyCopier, CopierConfiguration.Type.KEY));
+    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<K>((Copier) keyCopier, CopierConfiguration.Type.KEY));
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withKeyCopier(Class<Copier<K>> keyCopierClass) {
+  public CacheConfigurationBuilder<K, V> withKeyCopier(Class<? extends Copier<K>> keyCopierClass) {
     if (keyCopierClass == null) {
       throw new NullPointerException("Null key copier class");
     }
@@ -185,16 +185,16 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withValueCopier(Copier<V> valueCopier) {
+  public CacheConfigurationBuilder<K, V> withValueCopier(Copier<? super V> valueCopier) {
     if (valueCopier == null) {
       throw new NullPointerException("Null value copier");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<V>(valueCopier, CopierConfiguration.Type.VALUE));
+    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<V>((Copier) valueCopier, CopierConfiguration.Type.VALUE));
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withValueCopier(Class<Copier<V>> valueCopierClass) {
+  public CacheConfigurationBuilder<K, V> withValueCopier(Class<? extends Copier<V>> valueCopierClass) {
     if (valueCopierClass == null) {
       throw new NullPointerException("Null value copier");
     }
@@ -203,16 +203,16 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withKeySerializer(Serializer<K> keySerializer) {
+  public CacheConfigurationBuilder<K, V> withKeySerializer(Serializer<? super K> keySerializer) {
     if (keySerializer == null) {
       throw new NullPointerException("Null key serializer");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<K>(keySerializer, SerializerConfiguration.Type.KEY));
+    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<K>((Serializer) keySerializer, SerializerConfiguration.Type.KEY));
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withKeySerializer(Class<Serializer<K>> keySerializerClass) {
+  public CacheConfigurationBuilder<K, V> withKeySerializer(Class<? extends Serializer<K>> keySerializerClass) {
     if (keySerializerClass == null) {
       throw new NullPointerException("Null key serializer class");
     }
@@ -221,16 +221,16 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withValueSerializer(Serializer<V> valueSerializer) {
+  public CacheConfigurationBuilder<K, V> withValueSerializer(Serializer<? super V> valueSerializer) {
     if (valueSerializer == null) {
       throw new NullPointerException("Null value serializer");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<V>(valueSerializer, SerializerConfiguration.Type.VALUE));
+    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<V>((Serializer) valueSerializer, SerializerConfiguration.Type.VALUE));
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withValueSerializer(Class<Serializer<V>> valueSerializerClass) {
+  public CacheConfigurationBuilder<K, V> withValueSerializer(Class<? extends Serializer<V>> valueSerializerClass) {
     if (valueSerializerClass == null) {
       throw new NullPointerException("Null value serializer class");
     }

--- a/impl/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/CacheConfigurationBuilder.java
@@ -167,12 +167,12 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withKeyCopier(Copier<? super K> keyCopier) {
+  public CacheConfigurationBuilder<K, V> withKeyCopier(Copier<K> keyCopier) {
     if (keyCopier == null) {
       throw new NullPointerException("Null key copier");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<K>((Copier) keyCopier, CopierConfiguration.Type.KEY));
+    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<K>(keyCopier, CopierConfiguration.Type.KEY));
     return otherBuilder;
   }
 
@@ -185,12 +185,12 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withValueCopier(Copier<? super V> valueCopier) {
+  public CacheConfigurationBuilder<K, V> withValueCopier(Copier<V> valueCopier) {
     if (valueCopier == null) {
       throw new NullPointerException("Null value copier");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<V>((Copier) valueCopier, CopierConfiguration.Type.VALUE));
+    otherBuilder.serviceConfigurations.add(new DefaultCopierConfiguration<V>(valueCopier, CopierConfiguration.Type.VALUE));
     return otherBuilder;
   }
 
@@ -203,12 +203,12 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withKeySerializer(Serializer<? super K> keySerializer) {
+  public CacheConfigurationBuilder<K, V> withKeySerializer(Serializer<K> keySerializer) {
     if (keySerializer == null) {
       throw new NullPointerException("Null key serializer");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<K>((Serializer) keySerializer, SerializerConfiguration.Type.KEY));
+    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<K>(keySerializer, SerializerConfiguration.Type.KEY));
     return otherBuilder;
   }
 
@@ -221,12 +221,12 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
     return otherBuilder;
   }
 
-  public CacheConfigurationBuilder<K, V> withValueSerializer(Serializer<? super V> valueSerializer) {
+  public CacheConfigurationBuilder<K, V> withValueSerializer(Serializer<V> valueSerializer) {
     if (valueSerializer == null) {
       throw new NullPointerException("Null value serializer");
     }
     CacheConfigurationBuilder<K, V> otherBuilder = new CacheConfigurationBuilder<K, V>(this);
-    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<V>((Serializer) valueSerializer, SerializerConfiguration.Type.VALUE));
+    otherBuilder.serviceConfigurations.add(new DefaultSerializerConfiguration<V>(valueSerializer, SerializerConfiguration.Type.VALUE));
     return otherBuilder;
   }
 

--- a/impl/src/main/java/org/ehcache/config/ConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/ConfigurationBuilder.java
@@ -31,7 +31,7 @@ import static java.util.Collections.unmodifiableMap;
 /**
  * @author Alex Snaps
  */
-public class ConfigurationBuilder {
+public class ConfigurationBuilder implements Builder<Configuration> {
 
   private final Map<String, CacheConfiguration<?, ?>> caches;
   private final List<ServiceCreationConfiguration<?>> serviceConfigurations;
@@ -64,7 +64,8 @@ public class ConfigurationBuilder {
     this.serviceConfigurations = builder.serviceConfigurations;
     this.classLoader = classLoader;
   }
-  
+
+  @Override
   public Configuration build() {
     return new DefaultConfiguration(caches, classLoader, serviceConfigurations.toArray(new ServiceCreationConfiguration<?>[serviceConfigurations.size()]));
   }

--- a/impl/src/main/java/org/ehcache/config/ResourcePoolsBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/ResourcePoolsBuilder.java
@@ -27,7 +27,7 @@ import static org.ehcache.config.ResourcePoolsImpl.validateResourcePools;
 /**
  * @author Ludovic Orban
  */
-public class ResourcePoolsBuilder {
+public class ResourcePoolsBuilder implements Builder<ResourcePools> {
 
   private final Map<ResourceType, ResourcePool> resourcePools;
 
@@ -75,6 +75,7 @@ public class ResourcePoolsBuilder {
     return with(ResourceType.Core.DISK, size, unit, persistent);
   }
 
+  @Override
   public ResourcePools build() {
     return new ResourcePoolsImpl(resourcePools);
   }

--- a/impl/src/test/java/org/ehcache/EhcacheRuntimeConfigurationTest.java
+++ b/impl/src/test/java/org/ehcache/EhcacheRuntimeConfigurationTest.java
@@ -38,9 +38,9 @@ public class EhcacheRuntimeConfigurationTest {
 
   @Test
   public void testUpdateResources() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
-            .heap(10L, EntryUnit.ENTRIES).disk(10, MemoryUnit.MB).build()).buildConfig(Long.class, String.class);
+            .heap(10L, EntryUnit.ENTRIES).disk(10, MemoryUnit.MB).build()).build();
 
     final CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(System.getProperty("java.io.tmpdir") + "/myData")))
@@ -63,9 +63,9 @@ public class EhcacheRuntimeConfigurationTest {
 
   @Test
   public void testUpdateFailureDoesNotUpdate() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
-            .heap(10L, EntryUnit.ENTRIES).build()).buildConfig(Long.class, String.class);
+            .heap(10L, EntryUnit.ENTRIES).build()).build();
 
     final CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("cache", cacheConfiguration).build(true);

--- a/impl/src/test/java/org/ehcache/TieringTest.java
+++ b/impl/src/test/java/org/ehcache/TieringTest.java
@@ -37,9 +37,9 @@ public class TieringTest {
 
   @Test
   public void testTieredStore() throws Exception {
-    CacheConfiguration<Long, String> tieredCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> tieredCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).disk(10L, MemoryUnit.MB))
-        .buildConfig(Long.class, String.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(System.getProperty("java.io.tmpdir") + "/tiered-cache-data")))
@@ -57,9 +57,9 @@ public class TieringTest {
 
   @Test
   public void testTieredOffHeapStore() throws Exception {
-    CacheConfiguration<Long, String> tieredCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> tieredCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
-        .buildConfig(Long.class, String.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().withCache("tieredCache", tieredCacheConfiguration).build(true);
 
@@ -75,9 +75,9 @@ public class TieringTest {
 
   @Test
   public void testPersistentDiskCache() throws Exception {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).disk(10L, MemoryUnit.MB, true))
-        .buildConfig(Long.class, String.class);
+        .build();
 
     PersistentCacheManager persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(getClass().getClassLoader().getResource(".").toURI().getPath() + "/../../persistent-cache-data")))

--- a/impl/src/test/java/org/ehcache/WriteBehindProviderFactoryTest.java
+++ b/impl/src/test/java/org/ehcache/WriteBehindProviderFactoryTest.java
@@ -18,8 +18,8 @@ package org.ehcache;
 import org.ehcache.config.CacheConfigurationBuilder;
 import org.ehcache.config.ResourcePoolsBuilder;
 import org.ehcache.config.loaderwriter.DefaultCacheLoaderWriterConfiguration;
-import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.loaderwriter.writebehind.WriteBehindConfigurationBuilder;
+import org.ehcache.config.units.EntryUnit;
 import org.ehcache.loaderwriter.writebehind.WriteBehindProviderFactory;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
@@ -55,12 +55,12 @@ public class WriteBehindProviderFactoryTest {
     Class<CacheLoaderWriter<?, ?>> klazz = (Class<CacheLoaderWriter<?, ?>>) (Class) (SampleLoaderWriter.class);
     CacheManager cacheManager = cacheManagerBuilder.build(true);
     final Cache<Long, String> cache = cacheManager.createCache("cache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .add(writeBehindConfiguration)
             .add(new DefaultCacheLoaderWriterConfiguration(klazz))
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(100, EntryUnit.ENTRIES).build())
-            .buildConfig(Long.class, String.class));
+            .build());
     Collection<ServiceConfiguration<?>> serviceConfiguration = cache.getRuntimeConfiguration()
         .getServiceConfigurations();
     assertThat(serviceConfiguration, IsCollectionContaining.<ServiceConfiguration<?>>hasItem(instanceOf(WriteBehindConfiguration.class)));

--- a/impl/src/test/java/org/ehcache/config/CacheConfigurationBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/CacheConfigurationBuilderTest.java
@@ -52,9 +52,9 @@ public class CacheConfigurationBuilderTest {
       }
     };
 
-    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .withEvictionVeto(veto)
-        .buildConfig(Object.class, Object.class);
+        .build();
 
     assertThat(veto, (Matcher) sameInstance(cacheConfiguration.getEvictionVeto()));
   }
@@ -93,9 +93,9 @@ public class CacheConfigurationBuilderTest {
       }
     };
 
-    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .withLoaderWriter(loaderWriter)
-        .buildConfig(Object.class, Object.class);
+        .build();
 
     CacheLoaderWriterConfiguration cacheLoaderWriterConfiguration = ServiceLocator.findSingletonAmongst(CacheLoaderWriterConfiguration.class, cacheConfiguration.getServiceConfigurations());
     Object instance = ((ClassInstanceConfiguration) cacheLoaderWriterConfiguration).getInstance();
@@ -121,9 +121,9 @@ public class CacheConfigurationBuilderTest {
       }
     };
 
-    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .withKeySerializer(keySerializer)
-        .buildConfig(Object.class, Object.class);
+        .build();
 
 
     SerializerConfiguration serializerConfiguration = ServiceLocator.findSingletonAmongst(SerializerConfiguration.class, cacheConfiguration.getServiceConfigurations());
@@ -151,9 +151,9 @@ public class CacheConfigurationBuilderTest {
       }
     };
 
-    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .withValueSerializer(valueSerializer)
-        .buildConfig(Object.class, Object.class);
+        .build();
 
 
     SerializerConfiguration serializerConfiguration = ServiceLocator.findSingletonAmongst(SerializerConfiguration.class, cacheConfiguration.getServiceConfigurations());
@@ -176,9 +176,9 @@ public class CacheConfigurationBuilderTest {
       }
     };
 
-    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .withKeyCopier(keyCopier)
-        .buildConfig(Object.class, Object.class);
+        .build();
 
 
     CopierConfiguration copierConfiguration = ServiceLocator.findSingletonAmongst(CopierConfiguration.class, cacheConfiguration.getServiceConfigurations());
@@ -201,9 +201,9 @@ public class CacheConfigurationBuilderTest {
       }
     };
 
-    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .withValueCopier(valueCopier)
-        .buildConfig(Object.class, Object.class);
+        .build();
 
 
     CopierConfiguration copierConfiguration = ServiceLocator.findSingletonAmongst(CopierConfiguration.class, cacheConfiguration.getServiceConfigurations());
@@ -214,7 +214,7 @@ public class CacheConfigurationBuilderTest {
 
   @Test
   public void testNothing() {
-    final CacheConfigurationBuilder<Long, CharSequence> builder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    final CacheConfigurationBuilder<Long, CharSequence> builder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, CharSequence.class);
    
     final Expiry<Object, Object> expiry = Expirations.timeToIdleExpiration(Duration.FOREVER);
 
@@ -226,16 +226,12 @@ public class CacheConfigurationBuilderTest {
           }
         })
         .withExpiry(expiry)
-        .buildConfig(Long.class, String.class);
-    builder
-        .buildConfig(Long.class, String.class, null);
-    builder
-        .buildConfig(Long.class, String.class, null);
+        .build();
   }
 
   @Test
   public void testOffheapGetsAddedToCacheConfiguration() {
-    CacheConfigurationBuilder<Long, CharSequence> builder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder<Long, CharSequence> builder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, CharSequence.class);
 
     final Expiry<Object, Object> expiry = Expirations.timeToIdleExpiration(Duration.FOREVER);
 
@@ -249,7 +245,7 @@ public class CacheConfigurationBuilderTest {
           }
         })
         .withExpiry(expiry)
-        .buildConfig(Long.class, String.class);
+        .build();
     assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getType(), Matchers.<ResourceType>is(ResourceType.Core.OFFHEAP));
     assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
   }

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -68,9 +68,8 @@ public class GettingStarted {
     CacheManager cacheManager
         = CacheManagerBuilder.newCacheManagerBuilder() // <1>
         .withCache("preConfigured",
-            CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
-                .build()) // <2>
-        .build(false); // <3>
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)) // <2>
+        .build(); // <3>
     cacheManager.init(); // <4>
 
     Cache<Long, String> preConfigured =
@@ -97,7 +96,7 @@ public class GettingStarted {
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .disk(10L, MemoryUnit.MB, true)) // <2>
-            .build())
+            )
         .build(true);
 
     persistentCacheManager.close();
@@ -112,7 +111,8 @@ public class GettingStarted {
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)) // <1>
-            .build()).build(true);
+            )
+        .build(true);
 
     cacheManager.close();
     // end::offheapCacheManager[]
@@ -126,11 +126,11 @@ public class GettingStarted {
         .withCache("threeTieredCache",
             CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
-                        .heap(10, EntryUnit.ENTRIES) // <2>
-                        .offheap(1, MemoryUnit.MB) // <3>
-                        .disk(20, MemoryUnit.MB) // <4>
+                    .heap(10, EntryUnit.ENTRIES) // <2>
+                    .offheap(1, MemoryUnit.MB) // <3>
+                    .disk(20, MemoryUnit.MB) // <4>
                 )
-                .build()).build(true);
+        ).build(true);
 
     persistentCacheManager.close();
     // end::threeTiersCacheManager[]
@@ -141,7 +141,7 @@ public class GettingStarted {
     // tag::defaultSerializers[]
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder
-            .newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(1, MemoryUnit.MB).build())
+            .newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(1, MemoryUnit.MB))
         .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -186,12 +186,12 @@ public class GettingStarted {
     CacheEventListenerConfigurationBuilder cacheEventListenerConfiguration = CacheEventListenerConfigurationBuilder
         .newEventListenerConfiguration(new ListenerObject(), EventType.CREATED, EventType.UPDATED) // <1>
         .unordered().asynchronous(); // <2>
-    
+
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
             CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class)
                 .add(cacheEventListenerConfiguration) // <3>
-                .build()).build(true);
+        ).build(true);
 
     final Cache<String, String> cache = manager.getCache("foo", String.class, String.class);
     cache.put("Hello", "World"); // <4>
@@ -254,7 +254,7 @@ public class GettingStarted {
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .add(cacheEventListenerConfiguration)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
-            .heap(10L, EntryUnit.ENTRIES).build()).build();
+            .heap(10L, EntryUnit.ENTRIES)).build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().withCache("cache", cacheConfiguration)
         .build(true);
@@ -311,7 +311,7 @@ public class GettingStarted {
   public void cacheSerializingCopiers() throws Exception {
     // tag::cacheSerializingCopiers[]
     CacheConfiguration<Long, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, Person.class)
-        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
+        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
         .withValueSerializingCopier() // <1>
         .build();
     // end::cacheSerializingCopiers[]
@@ -335,11 +335,11 @@ public class GettingStarted {
   public void defaultCopiers() throws Exception {
     // tag::defaultCopiers[]
     CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
-        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
+        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
         .build();
 
     CacheConfiguration<Long, Person> anotherCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, Person.class)
-        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
+        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
         .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -369,7 +369,7 @@ public class GettingStarted {
   public void cacheServiceConfiguration() throws Exception {
     // tag::cacheServiceConfigurations[]
     CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
-        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
+        .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
         .withKeyCopier(DescriptionCopier.class) // <1>
         .withValueCopier(new PersonCopier()) // <2>
         .build();

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -38,6 +38,7 @@ import org.ehcache.docs.plugs.SampleLoaderWriter;
 import org.ehcache.docs.plugs.StringSerializer;
 import org.ehcache.event.EventType;
 import org.ehcache.internal.copy.ReadWriteCopier;
+import org.ehcache.spi.serialization.Serializer;
 import org.junit.Test;
 
 import java.io.File;
@@ -164,7 +165,7 @@ public class GettingStarted {
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
         .withKeySerializer(new LongSerializer()) // <1>
-        .withValueSerializer(new CharSequenceSerializer()) // <2>
+        .withValueSerializer((Serializer) new CharSequenceSerializer()) // <2>
         .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -22,7 +22,6 @@ import org.ehcache.CacheManagerBuilder;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.CacheConfigurationBuilder;
-import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourcePoolsBuilder;
 import org.ehcache.config.ResourceType;
@@ -39,8 +38,6 @@ import org.ehcache.docs.plugs.SampleLoaderWriter;
 import org.ehcache.docs.plugs.StringSerializer;
 import org.ehcache.event.EventType;
 import org.ehcache.internal.copy.ReadWriteCopier;
-import org.ehcache.spi.copy.Copier;
-import org.ehcache.spi.serialization.Serializer;
 import org.junit.Test;
 
 import java.io.File;
@@ -166,8 +163,8 @@ public class GettingStarted {
     // tag::cacheSerializers[]
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
-        .withKeySerializer((Serializer) new LongSerializer()) // <1>
-        .withValueSerializer((Serializer) new CharSequenceSerializer()) // <2>
+        .withKeySerializer(new LongSerializer()) // <1>
+        .withValueSerializer(new CharSequenceSerializer()) // <2>
         .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -212,7 +209,7 @@ public class GettingStarted {
 
     final Cache<Long, String> writeThroughCache = cacheManager.createCache("writeThroughCache",
         CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
-            .withLoaderWriter((SampleLoaderWriter) new SampleLoaderWriter<Long, String>(singletonMap(41L, "zero"))) // <1>
+            .withLoaderWriter(new SampleLoaderWriter<Long, String>(singletonMap(41L, "zero"))) // <1>
             .build());
     
     assertThat(writeThroughCache.get(41L), is("zero"));
@@ -230,7 +227,7 @@ public class GettingStarted {
 
     final Cache<Long, String> writeBehindCache = cacheManager.createCache("writeBehindCache",
         CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
-            .withLoaderWriter((SampleLoaderWriter) new SampleLoaderWriter<Long, String>(singletonMap(41L, "zero"))) // <1>
+            .withLoaderWriter(new SampleLoaderWriter<Long, String>(singletonMap(41L, "zero"))) // <1>
             .add(WriteBehindConfigurationBuilder // <2>
                 .newBatchedWriteBehindConfiguration(1, TimeUnit.SECONDS, 3)// <3>
                 .queueSize(3)// <4>
@@ -291,8 +288,8 @@ public class GettingStarted {
     // tag::cacheCopiers[]
     CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
-        .withKeyCopier((Copier) new DescriptionCopier()) // <1>
-        .withValueCopier((Copier) new PersonCopier()) // <2>
+        .withKeyCopier(new DescriptionCopier()) // <1>
+        .withValueCopier(new PersonCopier()) // <2>
         .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -373,8 +370,8 @@ public class GettingStarted {
     // tag::cacheServiceConfigurations[]
     CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .withKeyCopier((Class) DescriptionCopier.class) // <1>
-        .withValueCopier((Copier) new PersonCopier()) // <2>
+        .withKeyCopier(DescriptionCopier.class) // <1>
+        .withValueCopier(new PersonCopier()) // <2>
         .build();
     // end::cacheServiceConfigurations[]
 
@@ -396,7 +393,7 @@ public class GettingStarted {
   public void cacheEvictionVeto() throws Exception {
     // tag::cacheEvictionVeto[]
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
-        .withEvictionVeto((EvictionVeto) new OddKeysEvictionVeto<Long, String>()) // <1>
+        .withEvictionVeto(new OddKeysEvictionVeto<Long, String>()) // <1>
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
             .heap(2L, EntryUnit.ENTRIES)) // <2>
         .build();

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -71,8 +71,8 @@ public class GettingStarted {
     CacheManager cacheManager
         = CacheManagerBuilder.newCacheManagerBuilder() // <1>
         .withCache("preConfigured",
-            CacheConfigurationBuilder.newCacheConfigurationBuilder()
-                .buildConfig(Long.class, String.class)) // <2>
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+                .build()) // <2>
         .build(false); // <3>
     cacheManager.init(); // <4>
 
@@ -80,7 +80,7 @@ public class GettingStarted {
         cacheManager.getCache("preConfigured", Long.class, String.class); // <5>
 
     Cache<Long, String> myCache = cacheManager.createCache("myCache", // <6>
-        CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Long.class, String.class));
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class).build());
 
     myCache.put(1L, "da one!"); // <7>
     String value = myCache.get(1L); // <8>
@@ -96,11 +96,11 @@ public class GettingStarted {
     // tag::persistentCacheManager[]
     PersistentCacheManager persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(getStoragePath(), "myData"))) // <1>
-        .withCache("persistent-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        .withCache("persistent-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .disk(10L, MemoryUnit.MB, true)) // <2>
-            .buildConfig(Long.class, String.class))
+            .build())
         .build(true);
 
     persistentCacheManager.close();
@@ -111,11 +111,11 @@ public class GettingStarted {
   public void offheapCacheManager() {
     // tag::offheapCacheManager[]
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().withCache("tieredCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)) // <1>
-            .buildConfig(Long.class, String.class)).build(true);
+            .build()).build(true);
 
     cacheManager.close();
     // end::offheapCacheManager[]
@@ -127,13 +127,13 @@ public class GettingStarted {
     PersistentCacheManager persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(getStoragePath(), "myData"))) // <1>
         .withCache("threeTieredCache",
-            CacheConfigurationBuilder.newCacheConfigurationBuilder()
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                         .heap(10, EntryUnit.ENTRIES) // <2>
                         .offheap(1, MemoryUnit.MB) // <3>
                         .disk(20, MemoryUnit.MB) // <4>
                 )
-                .buildConfig(Long.class, String.class)).build(true);
+                .build()).build(true);
 
     persistentCacheManager.close();
     // end::threeTiersCacheManager[]
@@ -142,10 +142,10 @@ public class GettingStarted {
   @Test
   public void defaultSerializers() throws Exception {
     // tag::defaultSerializers[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder
             .newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(1, MemoryUnit.MB).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("cache", cacheConfiguration)
@@ -164,11 +164,11 @@ public class GettingStarted {
   @Test
   public void cacheSerializers() throws Exception {
     // tag::cacheSerializers[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
         .withKeySerializer((Serializer) new LongSerializer()) // <1>
         .withValueSerializer((Serializer) new CharSequenceSerializer()) // <2>
-        .buildConfig(Long.class, String.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("cache", cacheConfiguration)
@@ -192,9 +192,9 @@ public class GettingStarted {
     
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
-            CacheConfigurationBuilder.newCacheConfigurationBuilder()
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class)
                 .add(cacheEventListenerConfiguration) // <3>
-                .buildConfig(String.class, String.class)).build(true);
+                .build()).build(true);
 
     final Cache<String, String> cache = manager.getCache("foo", String.class, String.class);
     cache.put("Hello", "World"); // <4>
@@ -209,11 +209,11 @@ public class GettingStarted {
   public void writeThroughCache() throws ClassNotFoundException {
     // tag::writeThroughCache[]
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
-    
+
     final Cache<Long, String> writeThroughCache = cacheManager.createCache("writeThroughCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .withLoaderWriter((SampleLoaderWriter) new SampleLoaderWriter<Long, String>(singletonMap(41L, "zero"))) // <1>
-            .buildConfig(Long.class, String.class));
+            .build());
     
     assertThat(writeThroughCache.get(41L), is("zero"));
     writeThroughCache.put(42L, "one");
@@ -227,16 +227,16 @@ public class GettingStarted {
   public void writeBehindCache() throws ClassNotFoundException {
     // tag::writeBehindCache[]
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
-    
+
     final Cache<Long, String> writeBehindCache = cacheManager.createCache("writeBehindCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .withLoaderWriter((SampleLoaderWriter) new SampleLoaderWriter<Long, String>(singletonMap(41L, "zero"))) // <1>
             .add(WriteBehindConfigurationBuilder // <2>
                 .newBatchedWriteBehindConfiguration(1, TimeUnit.SECONDS, 3)// <3>
                 .queueSize(3)// <4>
                 .concurrencyLevel(1) // <5>
                 .enableCoalescing()) // <6>
-            .buildConfig(Long.class, String.class));
+            .build());
     
     assertThat(writeBehindCache.get(41L), is("zero"));
     writeBehindCache.put(42L, "one");
@@ -254,10 +254,10 @@ public class GettingStarted {
     CacheEventListenerConfigurationBuilder cacheEventListenerConfiguration = CacheEventListenerConfigurationBuilder
         .newEventListenerConfiguration(listener, EventType.EVICTED).unordered().synchronous();
 
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .add(cacheEventListenerConfiguration)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
-            .heap(10L, EntryUnit.ENTRIES).build()).buildConfig(Long.class, String.class);
+            .heap(10L, EntryUnit.ENTRIES).build()).build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().withCache("cache", cacheConfiguration)
         .build(true);
@@ -289,11 +289,11 @@ public class GettingStarted {
   @Test
   public void cacheCopiers() throws Exception {
     // tag::cacheCopiers[]
-    CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
         .withKeyCopier((Copier) new DescriptionCopier()) // <1>
         .withValueCopier((Copier) new PersonCopier()) // <2>
-        .buildConfig(Description.class, Person.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("cache", cacheConfiguration)
@@ -313,10 +313,10 @@ public class GettingStarted {
   @Test
   public void cacheSerializingCopiers() throws Exception {
     // tag::cacheSerializingCopiers[]
-    CacheConfiguration<Long, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
         .withValueSerializingCopier() // <1>
-        .buildConfig(Long.class, Person.class);
+        .build();
     // end::cacheSerializingCopiers[]
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -337,13 +337,13 @@ public class GettingStarted {
   @Test
   public void defaultCopiers() throws Exception {
     // tag::defaultCopiers[]
-    CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Description.class, Person.class);
+        .build();
 
-    CacheConfiguration<Long, Person> anotherCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, Person> anotherCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, Person.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCopier(Description.class, DescriptionCopier.class) // <1>
@@ -371,11 +371,11 @@ public class GettingStarted {
   @Test
   public void cacheServiceConfiguration() throws Exception {
     // tag::cacheServiceConfigurations[]
-    CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Description, Person> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Description.class, Person.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
         .withKeyCopier((Class) DescriptionCopier.class) // <1>
         .withValueCopier((Copier) new PersonCopier()) // <2>
-        .buildConfig(Description.class, Person.class);
+        .build();
     // end::cacheServiceConfigurations[]
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -395,11 +395,11 @@ public class GettingStarted {
   @Test
   public void cacheEvictionVeto() throws Exception {
     // tag::cacheEvictionVeto[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withEvictionVeto((EvictionVeto) new OddKeysEvictionVeto<Long, String>()) // <1>
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
             .heap(2L, EntryUnit.ENTRIES)) // <2>
-        .buildConfig(Long.class, String.class);
+        .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("cache", cacheConfiguration)

--- a/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/integration/SerializerCountingTest.java
@@ -35,7 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,10 +76,10 @@ public class SerializerCountingTest {
   @Test
   public void testOnHeapPutGet() {
 
-    Cache<Long, String> cache = cacheManager.createCache("onHeap", newCacheConfigurationBuilder()
+    Cache<Long, String> cache = cacheManager.createCache("onHeap", newCacheConfigurationBuilder(Long.class, String.class)
                 .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
                 .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.VALUE))
-                .buildConfig(Long.class, String.class));
+                .build());
 
     cache.put(42L, "TheAnswer!");
     assertCounters(2, 2, 0, 1, 0, 0);
@@ -96,9 +95,9 @@ public class SerializerCountingTest {
 
   @Test
   public void testOffHeapPutGet() {
-    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
+    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder(Long.class, String.class)
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
-            .buildConfig(Long.class, String.class)
+            .build()
     );
 
     cache.put(42L, "TheAnswer");
@@ -118,11 +117,11 @@ public class SerializerCountingTest {
 
   @Test
   public void testOffHeapOnHeapCopyPutGet() {
-    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
+    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder(Long.class, String.class)
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
             .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
             .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.VALUE))
-            .buildConfig(Long.class, String.class)
+            .build()
     );
 
     cache.put(42L, "TheAnswer");
@@ -142,11 +141,11 @@ public class SerializerCountingTest {
 
   @Test
   public void testDiskOffHeapOnHeapCopyPutGet() {
-    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder()
+    Cache<Long, String> cache = cacheManager.createCache("offHeap", newCacheConfigurationBuilder(Long.class, String.class)
             .withResourcePools(newResourcePoolsBuilder().heap(2, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB).disk(100, MemoryUnit.MB))
             .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.KEY))
             .add(new DefaultCopierConfiguration(SerializingCopier.class, CopierConfiguration.Type.VALUE))
-            .buildConfig(Long.class, String.class)
+            .build()
     );
 
 

--- a/impl/src/test/java/org/ehcache/internal/persistence/CacheManagerDestroyRemovesPersistenceTest.java
+++ b/impl/src/test/java/org/ehcache/internal/persistence/CacheManagerDestroyRemovesPersistenceTest.java
@@ -68,11 +68,11 @@ public class CacheManagerDestroyRemovesPersistenceTest {
   public void initCacheManager(File file) throws URISyntaxException {
     persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(file)) 
-        .withCache("persistent-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        .withCache("persistent-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .disk(10L, MemoryUnit.MB, true)) 
-            .buildConfig(Long.class, String.class))
+            .build())
         .build(true);
   }
 

--- a/impl/src/test/java/org/ehcache/internal/store/heap/OnHeapStoreByValueTest.java
+++ b/impl/src/test/java/org/ehcache/internal/store/heap/OnHeapStoreByValueTest.java
@@ -167,22 +167,22 @@ public class OnHeapStoreByValueTest extends BaseOnHeapStoreTest {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(false);
     cacheManager.init();
 
-    DefaultCopierConfiguration copierConfiguration = new DefaultCopierConfiguration(
+    DefaultCopierConfiguration<String> copierConfiguration = new DefaultCopierConfiguration(
         SerializingCopier.class, CopierConfiguration.Type.VALUE);
     final Cache<Long, String> cache1 = cacheManager.createCache("cache1",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder().withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(1, EntryUnit.ENTRIES))
-            .buildConfig(Long.class, String.class));
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class).withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(1, EntryUnit.ENTRIES))
+            .build());
     performAssertions(cache1, true);
 
     final Cache<Long, String> cache2 = cacheManager.createCache("cache2",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .add(copierConfiguration)
-            .buildConfig(Long.class, String.class));
+            .build());
     performAssertions(cache2, false);
 
     final Cache<Long, String> cache3 = cacheManager.createCache("cache3",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
-            .buildConfig(Long.class, String.class));
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+            .build());
     performAssertions(cache3, true);
 
     cacheManager.close();

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindTestBase.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/AbstractWriteBehindTestBase.java
@@ -65,7 +65,7 @@ public abstract class AbstractWriteBehindTestBase {
 
   protected abstract CacheManagerBuilder managerBuilder();
   
-  protected abstract CacheConfigurationBuilder<Object, Object> configurationBuilder();
+  protected abstract CacheConfigurationBuilder<String, String> configurationBuilder();
 
   @Test
   public void testWriteOrdering() throws Exception {
@@ -77,7 +77,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testWriteOrdering", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 8).build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       CountDownLatch countDownLatch = new CountDownLatch(8);
 
@@ -108,9 +108,9 @@ public abstract class AbstractWriteBehindTestBase {
     
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
-      Cache<String, String> testCache = cacheManager.createCache("testWrites", CacheConfigurationBuilder.newCacheConfigurationBuilder()
+      Cache<String, String> testCache = cacheManager.createCache("testWrites", CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class)
           .add(newUnBatchedWriteBehindConfiguration().concurrencyLevel(3).queueSize(10).build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       CountDownLatch countDownLatch = new CountDownLatch(4);
       loaderWriter.setLatch(countDownLatch);
@@ -137,9 +137,9 @@ public abstract class AbstractWriteBehindTestBase {
     
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
-      Cache<String, String> testCache = cacheManager.createCache("testBulkWrites", CacheConfigurationBuilder.newCacheConfigurationBuilder()
+      Cache<String, String> testCache = cacheManager.createCache("testBulkWrites", CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class)
           .add(newUnBatchedWriteBehindConfiguration().concurrencyLevel(3).queueSize(10).build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       CountDownLatch countDownLatch = new CountDownLatch(20);
       loaderWriter.setLatch(countDownLatch);
@@ -188,7 +188,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testThatAllGetsReturnLatestData", configurationBuilder()
           .add(newUnBatchedWriteBehindConfiguration().concurrencyLevel(3).queueSize(10).build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       for(int i=0 ; i<10; i++) {
         String val = "test"+i; 
@@ -236,7 +236,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testAllGetsReturnLatestDataWithKeyCollision", configurationBuilder()
           .add(newUnBatchedWriteBehindConfiguration().concurrencyLevel(3).queueSize(10).build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       Random random = new Random();
       Set<String> keys = new HashSet<String>();
@@ -268,7 +268,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testBatchedDeletedKeyReturnsNull", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 2).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       assertThat(testCache.get("key"), is("value"));
       
@@ -300,7 +300,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testUnBatchedDeletedKeyReturnsNull", configurationBuilder()
           .add(newUnBatchedWriteBehindConfiguration().build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       assertThat(testCache.get("key"), is("value"));
       
@@ -324,7 +324,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testBatchedOverwrittenKeyReturnsNewValue", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 2).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       assertThat(testCache.get("key"), is("value"));
       
@@ -356,7 +356,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testUnBatchedOverwrittenKeyReturnsNewValue", configurationBuilder()
           .add(newUnBatchedWriteBehindConfiguration().build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       assertThat(testCache.get("key"), is("value"));
       
@@ -379,7 +379,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testCoaslecedWritesAreNotSeen", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 2).enableCoalescing().build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       CountDownLatch latch = new CountDownLatch(2);
       loaderWriter.setLatch(latch);
@@ -407,7 +407,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testUnBatchedWriteBehindStopWaitsForEmptyQueue", configurationBuilder()
           .add(newUnBatchedWriteBehindConfiguration().build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       testCache.put("key", "value");
     } finally {
@@ -426,7 +426,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testBatchedWriteBehindStopWaitsForEmptyQueue", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 2).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       testCache.put("key", "value");
     } finally {
@@ -455,7 +455,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       final Cache<String, String> testCache = cacheManager.createCache("testUnBatchedWriteBehindBlocksWhenFull", configurationBuilder()
           .add(newUnBatchedWriteBehindConfiguration().queueSize(1).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       testCache.put("key1", "value");
       testCache.put("key2", "value");
@@ -507,7 +507,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       final Cache<String, String> testCache = cacheManager.createCache("testBatchedWriteBehindBlocksWhenFull", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 1).queueSize(1).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       testCache.put("key1", "value");
       testCache.put("key2", "value");
@@ -549,7 +549,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testFilledBatchedIsWritten", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(Long.MAX_VALUE, SECONDS, 2).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       CountDownLatch latch = new CountDownLatch(2);
       loaderWriter.setLatch(latch);
@@ -578,7 +578,7 @@ public abstract class AbstractWriteBehindTestBase {
     try {
       Cache<String, String> testCache = cacheManager.createCache("testAgedBatchedIsWritten", configurationBuilder()
           .add(newBatchedWriteBehindConfiguration(1, SECONDS, 2).build())
-          .buildConfig(String.class, String.class));
+          .build());
       
       CountDownLatch latch = new CountDownLatch(1);
       loaderWriter.setLatch(latch);
@@ -621,7 +621,7 @@ public abstract class AbstractWriteBehindTestBase {
       Cache<String, String> testCache = cacheManager.createCache("testAgedBatchedIsWritten", configurationBuilder()
           .add(new DefaultCacheLoaderWriterConfiguration(loaderWriter))
           .add(newBatchedWriteBehindConfiguration(5, SECONDS, 2).build())
-          .buildConfig(String.class, String.class));
+          .build());
 
       testCache.put("key1", "value1");
       assertThat(writeBehindProvider.getWriteBehind().getQueueSize(), is(1L));

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/PooledExecutorWriteBehindTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/PooledExecutorWriteBehindTest.java
@@ -32,8 +32,8 @@ import static org.ehcache.config.CacheConfigurationBuilder.newCacheConfiguration
 public class PooledExecutorWriteBehindTest extends AbstractWriteBehindTestBase {
 
   @Override
-  protected CacheConfigurationBuilder<Object, Object> configurationBuilder() {
-    return newCacheConfigurationBuilder()
+  protected CacheConfigurationBuilder<String, String> configurationBuilder() {
+    return newCacheConfigurationBuilder(String.class, String.class)
             .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS)));
   }
 

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindEvictionTest.java
@@ -34,8 +34,8 @@ import static org.ehcache.config.CacheConfigurationBuilder.newCacheConfiguration
 public class WriteBehindEvictionTest extends AbstractWriteBehindTestBase {
 
   @Override
-  protected CacheConfigurationBuilder<Object, Object> configurationBuilder() {
-    return newCacheConfigurationBuilder()
+  protected CacheConfigurationBuilder<String, String> configurationBuilder() {
+    return newCacheConfigurationBuilder(String.class, String.class)
             .withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
             .withExpiry(Expirations.timeToLiveExpiration(new Duration(100, TimeUnit.MILLISECONDS)));
   }

--- a/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindTest.java
+++ b/impl/src/test/java/org/ehcache/loaderwriter/writebehind/WriteBehindTest.java
@@ -32,8 +32,8 @@ import static org.ehcache.config.CacheConfigurationBuilder.newCacheConfiguration
 public class WriteBehindTest extends AbstractWriteBehindTestBase {
     
   @Override
-  protected CacheConfigurationBuilder<Object, Object> configurationBuilder() {
-    return newCacheConfigurationBuilder()
+  protected CacheConfigurationBuilder<String, String> configurationBuilder() {
+    return newCacheConfigurationBuilder(String.class, String.class)
             .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.MILLISECONDS)));
   }
 

--- a/impl/src/test/java/org/ehcache/spi/event/DefaultCacheEventListenerProviderTest.java
+++ b/impl/src/test/java/org/ehcache/spi/event/DefaultCacheEventListenerProviderTest.java
@@ -55,9 +55,9 @@ public class DefaultCacheEventListenerProviderTest {
         .newEventListenerConfiguration(ListenerObject.class, eventTypeSet).unordered().asynchronous();
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
-            CacheConfigurationBuilder.newCacheConfigurationBuilder()
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
                 .add(listenerBuilder)
-                .buildConfig(Object.class, Object.class)).build(true);
+                .build()).build(true);
     final Collection<?> bar = manager.getCache("foo", Object.class, Object.class).getRuntimeConfiguration().getServiceConfigurations();
     assertThat(bar.iterator().next().getClass().toString(), is(ListenerObject.object.toString()));
   }
@@ -69,11 +69,11 @@ public class DefaultCacheEventListenerProviderTest {
         .newEventListenerConfiguration(ListenerObject.class, EventType.CREATED).unordered().asynchronous().build();
     CacheManager cacheManager = cacheManagerBuilder.build(true);
     final Cache<Long, String> cache = cacheManager.createCache("cache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .add(cacheEventListenerConfiguration)
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(100, EntryUnit.ENTRIES).build())
-            .buildConfig(Long.class, String.class));
+            .build());
     Collection<ServiceConfiguration<?>> serviceConfiguration = cache.getRuntimeConfiguration()
         .getServiceConfigurations();
     assertThat(serviceConfiguration, IsCollectionContaining.<ServiceConfiguration<?>>hasItem(instanceOf(DefaultCacheEventListenerConfiguration.class)));

--- a/impl/src/test/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProviderTest.java
+++ b/impl/src/test/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProviderTest.java
@@ -47,9 +47,9 @@ public class DefaultCacheLoaderWriterProviderTest {
   public void testCacheConfigUsage() {
     final CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("foo",
-            CacheConfigurationBuilder.newCacheConfigurationBuilder()
+            CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
                 .add(new DefaultCacheLoaderWriterConfiguration(MyLoader.class))
-                .buildConfig(Object.class, Object.class)).build(true);
+                .build()).build(true);
     final Object foo = manager.getCache("foo", Object.class, Object.class).get(new Object());
     assertThat(foo, is(MyLoader.object));
   }
@@ -57,8 +57,8 @@ public class DefaultCacheLoaderWriterProviderTest {
   @Test
   public void testCacheManagerConfigUsage() {
 
-    final CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
-        .buildConfig(Object.class, Object.class);
+    final CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
+        .build();
 
     final Map<String, CacheConfiguration<?, ?>> caches = new HashMap<String, CacheConfiguration<?, ?>>();
     caches.put("foo", cacheConfiguration);
@@ -72,9 +72,9 @@ public class DefaultCacheLoaderWriterProviderTest {
 
   @Test
   public void testCacheConfigOverridesCacheManagerConfig() {
-    final CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    final CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class)
         .add(new DefaultCacheLoaderWriterConfiguration(MyOtherLoader.class))
-        .buildConfig(Object.class, Object.class);
+        .build();
 
     final Map<String, CacheConfiguration<?, ?>> caches = new HashMap<String, CacheConfiguration<?, ?>>();
     caches.put("foo", cacheConfiguration);
@@ -93,11 +93,11 @@ public class DefaultCacheLoaderWriterProviderTest {
     Class<CacheLoaderWriter<?, ?>> klazz = (Class<CacheLoaderWriter<?, ?>>) (Class) (MyLoader.class);
     CacheManager cacheManager = cacheManagerBuilder.build(true);
     final Cache<Long, String> cache = cacheManager.createCache("cache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
             .add(new DefaultCacheLoaderWriterConfiguration(klazz))
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(100, EntryUnit.ENTRIES).build())
-            .buildConfig(Long.class, String.class));
+            .build());
     Collection<ServiceConfiguration<?>> serviceConfiguration = cache.getRuntimeConfiguration()
         .getServiceConfigurations();
     assertThat(serviceConfiguration, IsCollectionContaining.<ServiceConfiguration<?>>hasItem(instanceOf(DefaultCacheLoaderWriterConfiguration.class)));

--- a/integration-test/src/test/java/org/ehcache/integration/CacheCopierTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/CacheCopierTest.java
@@ -36,7 +36,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -52,7 +51,7 @@ import static org.junit.Assert.assertThat;
 public class CacheCopierTest {
 
   CacheManager cacheManager;
-  CacheConfigurationBuilder<Long, Person> baseConfig = CacheConfigurationBuilder.<Long, Person>newCacheConfigurationBuilder()
+  CacheConfigurationBuilder<Long, Person> baseConfig = CacheConfigurationBuilder.<Long, Person>newCacheConfigurationBuilder(Long.class, Person.class)
       .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(5, EntryUnit.ENTRIES).build());
 
 
@@ -71,7 +70,7 @@ public class CacheCopierTest {
   public void testCopyValueOnRead() throws Exception {
     CacheConfiguration<Long, Person> cacheConfiguration = baseConfig
         .add(new DefaultCopierConfiguration<Person>(PersonOnReadCopier.class, CopierConfiguration.Type.VALUE))
-        .buildConfig(Long.class, Person.class);
+        .build();
 
     Cache<Long, Person> cache = cacheManager.createCache("cache", cacheConfiguration);
 
@@ -94,7 +93,7 @@ public class CacheCopierTest {
   public void testCopyValueOnWrite() throws Exception {
     CacheConfiguration<Long, Person> cacheConfiguration = baseConfig
         .add(new DefaultCopierConfiguration<Person>(PersonOnWriteCopier.class, CopierConfiguration.Type.VALUE))
-        .buildConfig(Long.class, Person.class);
+        .build();
 
     Cache<Long, Person> cache = cacheManager.createCache("cache", cacheConfiguration);
 
@@ -115,7 +114,7 @@ public class CacheCopierTest {
 
   @Test
   public void testIdentityCopier() throws Exception {
-    CacheConfiguration<Long, Person> cacheConfiguration = baseConfig.buildConfig(Long.class, Person.class);
+    CacheConfiguration<Long, Person> cacheConfiguration = baseConfig.build();
 
     Cache<Long, Person> cache = cacheManager.createCache("cache", cacheConfiguration);
 
@@ -137,7 +136,7 @@ public class CacheCopierTest {
     CacheConfiguration<Long, Person> cacheConfiguration = baseConfig
         .add(new DefaultCopierConfiguration<Person>((Class)SerializingCopier.class, CopierConfiguration.Type.VALUE))
         .add(new DefaultSerializerConfiguration<Person>(PersonSerializer.class, SerializerConfiguration.Type.VALUE))
-        .buildConfig(Long.class, Person.class);
+        .build();
 
     Cache<Long, Person> cache = cacheManager.createCache("cache", cacheConfiguration);
 
@@ -160,7 +159,7 @@ public class CacheCopierTest {
   public void testReadWriteCopier() throws Exception {
     CacheConfiguration<Long, Person> cacheConfiguration = baseConfig
         .add(new DefaultCopierConfiguration<Person>(PersonCopier.class, CopierConfiguration.Type.VALUE))
-        .buildConfig(Long.class, Person.class);
+        .build();
 
     Cache<Long, Person> cache = cacheManager.createCache("cache", cacheConfiguration);
 

--- a/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
@@ -66,8 +66,8 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testPutAll_without_cache_writer() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
-    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.buildConfig(String.class, String.class);
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
+    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.build();
 
     CacheManagerBuilder<CacheManager> managerBuilder = CacheManagerBuilder.newCacheManagerBuilder();
     CacheManager cacheManager = managerBuilder.withCache("myCache", cacheConfiguration).build(true);
@@ -90,9 +90,9 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testPutAll_with_cache_writer() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
     CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder
-        .buildConfig(String.class, String.class);
+        .build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
@@ -129,9 +129,9 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testPutAll_with_cache_writer_that_throws_exception() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
     CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder
-        .buildConfig(String.class, String.class);
+        .build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriterThatThrows = mock(CacheLoaderWriter.class);
@@ -164,9 +164,9 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testPutAll_store_throws_cache_exception() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
     CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder
-        .buildConfig(String.class, String.class);
+        .build();
 
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
@@ -205,8 +205,8 @@ public class EhcacheBulkMethodsITest {
   
   @Test
   public void testGetAll_without_cache_loader() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
-    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.buildConfig(String.class, String.class);
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
+    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.build();
 
     CacheManagerBuilder<CacheManager> managerBuilder = CacheManagerBuilder.newCacheManagerBuilder();
     CacheManager cacheManager = managerBuilder.withCache("myCache", cacheConfiguration).build(true);
@@ -234,8 +234,8 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testGetAll_with_cache_loader() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
-    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.buildConfig(String.class, String.class);
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
+    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
@@ -266,8 +266,8 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testGetAll_cache_loader_throws_exception() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
-    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.buildConfig(String.class, String.class);
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
+    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
@@ -301,8 +301,8 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testGetAll_store_throws_cache_exception() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
-    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.buildConfig(String.class, String.class);
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
+    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
@@ -333,8 +333,8 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testRemoveAll_without_cache_writer() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
-    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.buildConfig(String.class, String.class);
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
+    CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder.build();
 
     CacheManagerBuilder<CacheManager> managerBuilder = CacheManagerBuilder.newCacheManagerBuilder();
     CacheManager cacheManager = managerBuilder.withCache("myCache", cacheConfiguration).build(true);
@@ -366,9 +366,9 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testRemoveAll_with_cache_writer() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
     CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder
-        .buildConfig(String.class, String.class);
+        .build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
@@ -411,9 +411,9 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testRemoveAll_cache_writer_throws_exception() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
     CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder
-        .buildConfig(String.class, String.class);
+        .build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriterThatThrows = mock(CacheLoaderWriter.class);
@@ -453,9 +453,9 @@ public class EhcacheBulkMethodsITest {
 
   @Test
   public void testRemoveAll_with_store_that_throws() throws Exception {
-    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder();
+    CacheConfigurationBuilder cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, String.class);
     CacheConfiguration<String, String> cacheConfiguration = cacheConfigurationBuilder
-        .buildConfig(String.class, String.class);
+        .build();
 
     CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
     CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);

--- a/integration-test/src/test/java/org/ehcache/integration/EvictionEhcacheTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/EvictionEhcacheTest.java
@@ -55,9 +55,9 @@ public class EvictionEhcacheTest {
   @Test
   public void testSimplePutWithEviction() throws Exception {
     Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class)
             .withResourcePools(newResourcePoolsBuilder().heap(2, EntryUnit.ENTRIES))
-            .buildConfig(Number.class, CharSequence.class));
+            .build());
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -77,9 +77,9 @@ public class EvictionEhcacheTest {
   @Test
   public void testSimplePutIfAbsentWithEviction() throws Exception {
     Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class)
             .withResourcePools(newResourcePoolsBuilder().heap(2, EntryUnit.ENTRIES))
-            .buildConfig(Number.class, CharSequence.class));
+            .build());
 
     testCache.putIfAbsent(1, "one");
     testCache.putIfAbsent(2, "two");
@@ -99,9 +99,9 @@ public class EvictionEhcacheTest {
   @Test
   public void testSimplePutAllWithEviction() throws Exception {
     Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class)
             .withResourcePools(newResourcePoolsBuilder().heap(2, EntryUnit.ENTRIES))
-            .buildConfig(Number.class, CharSequence.class));
+            .build());
 
     Map<Integer, String> values = new HashMap<Integer, String>();
     values.put(1, "one");

--- a/integration-test/src/test/java/org/ehcache/integration/ExpiryEhcacheTestBase.java
+++ b/integration-test/src/test/java/org/ehcache/integration/ExpiryEhcacheTestBase.java
@@ -21,7 +21,6 @@ import org.ehcache.CacheManagerBuilder;
 import org.ehcache.config.CacheConfigurationBuilder;
 import org.ehcache.expiry.Duration;
 import org.ehcache.expiry.Expirations;
-import org.ehcache.internal.TimeSource;
 import org.ehcache.internal.TimeSourceConfiguration;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -52,9 +51,9 @@ public abstract class ExpiryEhcacheTestBase {
     manualTimeSource.setTimeMillis(0L);
     CacheManagerBuilder<CacheManager> builder = CacheManagerBuilder.newCacheManagerBuilder().using(new TimeSourceConfiguration(manualTimeSource));
     cacheManager = builder.build(true);
-    CacheConfigurationBuilder<Object, Object> objectObjectCacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Number, CharSequence> objectObjectCacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class)
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.SECONDS)));
-    testCache = cacheManager.createCache("testCache", objectObjectCacheConfigurationBuilder.buildConfig(Number.class, CharSequence.class));
+    testCache = cacheManager.createCache("testCache", objectObjectCacheConfigurationBuilder.build());
   }
 
   @After

--- a/integration-test/src/test/java/org/ehcache/integration/ExpiryEventsTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/ExpiryEventsTest.java
@@ -59,7 +59,7 @@ public class ExpiryEventsTest {
       ResourcePoolsBuilder.newResourcePoolsBuilder().heap(3, EntryUnit.ENTRIES);
 
   private static final CacheConfigurationBuilder<Long, String> byRefCacheConfigBuilder =
-      CacheConfigurationBuilder.<Long, String>newCacheConfigurationBuilder()
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
           .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.SECONDS)));;
 
   private static final CacheConfigurationBuilder<Long, String> byValueCacheConfigBuilder =
@@ -93,7 +93,7 @@ public class ExpiryEventsTest {
   public void testExpiredEventsOnHeapByReference() throws Exception {
 
     Cache<Long, String> testCache = cacheManager.createCache("onHeapCache",
-        byRefCacheConfigBuilder.buildConfig(Long.class, String.class));
+        byRefCacheConfigBuilder.build());
 
     performActualTest(testCache);
  }
@@ -102,7 +102,7 @@ public class ExpiryEventsTest {
   public void testExpiredEventsOnHeapByValue() throws Exception {
 
     Cache<Long, String> testCache = cacheManager.createCache("onHeapCache",
-        byValueCacheConfigBuilder.buildConfig(Long.class, String.class));
+        byValueCacheConfigBuilder.build());
 
     performActualTest(testCache);
   }
@@ -113,7 +113,7 @@ public class ExpiryEventsTest {
     CacheConfigurationBuilder<Long, String> configBuilder = byRefCacheConfigBuilder.withResourcePools(
         resourcePoolsBuilder.offheap(1, MemoryUnit.MB));
     Cache<Long, String> testCache = cacheManager.createCache("onHeapOffHeapCache",
-        configBuilder.buildConfig(Long.class, String.class));
+        configBuilder.build());
 
     performActualTest(testCache);
   }
@@ -124,7 +124,7 @@ public class ExpiryEventsTest {
     CacheConfigurationBuilder<Long, String> configBuilder = byValueCacheConfigBuilder.withResourcePools(
         resourcePoolsBuilder.offheap(1, MemoryUnit.MB));
     Cache<Long, String> testCache = cacheManager.createCache("onHeapOffHeapCache",
-        configBuilder.buildConfig(Long.class, String.class));
+        configBuilder.build());
 
     performActualTest(testCache);
   }
@@ -135,7 +135,7 @@ public class ExpiryEventsTest {
     CacheConfigurationBuilder<Long, String> configBuilder = byRefCacheConfigBuilder.withResourcePools(
         resourcePoolsBuilder.disk(1, MemoryUnit.MB));
     Cache<Long, String> testCache = cacheManager.createCache("onHeapDiskCache",
-        configBuilder.buildConfig(Long.class, String.class));
+        configBuilder.build());
 
     performActualTest(testCache);
   }
@@ -146,7 +146,7 @@ public class ExpiryEventsTest {
     CacheConfigurationBuilder<Long, String> configBuilder = byValueCacheConfigBuilder.withResourcePools(
         resourcePoolsBuilder.disk(1, MemoryUnit.MB));
     Cache<Long, String> testCache = cacheManager.createCache("onHeapDiskCache",
-        configBuilder.buildConfig(Long.class, String.class));
+        configBuilder.build());
 
     performActualTest(testCache);
   }
@@ -157,7 +157,7 @@ public class ExpiryEventsTest {
     CacheConfigurationBuilder<Long, String> configBuilder = byRefCacheConfigBuilder.withResourcePools(
         resourcePoolsBuilder.offheap(1, MemoryUnit.MB).disk(2, MemoryUnit.MB));
     Cache<Long, String> testCache = cacheManager.createCache("onHeapOffHeapDiskCache",
-        configBuilder.buildConfig(Long.class, String.class));
+        configBuilder.build());
 
     performActualTest(testCache);
   }
@@ -168,7 +168,7 @@ public class ExpiryEventsTest {
     CacheConfigurationBuilder<Long, String> configBuilder = byValueCacheConfigBuilder.withResourcePools(
         resourcePoolsBuilder.offheap(1, MemoryUnit.MB).disk(2, MemoryUnit.MB));
     Cache<Long, String> testCache = cacheManager.createCache("onHeapOffHeapDiskCache",
-        configBuilder.buildConfig(Long.class, String.class));
+        configBuilder.build());
 
     performActualTest(testCache);
   }

--- a/integration-test/src/test/java/org/ehcache/integration/LoaderWriterErrorEhcacheTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/LoaderWriterErrorEhcacheTest.java
@@ -17,11 +17,12 @@ package org.ehcache.integration;
 
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
-import org.ehcache.CacheManagerBuilder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.CacheConfigurationBuilder;
 import org.ehcache.exceptions.BulkCacheLoadingException;
+import org.ehcache.exceptions.BulkCacheWritingException;
 import org.ehcache.exceptions.CacheLoadingException;
+import org.ehcache.exceptions.CacheWritingException;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
 import org.junit.After;
@@ -36,9 +37,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.ehcache.exceptions.BulkCacheWritingException;
-import org.ehcache.exceptions.CacheWritingException;
 
 import static org.ehcache.CacheManagerBuilder.newCacheManagerBuilder;
 import static org.hamcrest.Matchers.lessThan;
@@ -73,7 +71,7 @@ public class LoaderWriterErrorEhcacheTest {
     cacheLoaderWriter = mock(CacheLoaderWriter.class);
     when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<Number, CharSequence>) anyObject())).thenReturn((CacheLoaderWriter) cacheLoaderWriter);
     cacheManager = newCacheManagerBuilder().using(cacheLoaderWriterProvider).build(true);
-    testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
   }
 
   @After

--- a/integration-test/src/test/java/org/ehcache/integration/LoaderWriterSimpleEhcacheTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/LoaderWriterSimpleEhcacheTest.java
@@ -58,7 +58,7 @@ public class LoaderWriterSimpleEhcacheTest {
     cacheLoaderWriter = mock(CacheLoaderWriter.class);
     when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<Number, CharSequence>)anyObject())).thenReturn((CacheLoaderWriter) cacheLoaderWriter);
     cacheManager = newCacheManagerBuilder().using(cacheLoaderWriterProvider).build(true);
-    testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
   }
 
   @After

--- a/integration-test/src/test/java/org/ehcache/integration/SimpleEhcacheTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/SimpleEhcacheTest.java
@@ -57,7 +57,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimplePut() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
     assertThat(testCache.get(1), Matchers.<CharSequence>equalTo("one"));
@@ -65,7 +65,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimplePutIfAbsent() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     CharSequence one = testCache.putIfAbsent(1, "one");
     assertThat(one, is(nullValue()));
@@ -76,7 +76,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimplePutAll() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     Map<Integer, String> values = new HashMap<Integer, String>();
     values.put(1, "one");
@@ -92,7 +92,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleGetAll() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -106,7 +106,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleContainsKey() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
 
@@ -116,7 +116,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testClear() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -129,7 +129,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleRemove() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -142,7 +142,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleRemoveAll() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -157,7 +157,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleRemove2Args() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
 
@@ -169,7 +169,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleReplace() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
 
@@ -180,7 +180,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleReplace3Args() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder().buildConfig(Number.class, CharSequence.class));
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Number.class, CharSequence.class).build());
 
     testCache.put(1, "one");
 

--- a/integration-test/src/test/java/org/ehcache/integration/ThreadPoolsTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/ThreadPoolsTest.java
@@ -39,8 +39,8 @@ public class ThreadPoolsTest {
 
     try {
       cacheManager.createCache("testCache",
-          CacheConfigurationBuilder.newCacheConfigurationBuilder()
-              .buildConfig(Long.class, String.class));
+          CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+              .build());
       fail("expected IllegalStateException");
     } catch (IllegalStateException ise) {
       // expected
@@ -59,8 +59,8 @@ public class ThreadPoolsTest {
         .build(true);
 
     cacheManager.createCache("testCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
-            .buildConfig(Long.class, String.class));
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+            .build());
 
     cacheManager.close();
   }
@@ -74,8 +74,8 @@ public class ThreadPoolsTest {
         .build(true);
 
     cacheManager.createCache("testCache",
-        CacheConfigurationBuilder.newCacheConfigurationBuilder()
-            .buildConfig(Long.class, String.class));
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+            .build());
 
     cacheManager.close();
   }
@@ -91,8 +91,8 @@ public class ThreadPoolsTest {
 
     try {
       cacheManager.createCache("testCache",
-          CacheConfigurationBuilder.newCacheConfigurationBuilder()
-              .buildConfig(Long.class, String.class));
+          CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+              .build());
       fail("expected IllegalStateException");
     } catch (IllegalStateException ise) {
       // expected

--- a/integration-test/src/test/java/org/ehcache/integration/TieringTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/TieringTest.java
@@ -36,9 +36,9 @@ public class TieringTest {
   @Test
   public void testDiskTierWithoutPersistenceServiceFailsWithClearException() {
     try {
-      newCacheManagerBuilder().withCache("failing", newCacheConfigurationBuilder().withResourcePools(newResourcePoolsBuilder()
+      newCacheManagerBuilder().withCache("failing", newCacheConfigurationBuilder(Long.class, String.class).withResourcePools(newResourcePoolsBuilder()
           .heap(5, EntryUnit.ENTRIES)
-          .disk(5, MemoryUnit.MB)).buildConfig(Long.class, String.class)).build(true);
+          .disk(5, MemoryUnit.MB)).build()).build(true);
       fail("Should not initialize");
     } catch (StateTransitionException e) {
       assertThat(e.getCause().getCause().getMessage(), containsString("No LocalPersistenceService could be found"));

--- a/integration-test/src/test/java/org/ehcache/integration/transactions/xa/XACacheTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/transactions/xa/XACacheTest.java
@@ -81,16 +81,16 @@ public class XACacheTest {
   public void testEndToEnd() throws Exception {
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)
         );
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).buildConfig(Long.class, String.class))
-        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).buildConfig(Long.class, String.class))
-        .withCache("nonTxCache", cacheConfigurationBuilder.buildConfig(Long.class, String.class))
+        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).build())
+        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).build())
+        .withCache("nonTxCache", cacheConfigurationBuilder.build())
         .using(new XAStoreProviderConfiguration())
         .build(true);
 
@@ -151,15 +151,15 @@ public class XACacheTest {
   public void testRecoveryWithInflightTx() throws Exception {
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)
         );
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).buildConfig(Long.class, String.class))
-        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).buildConfig(Long.class, String.class))
+        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).build())
+        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).build())
         .using(new XAStoreProviderConfiguration())
         .build(true);
 
@@ -200,7 +200,7 @@ public class XACacheTest {
   public void testRecoveryAfterCrash() throws Exception {
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)
@@ -209,8 +209,8 @@ public class XACacheTest {
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(getStoragePath())))
-        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).buildConfig(Long.class, String.class))
-        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).buildConfig(Long.class, String.class))
+        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).build())
+        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).build())
         .using(new XAStoreProviderConfiguration())
         .build(true);
 
@@ -268,7 +268,7 @@ public class XACacheTest {
     TestTimeSource testTimeSource = new TestTimeSource();
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.SECONDS)))
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
@@ -276,8 +276,8 @@ public class XACacheTest {
         );
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).buildConfig(Long.class, String.class))
-        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).buildConfig(Long.class, String.class))
+        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).build())
+        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).build())
         .using(new DefaultTimeSourceService(new TimeSourceConfiguration(testTimeSource)))
         .using(new XAStoreProviderConfiguration())
         .build(true);
@@ -319,7 +319,7 @@ public class XACacheTest {
     TestTimeSource testTimeSource = new TestTimeSource();
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)
@@ -332,13 +332,13 @@ public class XACacheTest {
                 .add(new XAStoreConfiguration("txCache1"))
                 .add(new DefaultCopierConfiguration<Long>(LongCopier.class, CopierConfiguration.Type.KEY))
                 .add(new DefaultCopierConfiguration<String>(StringCopier.class, CopierConfiguration.Type.VALUE))
-                .buildConfig(Long.class, String.class)
+                .build()
         )
         .withCache("txCache2", cacheConfigurationBuilder
             .add(new XAStoreConfiguration("txCache2"))
             .add(new DefaultCopierConfiguration<Long>(LongCopier.class, CopierConfiguration.Type.KEY))
             .add(new DefaultCopierConfiguration<String>(StringCopier.class, CopierConfiguration.Type.VALUE))
-            .buildConfig(Long.class, String.class))
+            .build())
         .using(new DefaultTimeSourceService(new TimeSourceConfiguration(testTimeSource)))
         .using(new XAStoreProviderConfiguration())
         .build(true);
@@ -379,7 +379,7 @@ public class XACacheTest {
     TestTimeSource testTimeSource = new TestTimeSource();
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(10, MemoryUnit.MB)
@@ -391,13 +391,13 @@ public class XACacheTest {
                 .add(new XAStoreConfiguration("txCache1"))
                 .add(new DefaultCopierConfiguration<Long>(LongCopier.class, CopierConfiguration.Type.KEY))
                 .add(new DefaultCopierConfiguration<String>(StringCopier.class, CopierConfiguration.Type.VALUE))
-                .buildConfig(Long.class, String.class)
+                .build()
         )
         .withCache("txCache2", cacheConfigurationBuilder
             .add(new XAStoreConfiguration("txCache2"))
             .add(new DefaultCopierConfiguration<Long>(LongCopier.class, CopierConfiguration.Type.KEY))
             .add(new DefaultCopierConfiguration<String>(StringCopier.class, CopierConfiguration.Type.VALUE))
-            .buildConfig(Long.class, String.class))
+            .build())
         .using(new DefaultTimeSourceService(new TimeSourceConfiguration(testTimeSource)))
         .using(new XAStoreProviderConfiguration())
         .build(true);
@@ -449,7 +449,7 @@ public class XACacheTest {
     TestTimeSource testTimeSource = new TestTimeSource();
     BitronixTransactionManager transactionManager = TransactionManagerServices.getTransactionManager();
 
-    CacheConfigurationBuilder<Object, Object> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfigurationBuilder<Long, String> cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.SECONDS)))
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
@@ -457,8 +457,8 @@ public class XACacheTest {
         );
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).buildConfig(Long.class, String.class))
-        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).buildConfig(Long.class, String.class))
+        .withCache("txCache1", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache1")).build())
+        .withCache("txCache2", cacheConfigurationBuilder.add(new XAStoreConfiguration("txCache2")).build())
         .using(new DefaultTimeSourceService(new TimeSourceConfiguration(testTimeSource)))
         .using(new XAStoreProviderConfiguration())
         .build(true);

--- a/management/src/test/java/org/ehcache/docs/ManagementTest.java
+++ b/management/src/test/java/org/ehcache/docs/ManagementTest.java
@@ -51,9 +51,9 @@ public class ManagementTest {
   @Test
   public void usingManagementRegistry() throws Exception {
     // tag::usingManagementRegistry[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     DefaultManagementRegistryConfiguration registryConfiguration = new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCacheManager"); // <1>
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(registryConfiguration); // <2>
@@ -89,9 +89,9 @@ public class ManagementTest {
   @Test
   public void capabilitiesAndContexts() throws Exception {
     // tag::capabilitiesAndContexts[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry();
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -134,9 +134,9 @@ public class ManagementTest {
   @Test
   public void actionCall() throws Exception {
     // tag::actionCall[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry();
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -164,9 +164,9 @@ public class ManagementTest {
   @Test
   public void managingMultipleCacheManagers() throws Exception {
     // tag::managingMultipleCacheManagers[]
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     SharedManagementService sharedManagementService = new DefaultSharedManagementService(); // <1>
     CacheManager cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryTest.java
@@ -56,9 +56,9 @@ public class DefaultManagementRegistryTest {
 
   @Test
   public void testCanGetContext() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
@@ -78,9 +78,9 @@ public class DefaultManagementRegistryTest {
 
   @Test
   public void testCanGetCapabilities() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
@@ -104,9 +104,9 @@ public class DefaultManagementRegistryTest {
 
   @Test
   public void testCanGetStats() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
@@ -158,9 +158,9 @@ public class DefaultManagementRegistryTest {
 
   @Test
   public void testCanGetStatsSinceTime() throws InterruptedException {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(new DefaultManagementRegistryConfiguration()
         .addConfiguration(new EhcacheStatisticsProviderConfiguration(5000, TimeUnit.MILLISECONDS, 100, 1, TimeUnit.SECONDS, 30, TimeUnit.SECONDS))
@@ -242,9 +242,9 @@ public class DefaultManagementRegistryTest {
 
   @Test
   public void testCall() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
@@ -279,9 +279,9 @@ public class DefaultManagementRegistryTest {
 
   @Test
   public void testCallOnInexistignContext() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     ManagementRegistry managementRegistry = new DefaultManagementRegistry(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 

--- a/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
@@ -65,9 +65,9 @@ public class DefaultSharedManagementServiceTest {
 
   @Before
   public void init() {
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
 
     service = new DefaultSharedManagementService();
 
@@ -191,9 +191,9 @@ public class DefaultSharedManagementServiceTest {
     assertThat(cacheManager1.getCache("aCache1", Long.class, String.class).get(1L), equalTo("1"));
     assertThat(cacheManager2.getCache("aCache2", Long.class, String.class).get(2L), equalTo("2"));
 
-    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder()
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).build())
-        .buildConfig(Long.class, String.class);
+        .build();
     cacheManager1.createCache("aCache4", cacheConfiguration);
 
     cacheManager1.getCache("aCache4", Long.class, String.class).put(4L, "4");

--- a/osgi-test/src/test/java/org/ehcache/osgi/OffHeapOsgiTest.java
+++ b/osgi-test/src/test/java/org/ehcache/osgi/OffHeapOsgiTest.java
@@ -60,8 +60,8 @@ public class OffHeapOsgiTest {
   @Test
   public void testOffHeapInOsgi() {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("myCache", newCacheConfigurationBuilder().withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
-            .buildConfig(Long.class, String.class))
+        .withCache("myCache", newCacheConfigurationBuilder(Long.class, String.class).withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(10, MemoryUnit.MB))
+            .build())
         .build(true);
 
     Cache<Long, String> cache = cacheManager.getCache("myCache", Long.class, String.class);
@@ -75,8 +75,8 @@ public class OffHeapOsgiTest {
   public void testOffHeapClientClass() {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withClassLoader(getClass().getClassLoader())
-        .withCache("myCache", newCacheConfigurationBuilder().withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(2, MemoryUnit.MB))
-            .buildConfig(Long.class, Order.class))
+        .withCache("myCache", newCacheConfigurationBuilder(Long.class, Order.class).withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES).offheap(2, MemoryUnit.MB))
+            .build())
         .build(true);
 
     Cache<Long, Order> cache = cacheManager.getCache("myCache", Long.class, Order.class);

--- a/osgi-test/src/test/java/org/ehcache/osgi/SimpleOsgiTest.java
+++ b/osgi-test/src/test/java/org/ehcache/osgi/SimpleOsgiTest.java
@@ -62,8 +62,8 @@ public class SimpleOsgiTest {
   @Test
   public void testEhcache3AsBundle() {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("myCache", newCacheConfigurationBuilder().withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
-            .buildConfig(Long.class, String.class))
+        .withCache("myCache", newCacheConfigurationBuilder(Long.class, String.class).withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
+            .build())
         .build(true);
 
     Cache<Long, String> myCache = cacheManager.getCache("myCache", Long.class, String.class);
@@ -75,10 +75,10 @@ public class SimpleOsgiTest {
   @Test
   public void testEhcache3WithSerializationAndClientClass() {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("myCache", newCacheConfigurationBuilder().withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
+        .withCache("myCache", newCacheConfigurationBuilder(Long.class, Person.class).withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
             .add(new DefaultCopierConfiguration<Person>((Class) SerializingCopier.class, CopierConfiguration.Type.VALUE))
             .withClassLoader(getClass().getClassLoader())
-            .buildConfig(Long.class, Person.class))
+            .build())
         .build(true);
 
     Cache<Long, Person> myCache = cacheManager.getCache("myCache", Long.class, Person.class);
@@ -90,10 +90,10 @@ public class SimpleOsgiTest {
   @Test
   public void testCustomCopier() {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        .withCache("myCache", newCacheConfigurationBuilder().withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
+        .withCache("myCache", newCacheConfigurationBuilder(Long.class, String.class).withResourcePools(newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
             .add(new DefaultCopierConfiguration<String>(StringCopier.class, CopierConfiguration.Type.VALUE))
             .withClassLoader(getClass().getClassLoader())
-            .buildConfig(Long.class, String.class))
+            .build())
         .build(true);
 
     Cache<Long, String> cache = cacheManager.getCache("myCache", Long.class, String.class);

--- a/transactions/src/test/java/org/ehcache/docs/transactions/xa/XAGettingStarted.java
+++ b/transactions/src/test/java/org/ehcache/docs/transactions/xa/XAGettingStarted.java
@@ -80,12 +80,12 @@ public class XAGettingStarted {
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .using(new XAStoreProviderConfiguration()) // <2>
-        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder() // <3>
+        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class) // <3>
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder() // <4>
                     .heap(10, EntryUnit.ENTRIES)
             )
             .add(new XAStoreConfiguration("xaCache")) // <5>
-            .buildConfig(Long.class, String.class)
+            .build()
         )
         .build(true);
 
@@ -110,12 +110,12 @@ public class XAGettingStarted {
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .using(new XAStoreProviderConfiguration()) // <2>
-        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder() // <3>
+        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class) // <3>
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder() // <4>
                     .heap(10, EntryUnit.ENTRIES)
             )
             .add(new XAStoreConfiguration("xaCache")) // <5>
-            .buildConfig(Long.class, String.class)
+            .build()
         )
         .build(true);
 
@@ -143,12 +143,12 @@ public class XAGettingStarted {
         .using(new XAStoreProviderConfiguration()) // <2>
         .using(new TransactionManagerProviderConfiguration(
             new TransactionManagerWrapper(transactionManager, new BitronixXAResourceRegistry()))) // <3>
-        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder() // <4>
+        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class) // <4>
             .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder() // <5>
                     .heap(10, EntryUnit.ENTRIES)
             )
             .add(new XAStoreConfiguration("xaCache")) // <6>
-            .buildConfig(Long.class, String.class)
+            .build()
         )
         .build(true);
 
@@ -175,13 +175,13 @@ public class XAGettingStarted {
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .using(new XAStoreProviderConfiguration()) // <2>
-        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder() // <3>
+        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class) // <3>
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder() // <4>
                         .heap(10, EntryUnit.ENTRIES)
                 )
                 .add(new XAStoreConfiguration("xaCache")) // <5>
                 .add(new DefaultCacheLoaderWriterConfiguration(klazz, singletonMap(1L, "eins"))) // <6>
-                .buildConfig(Long.class, String.class)
+                .build()
         )
         .build(true);
 
@@ -208,14 +208,14 @@ public class XAGettingStarted {
     PersistentCacheManager persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .using(new XAStoreProviderConfiguration()) // <2>
         .with(new CacheManagerPersistenceConfiguration(new File(getStoragePath(), "testXACacheWithThreeTiers"))) // <3>
-        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder() // <4>
+        .withCache("xaCache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class) // <4>
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder() // <5>
                         .heap(10, EntryUnit.ENTRIES)
                         .offheap(10, MemoryUnit.MB)
                         .disk(20, MemoryUnit.MB, true)
                 )
                 .add(new XAStoreConfiguration("xaCache")) // <6>
-                .buildConfig(Long.class, String.class)
+                .build()
         )
         .build(true);
 

--- a/xml/src/test/java/org/ehcache/config/xml/IntegrationConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/config/xml/IntegrationConfigurationTest.java
@@ -67,7 +67,7 @@ public class IntegrationConfigurationTest {
     baz.put("1", "one");
     assertThat(baz.get("1"), equalTo("one"));
 
-    Cache<String, Object> bam = cacheManager.createCache("bam", newCacheConfigurationBuilder().buildConfig(String.class, Object.class));
+    Cache<String, Object> bam = cacheManager.createCache("bam", newCacheConfigurationBuilder(String.class, Object.class).build());
     bam.put("1", "one");
     assertThat(bam.get("1"), equalTo((Object)"one"));
 
@@ -201,10 +201,10 @@ public class IntegrationConfigurationTest {
     final CacheManager cacheManager = CacheManagerBuilder.newCacheManager(configuration);
     cacheManager.init();
     try {
-      Cache<String, String> cache = cacheManager.createCache("testThreadPools", newCacheConfigurationBuilder()
+      Cache<String, String> cache = cacheManager.createCache("testThreadPools", newCacheConfigurationBuilder(String.class, String.class)
               .add(new DefaultCacheLoaderWriterConfiguration(ThreadRememberingLoaderWriter.class))
               .add(newUnBatchedWriteBehindConfiguration().useThreadPool("small"))
-              .buildConfig(String.class, String.class));
+              .build());
 
       cache.put("foo", "bar");
 
@@ -222,10 +222,10 @@ public class IntegrationConfigurationTest {
     final CacheManager cacheManager = CacheManagerBuilder.newCacheManager(configuration);
     cacheManager.init();
     try {
-      Cache<String, String> cache = cacheManager.createCache("testThreadPools", newCacheConfigurationBuilder()
+      Cache<String, String> cache = cacheManager.createCache("testThreadPools", newCacheConfigurationBuilder(String.class, String.class)
               .add(new DefaultCacheLoaderWriterConfiguration(ThreadRememberingLoaderWriter.class))
               .add(newUnBatchedWriteBehindConfiguration())
-              .buildConfig(String.class, String.class));
+              .build());
 
       cache.put("foo", "bar");
 


### PR DESCRIPTION
Parameters previously given to *Builder.build(...) are now given to *Buider.new*Builder(...). This has two nice side effects:

 - All builders now implement the Builder interface that mandates a build() method.
 - The ugly casts in GettingStarted are gone as the compiler can now infer the types.