### PR TITLE
Issue #740 Prevent duplicate service configuration in builder

### DIFF
--- a/core/src/main/java/org/ehcache/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/EhcacheManager.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -111,7 +112,19 @@ public class EhcacheManager implements PersistentCacheManager {
     this.useLoaderInAtomics = useLoaderInAtomics;
     this.cacheManagerClassLoader = config.getClassLoader() != null ? config.getClassLoader() : ClassLoading.getDefaultClassLoader();
     this.configuration = new DefaultConfiguration(config);
+    validateServicesConfigs();
   }
+
+
+  private void validateServicesConfigs() {
+    HashSet<Class> classes = new HashSet<Class>();
+    for (ServiceCreationConfiguration<?> service : configuration.getServiceCreationConfigurations()) {
+      if (!classes.add(service.getServiceType())) {
+        throw new IllegalStateException("Duplicate creation configuration for service " + service.getServiceType());
+      }
+    }
+  }
+
 
   @Override
   public <K, V> Cache<K, V> getCache(String alias, Class<K> keyType, Class<V> valueType) {

--- a/core/src/main/java/org/ehcache/spi/ServiceLocator.java
+++ b/core/src/main/java/org/ehcache/spi/ServiceLocator.java
@@ -200,7 +200,7 @@ public final class ServiceLocator implements ServiceProvider {
     } else if (matches.size() == 1) {
       return matches.iterator().next();
     } else {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("More than one " + clazz.getName() + " found");
     }
   }
 

--- a/core/src/test/java/org/ehcache/EhcacheManagerTest.java
+++ b/core/src/test/java/org/ehcache/EhcacheManagerTest.java
@@ -22,6 +22,7 @@ import org.ehcache.config.Configuration;
 import org.ehcache.config.DefaultConfiguration;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourcePoolsHelper;
+import org.ehcache.config.persistence.DefaultPersistenceConfiguration;
 import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.events.CacheEventDispatcher;
 import org.ehcache.events.CacheEventDispatcherFactory;
@@ -46,12 +47,14 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -121,6 +124,27 @@ public class EhcacheManagerTest {
     } catch (StateTransitionException e) {
       assertTrue(e.getMessage().contains(NoSuchService.class.getName()));
       assertTrue(e.getCause().getMessage().contains(NoSuchService.class.getName()));
+    }
+  }
+
+  @Test
+  public void testCreationFailsOnDuplicateServiceCreationConfiguration() {
+    DefaultConfiguration config = new DefaultConfiguration(Collections.<String, CacheConfiguration<?, ?>>emptyMap(), null, new ServiceCreationConfiguration<NoSuchService>() {
+      @Override
+      public Class<NoSuchService> getServiceType() {
+        return NoSuchService.class;
+      }
+    }, new ServiceCreationConfiguration<NoSuchService>() {
+      @Override
+      public Class<NoSuchService> getServiceType() {
+        return NoSuchService.class;
+      }
+    });
+    try {
+      new EhcacheManager(config);
+      fail("Should have thrown ...");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString("NoSuchService"));
     }
   }
   

