### PR TITLE
#165: fix event listener configuration

### DIFF
--- a/core/src/main/java/org/ehcache/events/CacheEventDispatcherImpl.java
+++ b/core/src/main/java/org/ehcache/events/CacheEventDispatcherImpl.java
@@ -165,6 +165,7 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
     storeEventSource.setEventOrdering(false);
     syncListenersList.clear();
     aSyncListenersList.clear();
+    unOrderedExectuor.shutdown();
     orderedExecutor.shutdown();
   }
 
@@ -176,7 +177,7 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
   public void onEvent(CacheEvent<K, V> event) {
     ExecutorService executor;
     if (storeEventSource.isEventOrdering()) {
-      executor= orderedExecutor;
+      executor = orderedExecutor;
     } else {
       executor = unOrderedExectuor;
     }

--- a/impl/src/test/java/org/ehcache/internal/events/CacheEventDispatcherFactoryImplTest.java
+++ b/impl/src/test/java/org/ehcache/internal/events/CacheEventDispatcherFactoryImplTest.java
@@ -17,11 +17,21 @@
 package org.ehcache.internal.events;
 
 import org.ehcache.config.event.DefaultCacheEventDispatcherConfiguration;
+import org.ehcache.events.CacheEventDispatcher;
+import org.ehcache.events.CacheEventDispatcherImpl;
 import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.cache.Store;
 import org.ehcache.spi.service.ExecutionService;
 import org.junit.Test;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -43,4 +53,37 @@ public class CacheEventDispatcherFactoryImplTest {
     verify(config).getThreadPoolAlias();
   }
 
+  @Test
+  public void testCreateCacheEventDispatcherReturnsDisabledDispatcherWhenNoThreadPool() throws Exception {
+    ServiceProvider serviceProvider = mock(ServiceProvider.class);
+    ExecutionService executionService = mock(ExecutionService.class);
+    when(serviceProvider.getService(ExecutionService.class)).thenReturn(executionService);
+    when(executionService.getOrderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenThrow(IllegalArgumentException.class);
+    when(executionService.getUnorderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenThrow(IllegalArgumentException.class);
+
+    CacheEventDispatcherFactoryImpl cacheEventDispatcherFactory = new CacheEventDispatcherFactoryImpl();
+    cacheEventDispatcherFactory.start(serviceProvider);
+
+    try {
+      cacheEventDispatcherFactory.createCacheEventDispatcher(mock(Store.class), new DefaultCacheEventDispatcherConfiguration("myAlias"));
+      fail("expected IllegalArgumentException");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testCreateCacheEventReturnsDisabledDispatcherWhenThreadPoolFound() throws Exception {
+    ServiceProvider serviceProvider = mock(ServiceProvider.class);
+    ExecutionService executionService = mock(ExecutionService.class);
+    when(serviceProvider.getService(ExecutionService.class)).thenReturn(executionService);
+    when(executionService.getOrderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenReturn(mock(ExecutorService.class));
+    when(executionService.getUnorderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenReturn(mock(ExecutorService.class));
+
+    CacheEventDispatcherFactoryImpl cacheEventDispatcherFactory = new CacheEventDispatcherFactoryImpl();
+    cacheEventDispatcherFactory.start(serviceProvider);
+
+    CacheEventDispatcher dispatcher = cacheEventDispatcherFactory.createCacheEventDispatcher(mock(Store.class), new DefaultCacheEventDispatcherConfiguration("myAlias"));
+    assertThat(dispatcher, instanceOf(CacheEventDispatcherImpl.class));
+  }
 }


### PR DESCRIPTION
Without this patch, a default thread pool is always needed for events even if a specific events pool is configured.