--- a/impl/src/main/java/org/ehcache/config/ConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/ConfigurationBuilder.java
@@ -83,6 +83,10 @@ public class ConfigurationBuilder implements Builder<Configuration> {
   }
 
   public ConfigurationBuilder addService(ServiceCreationConfiguration<?> serviceConfiguration) {
+    if (findServiceByClass(serviceConfiguration.getClass()) != null) {
+      throw new IllegalArgumentException("There is already a ServiceCreationConfiguration registered for service " + serviceConfiguration
+          .getServiceType() + " of type " + serviceConfiguration.getClass());
+    }
     List<ServiceCreationConfiguration<?>> newServiceConfigurations = new ArrayList<ServiceCreationConfiguration<?>>(serviceConfigurations);
     newServiceConfigurations.add(serviceConfiguration);
     return new ConfigurationBuilder(this, newServiceConfigurations);

--- a/impl/src/main/java/org/ehcache/config/copy/DefaultCopyProviderConfiguration.java
+++ b/impl/src/main/java/org/ehcache/config/copy/DefaultCopyProviderConfiguration.java
@@ -26,19 +26,56 @@ import org.ehcache.spi.service.ServiceCreationConfiguration;
  */
 public class DefaultCopyProviderConfiguration extends ClassInstanceProviderConfiguration<Class<?>, Copier<?>> implements ServiceCreationConfiguration<CopyProvider> {
 
+  public DefaultCopyProviderConfiguration() {
+    // Default constructor
+  }
+
+  public DefaultCopyProviderConfiguration(DefaultCopyProviderConfiguration other) {
+    getDefaults().putAll(other.getDefaults());
+  }
+
   @Override
   public Class<CopyProvider> getServiceType() {
     return CopyProvider.class;
   }
 
+  /**
+   * Adds a new {@code Class} - {@link Copier} pair to this configuration object
+   *
+   * @param clazz the {@code Class} for which this copier is
+   * @param copierClass the {@link Copier} type to use
+   * @param <T> the type of objects the copier will deal with
+   *
+   * @return this configuration instance
+   *
+   * @throws NullPointerException if any argument is null
+   * @throws IllegalArgumentException in a case a mapping for {@code clazz} already exists
+   */
   public <T> DefaultCopyProviderConfiguration addCopierFor(Class<T> clazz, Class<? extends Copier<T>> copierClass) {
+    return addCopierFor(clazz, copierClass, false);
+  }
+
+  /**
+   * Adds a new {@code Class} - {@link Copier} pair to this configuration object
+   *
+   * @param clazz the {@code Class} for which this copier is
+   * @param copierClass the {@link Copier} type to use
+   * @param overwrite indicates if an existing mapping is to be overwritten
+   * @param <T> the type of objects the copier will deal with
+   *
+   * @return this configuration instance
+   *
+   * @throws NullPointerException if any argument is null
+   * @throws IllegalArgumentException in a case a mapping for {@code clazz} already exists and {@code overwrite} is {@code false}
+   */
+  public <T> DefaultCopyProviderConfiguration addCopierFor(Class<T> clazz, Class<? extends Copier<T>> copierClass, boolean overwrite) {
     if (clazz == null) {
       throw new NullPointerException("Copy target class cannot be null");
     }
     if (copierClass == null) {
       throw new NullPointerException("Copier class cannot be null");
     }
-    if (getDefaults().containsKey(clazz)) {
+    if (!overwrite && getDefaults().containsKey(clazz)) {
       throw new IllegalArgumentException("Duplicate copier for class : " + clazz);
     }
     getDefaults().put(clazz, new DefaultCopierConfiguration(copierClass));

--- a/impl/src/main/java/org/ehcache/internal/events/CacheEventDispatcherFactoryImpl.java
+++ b/impl/src/main/java/org/ehcache/internal/events/CacheEventDispatcherFactoryImpl.java
@@ -21,7 +21,6 @@ import org.ehcache.events.CacheEventDispatcherFactory;
 import org.ehcache.events.CacheEventDispatcher;
 import org.ehcache.events.CacheEventDispatcherImpl;
 import org.ehcache.events.DisabledCacheEventNotificationService;
-import org.ehcache.spi.ServiceLocator;
 import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.service.ExecutionService;
@@ -30,6 +29,8 @@ import org.ehcache.spi.service.ServiceDependencies;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.ehcache.spi.ServiceLocator.findSingletonAmongst;
 
 /**
  * {@link CacheEventDispatcher} implementation that shares a single {@link ExecutorService} for unordered firing
@@ -66,7 +67,7 @@ public class CacheEventDispatcherFactoryImpl implements CacheEventDispatcherFact
   @Override
   public <K, V> CacheEventDispatcher<K, V> createCacheEventDispatcher(Store<K, V> store, ServiceConfiguration<?>... serviceConfigs) {
     String tPAlias = threadPoolAlias;
-    DefaultCacheEventDispatcherConfiguration config = ServiceLocator.findSingletonAmongst(DefaultCacheEventDispatcherConfiguration.class, serviceConfigs);
+    DefaultCacheEventDispatcherConfiguration config = findSingletonAmongst(DefaultCacheEventDispatcherConfiguration.class, serviceConfigs);
     if (config != null) {
       tPAlias = config.getThreadPoolAlias();
     }

--- a/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProvider.java
+++ b/impl/src/main/java/org/ehcache/spi/loaderwriter/DefaultCacheLoaderWriterProvider.java
@@ -27,7 +27,7 @@ import org.ehcache.internal.classes.ClassInstanceProvider;
 public class DefaultCacheLoaderWriterProvider extends ClassInstanceProvider<String, CacheLoaderWriter<?, ?>> implements CacheLoaderWriterProvider {
 
   public DefaultCacheLoaderWriterProvider(DefaultCacheLoaderWriterProviderConfiguration configuration) {
-    super(configuration, DefaultCacheLoaderWriterConfiguration.class);
+    super(configuration, DefaultCacheLoaderWriterConfiguration.class, true);
   }
 
   @SuppressWarnings("unchecked")

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -38,7 +38,6 @@ import org.ehcache.docs.plugs.SampleLoaderWriter;
 import org.ehcache.docs.plugs.StringSerializer;
 import org.ehcache.event.EventType;
 import org.ehcache.internal.copy.ReadWriteCopier;
-import org.ehcache.internal.sizeof.DefaultSizeOfEngineConfiguration;
 import org.ehcache.spi.serialization.Serializer;
 import org.junit.Test;
 
@@ -166,8 +165,7 @@ public class GettingStarted {
     CacheConfiguration<Long, String> usesConfiguredInCacheConfig = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
             .heap(10, MemoryUnit.KB) // <1>
-            .offheap(10, MemoryUnit.MB)
-            .build())
+            .offheap(10, MemoryUnit.MB))
         .withSizeOfMaxObjectGraph(1000)
         .withSizeOfMaxObjectSize(1000, MemoryUnit.B) // <2>
         .build();
@@ -175,8 +173,7 @@ public class GettingStarted {
     CacheConfiguration<Long, String> usesDefaultSizeOfEngineConfig = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
             .heap(10, MemoryUnit.KB)
-            .offheap(10, MemoryUnit.MB)
-            .build())
+            .offheap(10, MemoryUnit.MB))
         .build();
 
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()


### PR DESCRIPTION
When creating the cache configuration, most service configuration are
 expected to exist as a single instance. The builder now takes care of
 achieving this. At the same time, service consuming these configuration
 now properly check that no duplicates are found when this is not valid.

This pull requests takes care of the `CacheConfigurationBuilder` level, `CacheManagerBuilder` level to come later.