### PR TITLE
Issue #722 Terracotta clustering service configuration support

### DIFF
--- a/api/src/main/java/org/ehcache/config/ResourceType.java
+++ b/api/src/main/java/org/ehcache/config/ResourceType.java
@@ -23,10 +23,16 @@ package org.ehcache.config;
 public interface ResourceType {
 
   /**
-   * Whether the resource supports persistence
+   * Whether the resource supports persistence.
    * @return <code>true</code> if it supports persistence
    */
   boolean isPersistable();
+
+  /**
+   * Whether the resource requires serialization support.
+   * @return <code>true</code> if serializers are required
+   */
+  boolean requiresSerialization();
 
   /**
    * An enumeration of resource types handled by core ehcache.
@@ -35,26 +41,33 @@ public interface ResourceType {
     /**
      * Heap resource.
      */
-    HEAP(false),
+    HEAP(false, false),
     /**
      * OffHeap resource.
      */
-    OFFHEAP(false),
+    OFFHEAP(false, true),
     /**
      * Disk resource.
      */
-    DISK(true);
+    DISK(true, true);
 
 
     private final boolean persistable;
+    private final boolean requiresSerialization;
 
-    Core(boolean persistable) {
+    Core(boolean persistable, final boolean requiresSerialization) {
       this.persistable = persistable;
+      this.requiresSerialization = requiresSerialization;
     }
 
     @Override
     public boolean isPersistable() {
       return persistable;
+    }
+
+    @Override
+    public boolean requiresSerialization() {
+      return requiresSerialization;
     }
 
     @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManager.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.Maintainable;
+import org.ehcache.clustered.exceptions.CacheDurabilityException;
+
+/**
+ * Specifies a {@link CacheManager} supporting clustered operations.
+ *
+ * @author Clifford W. Johnson
+ */
+public interface ClusteredCacheManager extends CacheManager {
+
+  /**
+   * Lets you manipulate the durable, clustered data structures for this {@code ClusteredCacheManager}.
+   *
+   * @return a {@link org.ehcache.Maintainable} for this {@link ClusteredCacheManager}
+   * @throws java.lang.IllegalStateException if state {@link org.ehcache.Status#MAINTENANCE} couldn't be reached
+   */
+  Maintainable toMaintenance();
+
+  /**
+   * Destroys all durable data associated with the aliased {@link Cache} instance managed
+   * by this {@code ClusteredCacheManager}.
+   *
+   * @param alias the alias of the {@link Cache} in which all durable, clustered data is destroyed
+   *
+   * @throws CacheDurabilityException When something goes wrong destroying the durable data
+   */
+  void destroyCache(String alias) throws CacheDurabilityException;
+
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManagerBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManagerBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.config.Configuration;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ConfigurationBuilder;
+import org.ehcache.spi.service.Service;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * @author Clifford W. Johnson
+ */
+public class ClusteredCacheManagerBuilder extends CacheManagerBuilder<ClusteredCacheManager> {
+
+  protected ClusteredCacheManagerBuilder(final CacheManagerBuilder<ClusteredCacheManager> builder, final Set<Service> services) {
+    super(builder, services);
+  }
+
+  protected ClusteredCacheManagerBuilder(final CacheManagerBuilder<ClusteredCacheManager> builder, final ConfigurationBuilder configBuilder) {
+    super(builder, configBuilder);
+  }
+
+  private ClusteredCacheManagerBuilder(final CacheManagerBuilder<?> builder) {
+    super(builder);
+  }
+
+  @Override
+  protected ClusteredCacheManager newCacheManager(final Collection<Service> services, final Configuration configuration) {
+    return new ClusteredCacheManagerImpl(configuration, services);
+  }
+
+  @Override
+  protected ClusteredCacheManagerBuilder newBuilder(final Set<Service> services) {
+    return new ClusteredCacheManagerBuilder(this, services);
+  }
+
+  @Override
+  protected ClusteredCacheManagerBuilder newBuilder(final ConfigurationBuilder builder) {
+    return new ClusteredCacheManagerBuilder(this, builder);
+  }
+
+  public static ClusteredCacheManager newCacheManager(final Configuration configuration) {
+    return CacheManagerBuilder.newSpecializedCacheManager(ClusteredCacheManager.class, configuration);
+  }
+
+  public static ClusteredCacheManagerBuilder newCacheManagerBuilder(final CacheManagerBuilder<?> builder) {
+    return new ClusteredCacheManagerBuilder(builder);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManagerImpl.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManagerImpl.java
@@ -63,7 +63,7 @@ class ClusteredCacheManagerImpl extends BaseCacheManager implements ClusteredCac
 
   @Override
   public Maintainable toMaintenance() {
-    return null;
+    throw new UnsupportedOperationException("not yet implemented");
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManagerImpl.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/ClusteredCacheManagerImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.Maintainable;
+import org.ehcache.clustered.exceptions.CacheDurabilityException;
+import org.ehcache.config.Configuration;
+import org.ehcache.core.BaseCacheManager;
+import org.ehcache.core.Ehcache;
+import org.ehcache.core.events.CacheEventDispatcherFactory;
+import org.ehcache.core.spi.cache.Store;
+import org.ehcache.event.CacheEventListenerProvider;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
+import org.ehcache.spi.loaderwriter.WriteBehindProvider;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceDependencies;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Provides an implementation for a clustered {@link org.ehcache.CacheManager CacheManager}.
+ *
+ * @author Clifford W. Johnson
+ */
+class ClusteredCacheManagerImpl extends BaseCacheManager implements ClusteredCacheManager {
+
+  // TODO: Determine a way to identify the dependencies of BaseCacheManager ...
+  @ServiceDependencies({
+      Store.Provider.class,
+      CacheLoaderWriterProvider.class,
+      WriteBehindProvider.class,
+      CacheEventDispatcherFactory.class,
+      CacheEventListenerProvider.class
+  })
+  private static class ServiceDeps {
+    private ServiceDeps() {
+      throw new UnsupportedOperationException("This is an annotation place holder, not to be instantiated");
+    }
+  }
+
+  public ClusteredCacheManagerImpl(final Configuration configuration) {
+    this(configuration, Collections.<Service>emptyList());
+  }
+
+  public ClusteredCacheManagerImpl(final Configuration configuration, final Collection<Service> services) {
+    super(configuration, services, true);
+  }
+
+  @Override
+  public Maintainable toMaintenance() {
+    return null;
+  }
+
+  @Override
+  public void destroyCache(final String alias) throws CacheDurabilityException {
+  }
+
+  @Override
+  protected Class<?> getServiceDependencyMarkerClass() {
+    return ServiceDeps.class;
+  }
+
+  @Override
+  protected void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config;
+
+import org.ehcache.CacheManager;
+import org.ehcache.clustered.ClusteredCacheManager;
+import org.ehcache.clustered.ClusteredCacheManagerBuilder;
+import org.ehcache.clustered.service.ClusteringService;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.CacheManagerConfiguration;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+import java.net.URI;
+
+/**
+ * Specifies the configuration for a {@link ClusteringService}.
+ *
+ * @author Clifford W. Johnson
+ */
+// TODO: Should this accept/hold a *list* of URIs?
+// TODO: Is 'alias' *required*?
+public class ClusteringServiceConfiguration
+    implements ServiceCreationConfiguration<ClusteringService>,
+    CacheManagerConfiguration<ClusteredCacheManager> {
+
+  private final String alias;
+  private final URI connectionUrl;
+
+  public ClusteringServiceConfiguration(final String alias, final URI connectionUrl) {
+    if (connectionUrl == null) {
+      throw new NullPointerException("connectionUrl");
+    }
+    this.alias = (alias == null ? "" : alias);
+    this.connectionUrl = connectionUrl;
+  }
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public URI getConnectionUrl() {
+    return connectionUrl;
+  }
+
+  @Override
+  public Class<ClusteringService> getServiceType() {
+    return ClusteringService.class;
+  }
+
+  @Override
+  public CacheManagerBuilder<ClusteredCacheManager> builder(final CacheManagerBuilder<? extends CacheManager> other) {
+    return ClusteredCacheManagerBuilder.newCacheManagerBuilder(other).using(this);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
@@ -33,6 +33,7 @@ import java.net.URI;
  */
 // TODO: Should this accept/hold a *list* of URIs?
 // TODO: Is 'alias' *required*?
+// TODO: Add validation for connection URI(s)
 public class ClusteringServiceConfiguration
     implements ServiceCreationConfiguration<ClusteringService>,
     CacheManagerConfiguration<ClusteredCacheManager> {

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
@@ -32,25 +32,18 @@ import java.net.URI;
  * @author Clifford W. Johnson
  */
 // TODO: Should this accept/hold a *list* of URIs?
-// TODO: Is 'alias' *required*?
 // TODO: Add validation for connection URI(s)
 public class ClusteringServiceConfiguration
     implements ServiceCreationConfiguration<ClusteringService>,
     CacheManagerConfiguration<ClusteredCacheManager> {
 
-  private final String alias;
   private final URI connectionUrl;
 
-  public ClusteringServiceConfiguration(final String alias, final URI connectionUrl) {
+  public ClusteringServiceConfiguration(final URI connectionUrl) {
     if (connectionUrl == null) {
       throw new NullPointerException("connectionUrl");
     }
-    this.alias = (alias == null ? "" : alias);
     this.connectionUrl = connectionUrl;
-  }
-
-  public String getAlias() {
-    return alias;
   }
 
   public URI getConnectionUrl() {

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteredCacheConstants.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteredCacheConstants.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config.xml;
+
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * Constants shared between XML parsers used for clustered cache support.
+ *
+ * @author Clifford W. Johnson
+ */
+final class ClusteredCacheConstants {
+  /**
+   * Name of schema resource file.
+   */
+  static final String XSD = "ehcache-clustered-ext.xsd";
+  static final URL XML_SCHEMA = ClusteredCacheConstants.class.getResource("/" + XSD);
+  /**
+   * Namespace for cluster configuration elements.  Must match {@code targetNamespace} in <code>{@value #XSD}</code>.
+   */
+  static final URI NAMESPACE = URI.create("http://www.ehcache.org/v3/clustered");
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
@@ -20,6 +20,7 @@ import org.ehcache.clustered.config.ClusteringServiceConfiguration;
 import org.ehcache.clustered.service.ClusteringService;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
 import org.ehcache.xml.CacheManagerServiceConfigurationParser;
+import org.ehcache.xml.exceptions.XmlConfigurationException;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -27,6 +28,7 @@ import org.w3c.dom.NodeList;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
@@ -84,13 +86,13 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
             final Attr urlAttribute = ((Element)item).getAttributeNode("url");
             final String urlValue = urlAttribute.getValue();
             try {
-              connectionUri = URI.create(urlValue);
-            } catch (IllegalArgumentException e) {
-              throw new RuntimeException(
+              connectionUri = new URI(urlValue);
+            } catch (URISyntaxException e) {
+              throw new XmlConfigurationException(
                   String.format("Value of %s attribute on XML configuration element <%s> in <%s> is not a valid URI - '%s'",
                       urlAttribute.getName(), fragment.getTagName(),
                       (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName()),
-                      connectionUri));
+                      connectionUri), e);
             }
           }
         }
@@ -98,7 +100,7 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
       // TODO: Validate connectionUri is valid URL with proper content
       return new ClusteringServiceConfiguration(alias, connectionUri);
     }
-    throw new RuntimeException(String.format("XML configuration element <%s> in <%s> is not supported",
+    throw new XmlConfigurationException(String.format("XML configuration element <%s> in <%s> is not supported",
         fragment.getTagName(), (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName())));
   }
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config.xml;
+
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.service.ClusteringService;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.ehcache.xml.CacheManagerServiceConfigurationParser;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+import static org.ehcache.clustered.config.xml.ClusteredCacheConstants.*;
+
+/**
+ * Provides parsing support for the {@code <service>} elements representing a {@link ClusteringService ClusteringService}.
+ *
+ * @author Clifford W. Johnson
+ *
+ * @see ClusteredCacheConstants#XSD
+ */
+public class ClusteringServiceConfigurationParser implements CacheManagerServiceConfigurationParser<ClusteringService> {
+
+  @Override
+  public Source getXmlSchema() throws IOException {
+    return new StreamSource(XML_SCHEMA.openStream());
+  }
+
+  @Override
+  public URI getNamespace() {
+    return NAMESPACE;
+  }
+
+  /**
+   * Complete interpretation of the top-level elements defined in <code>{@value ClusteredCacheConstants#XSD}</code>.
+   * This method is called only for those elements from the namespace set by {@link ClusteredCacheConstants#NAMESPACE}.
+   *
+   * @param fragment the XML fragment to process
+   *
+   * @return a {@link org.ehcache.clustered.config.ClusteringServiceConfiguration ClusteringServiceConfiguration}
+   */
+  @Override
+  public ServiceCreationConfiguration<ClusteringService> parseServiceCreationConfiguration(final Element fragment) {
+    /*
+     * The presumptions in this code are:
+     *   1) the Element is schema-validated
+     *   2) 'connection' is defined as required (minOccurs=1, maxOccurs=1)
+     *   3) 'connection.url' is defined as "required"
+     *   4) 'cluster.alias' is optional
+     *   5) no other elements or attributes are defined
+     */
+    if ("cluster".equals(fragment.getLocalName())) {
+
+      final Attr aliasAttribute = fragment.getAttributeNode("alias");
+      final String alias = (aliasAttribute == null ? "" : aliasAttribute.getValue());
+
+      URI connectionUri = null;
+      final NodeList childNodes = fragment.getChildNodes();
+      for (int i = 0; i < childNodes.getLength(); i++) {
+        final Node item = childNodes.item(i);
+        if (Node.ELEMENT_NODE == item.getNodeType()) {
+          if ("connection".equals(item.getLocalName())) {
+            final Attr urlAttribute = ((Element)item).getAttributeNode("url");
+            final String urlValue = urlAttribute.getValue();
+            try {
+              connectionUri = URI.create(urlValue);
+            } catch (IllegalArgumentException e) {
+              throw new RuntimeException(
+                  String.format("Value of %s attribute on XML configuration element <%s> in <%s> is not a valid URI - '%s'",
+                      urlAttribute.getName(), fragment.getTagName(),
+                      (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName()),
+                      connectionUri));
+            }
+          }
+        }
+      }
+      // TODO: Validate connectionUri is valid URL with proper content
+      return new ClusteringServiceConfiguration(alias, connectionUri);
+    }
+    throw new RuntimeException(String.format("XML configuration element <%s> in <%s> is not supported",
+        fragment.getTagName(), (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName())));
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
@@ -69,13 +69,9 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
      *   1) the Element is schema-validated
      *   2) 'connection' is defined as required (minOccurs=1, maxOccurs=1)
      *   3) 'connection.url' is defined as "required"
-     *   4) 'cluster.alias' is optional
-     *   5) no other elements or attributes are defined
+     *   4) no other elements or attributes are defined
      */
     if ("cluster".equals(fragment.getLocalName())) {
-
-      final Attr aliasAttribute = fragment.getAttributeNode("alias");
-      final String alias = (aliasAttribute == null ? "" : aliasAttribute.getValue());
 
       URI connectionUri = null;
       final NodeList childNodes = fragment.getChildNodes();
@@ -98,7 +94,7 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
         }
       }
       // TODO: Validate connectionUri is valid URL with proper content
-      return new ClusteringServiceConfiguration(alias, connectionUri);
+      return new ClusteringServiceConfiguration(connectionUri);
     }
     throw new XmlConfigurationException(String.format("XML configuration element <%s> in <%s> is not supported",
         fragment.getTagName(), (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName())));

--- a/clustered/client/src/main/java/org/ehcache/clustered/exceptions/CacheDurabilityException.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/exceptions/CacheDurabilityException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.exceptions;
+
+/**
+ * Thrown by a {@link org.ehcache.clustered.ClusteredCacheManager ClusteredCacheManager} to
+ * indicate an error making the cache content durable.
+ *
+ * @author Clifford W. Johnson
+ */
+public class CacheDurabilityException extends Exception {
+  private static final long serialVersionUID = -2136833329018250611L;
+
+  /**
+   * Creates an exception with the provided message.
+   *
+   * @param message information about the exception
+   */
+  public CacheDurabilityException(final String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with the provided message and cause.
+   *
+   * @param message information about the exception
+   * @param cause the cause of this exception
+   */
+  public CacheDurabilityException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/service/ClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/service/ClusteringService.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-apply plugin: EhDeploy
+package org.ehcache.clustered.service;
 
-dependencies {
-  compile project(':api')
-  compile project(':xml')
-  compile project(':clustered:common')
-  compile "org.terracotta:coordinator-entity-client:$parent.coordinatorVersion"
-  compile "org.terracotta:entity-client-api:$parent.entityApiVersion"
+import org.ehcache.spi.service.Service;
+
+/**
+ * @author Clifford W. Johnson
+ */
+public interface ClusteringService extends Service {
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/service/ClusteringServiceFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/service/ClusteringServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.service;
+
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+/**
+ * A factory for creating a {@link ClusteringService} instance.
+ *
+ * @author Clifford W. Johnson
+ */
+public class ClusteringServiceFactory implements ServiceFactory<ClusteringService> {
+
+  @Override
+  public ClusteringService create(final ServiceCreationConfiguration<ClusteringService> configuration) {
+    return new DefaultClusteringService((ClusteringServiceConfiguration) configuration);
+  }
+
+  @Override
+  public Class<ClusteringService> getServiceType() {
+    return ClusteringService.class;
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/service/DefaultClusteringService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.service;
+
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.spi.ServiceProvider;
+
+/**
+ * @author Clifford W. Johnson
+ */
+public class DefaultClusteringService implements ClusteringService {
+
+  private final ClusteringServiceConfiguration config;
+
+  public DefaultClusteringService(final ClusteringServiceConfiguration configuration) {
+    this.config = configuration;
+  }
+
+  @Override
+  public void start(final ServiceProvider serviceProvider) {
+    // TODO: Implement start
+  }
+
+  @Override
+  public void stop() {
+    // TODO: Implement stop
+  }
+}

--- a/clustered/client/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
+++ b/clustered/client/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
@@ -1,0 +1,1 @@
+org.ehcache.clustered.service.ClusteringServiceFactory

--- a/clustered/client/src/main/resources/META-INF/services/org.ehcache.xml.CacheManagerServiceConfigurationParser
+++ b/clustered/client/src/main/resources/META-INF/services/org.ehcache.xml.CacheManagerServiceConfigurationParser
@@ -1,0 +1,1 @@
+org.ehcache.clustered.config.xml.ClusteringServiceConfigurationParser

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -47,14 +47,6 @@
 
     </xs:sequence>
 
-    <xs:attribute name="alias" type="xs:string" use="optional">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">
-          The alias used to identify the cluster.
-        </xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-
   </xs:complexType>
 
   <xs:complexType name="connection-spec">

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema version="1.0"
+           xmlns:tc="http://www.ehcache.org/v3/clustered"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.ehcache.org/v3/clustered">
+
+  <!--
+    Service configuration elements
+  -->
+  <xs:element name="cluster" type="tc:cluster-spec">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        Used within the /config/service element of an Ehcache configuration, this element
+        describes cluster service properties.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:complexType name="cluster-spec">
+
+    <xs:sequence minOccurs="1" maxOccurs="1">
+
+      <xs:element name="connection" type="tc:connection-spec" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the server endpoint to use for identifying cluster configuration.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+    </xs:sequence>
+
+    <xs:attribute name="alias" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          The alias used to identify the cluster.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+  </xs:complexType>
+
+  <xs:complexType name="connection-spec">
+    <!-- TODO: Add a 'pattern' attribute to 'url' -->
+    <xs:attribute name="url" type="xs:anyURI" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Identifies a single cluster member by URL.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+</xs:schema>

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -58,8 +58,7 @@
   </xs:complexType>
 
   <xs:complexType name="connection-spec">
-    <!-- TODO: Add a 'pattern' attribute to 'url' -->
-    <xs:attribute name="url" type="xs:anyURI" use="required">
+    <xs:attribute name="url" type="tc:connectionUrl" use="required">
       <xs:annotation>
         <xs:documentation xml:lang="en">
           Identifies a single cluster member by URL.
@@ -67,5 +66,11 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
+
+  <xs:simpleType name="connectionUrl">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="[Hh][Tt][Tt][Pp][Ss]?://([^\]\[/?#@]+@)?[^:?#/]+(:[1-9][0-9]{0,4})?(/[^\?#]*)?(\?[^#]*)?(#.*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
 
 </xs:schema>

--- a/clustered/client/src/test/java/org/ehcache/clustered/ClusteredCacheManagerBuilderTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/ClusteredCacheManagerBuilderTest.java
@@ -52,7 +52,7 @@ public class ClusteredCacheManagerBuilderTest {
   @Test
   public void testNewCacheManager() throws Exception {
     final ClusteringServiceConfiguration serviceConfiguration =
-        new ClusteringServiceConfiguration("myalias", URI.create("http://localhost:9540"));
+        new ClusteringServiceConfiguration(URI.create("http://localhost:9540"));
     final Configuration configuration = mock(Configuration.class);
     when(configuration.getServiceCreationConfigurations()).thenReturn(
         Collections.<ServiceCreationConfiguration<?>>singleton(serviceConfiguration));
@@ -78,7 +78,7 @@ public class ClusteredCacheManagerBuilderTest {
   public void clusteredCacheManagerWithSimpleCache() throws Exception {
     final CacheManagerBuilder<ClusteredCacheManager> clusteredCacheManagerBuilder =
         CacheManagerBuilder.newCacheManagerBuilder()
-            .with(new ClusteringServiceConfiguration("clusterAlias", URI.create("http://localhost:9540")))
+            .with(new ClusteringServiceConfiguration(URI.create("http://localhost:9540")))
             .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                     .heap(10, EntryUnit.ENTRIES))

--- a/clustered/client/src/test/java/org/ehcache/clustered/ClusteredCacheManagerBuilderTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/ClusteredCacheManagerBuilderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.Cache;
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.config.Configuration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests basic functionality of {@link ClusteredCacheManagerBuilder}.
+ *
+ * @author Clifford W. Johnson
+ */
+public class ClusteredCacheManagerBuilderTest {
+
+  @Test(expected = NullPointerException.class)
+  public void testNewCacheManagerNullConfig() throws Exception {
+    ClusteredCacheManagerBuilder.newCacheManager(null);
+  }
+
+  @Test
+  public void testNewCacheManager() throws Exception {
+    final ClusteringServiceConfiguration serviceConfiguration =
+        new ClusteringServiceConfiguration("myalias", URI.create("http://localhost:9540"));
+    final Configuration configuration = mock(Configuration.class);
+    when(configuration.getServiceCreationConfigurations()).thenReturn(
+        Collections.<ServiceCreationConfiguration<?>>singleton(serviceConfiguration));
+    final ClusteredCacheManager cacheManager = ClusteredCacheManagerBuilder.newCacheManager(configuration);
+    assertThat(cacheManager, is(not(nullValue())));
+    assertThat(cacheManager, is(instanceOf(ClusteredCacheManager.class)));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewCacheManagerBuilderNullBuilder() throws Exception {
+    ClusteredCacheManagerBuilder.newCacheManagerBuilder(null);
+  }
+
+  @Test
+  public void testNewCacheManagerBuilder() throws Exception {
+    final ClusteredCacheManagerBuilder builder =
+        ClusteredCacheManagerBuilder.newCacheManagerBuilder(CacheManagerBuilder.newCacheManagerBuilder());
+    assertThat(builder, is(not(nullValue())));
+    assertThat(builder, is(instanceOf(ClusteredCacheManagerBuilder.class)));
+  }
+
+  @Test
+  public void clusteredCacheManagerWithSimpleCache() throws Exception {
+    final CacheManagerBuilder<ClusteredCacheManager> clusteredCacheManagerBuilder =
+        CacheManagerBuilder.newCacheManagerBuilder()
+            .with(new ClusteringServiceConfiguration("clusterAlias", URI.create("http://localhost:9540")))
+            .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+                .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
+                    .heap(10, EntryUnit.ENTRIES))
+                .build());
+
+    assertThat(clusteredCacheManagerBuilder, is(not(nullValue())));
+    assertThat(clusteredCacheManagerBuilder, is(instanceOf(ClusteredCacheManagerBuilder.class)));
+
+    final ClusteredCacheManager cacheManager = clusteredCacheManagerBuilder.build(true);
+
+    assertThat(cacheManager, is(not(nullValue())));
+
+    final Cache<Long, String> cache = cacheManager.getCache("simple-cache", Long.class, String.class);
+    assertThat(cache, is(not(nullValue())));
+
+    cacheManager.close();
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/SimpleClusteredCacheByXmlTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/SimpleClusteredCacheByXmlTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.Status;
+import org.ehcache.config.Configuration;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.xml.XmlConfiguration;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests basic XML configuration of {@link ClusteredCacheManager}.
+ *
+ * @author Clifford W. Johnson
+ */
+public class SimpleClusteredCacheByXmlTest {
+
+  private static final String SIMPLE_CLUSTER_XML = "/configs/simple-cluster.xml";
+
+  @Test
+  public void testViaXml() throws Exception {
+    final Configuration configuration = new XmlConfiguration(this.getClass().getResource(SIMPLE_CLUSTER_XML));
+    final CacheManager cacheManager = CacheManagerBuilder.newCacheManager(configuration);
+
+    assertThat(cacheManager, is(instanceOf(ClusteredCacheManager.class)));
+
+    cacheManager.init();
+
+    final Cache<Long, String> cache = cacheManager.getCache("simple-cache", Long.class, String.class);
+    assertThat(cache, is(not(nullValue())));
+
+    if (cacheManager.getStatus() != Status.UNINITIALIZED) {
+      cacheManager.close();
+    }
+  }
+
+  @Test
+  public void testViaXmlDirect() throws Exception {
+    final Configuration configuration = new XmlConfiguration(this.getClass().getResource(SIMPLE_CLUSTER_XML));
+    final CacheManager cacheManager = ClusteredCacheManagerBuilder.newCacheManager(configuration);
+
+    assertThat(cacheManager, is(instanceOf(ClusteredCacheManager.class)));
+
+    cacheManager.init();
+
+    final Cache<Long, String> cache = cacheManager.getCache("simple-cache", Long.class, String.class);
+    assertThat(cache, is(not(nullValue())));
+
+    if (cacheManager.getStatus() != Status.UNINITIALIZED) {
+      cacheManager.close();
+    }
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
@@ -33,33 +33,26 @@ import static org.junit.Assert.*;
  */
 public class ClusteringServiceConfigurationTest {
 
-  @Test
-  public void testGetAlias() throws Exception {
-    final URI connectionUrl = URI.create("http://localhost:9450");
-    assertThat(new ClusteringServiceConfiguration(null, connectionUrl).getAlias(), is(""));
-    assertThat(new ClusteringServiceConfiguration("myalias", connectionUrl).getAlias(), is("myalias"));
-  }
-
   @Test(expected = NullPointerException.class)
   public void testGetConnectionUrlNull() throws Exception {
-    new ClusteringServiceConfiguration("myalias", null);
+    new ClusteringServiceConfiguration(null);
   }
 
   @Test
   public void testGetConnectionUrl() throws Exception {
     final URI connectionUrl = URI.create("http://localhost:9450");
-    assertThat(new ClusteringServiceConfiguration("myalias", connectionUrl).getConnectionUrl(), is(connectionUrl));
+    assertThat(new ClusteringServiceConfiguration(connectionUrl).getConnectionUrl(), is(connectionUrl));
   }
 
   @Test
   public void testGetServiceType() throws Exception {
-    assertThat(new ClusteringServiceConfiguration("myalias", URI.create("http://localhost:9450")).getServiceType(),
+    assertThat(new ClusteringServiceConfiguration(URI.create("http://localhost:9450")).getServiceType(),
         is(equalTo(ClusteringService.class)));
   }
 
   @Test
   public void testBuilder() throws Exception {
-    assertThat(new ClusteringServiceConfiguration("myalias", URI.create("http://localhost:9450"))
+    assertThat(new ClusteringServiceConfiguration(URI.create("http://localhost:9450"))
         .builder(CacheManagerBuilder.newCacheManagerBuilder()), is(instanceOf(ClusteredCacheManagerBuilder.class)));
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config;
+
+import org.ehcache.clustered.ClusteredCacheManagerBuilder;
+import org.ehcache.clustered.service.ClusteringService;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * @author Clifford W. Johnson
+ */
+public class ClusteringServiceConfigurationTest {
+
+  @Test
+  public void testGetAlias() throws Exception {
+    final URI connectionUrl = URI.create("http://localhost:9450");
+    assertThat(new ClusteringServiceConfiguration(null, connectionUrl).getAlias(), is(""));
+    assertThat(new ClusteringServiceConfiguration("myalias", connectionUrl).getAlias(), is("myalias"));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testGetConnectionUrlNull() throws Exception {
+    new ClusteringServiceConfiguration("myalias", null);
+  }
+
+  @Test
+  public void testGetConnectionUrl() throws Exception {
+    final URI connectionUrl = URI.create("http://localhost:9450");
+    assertThat(new ClusteringServiceConfiguration("myalias", connectionUrl).getConnectionUrl(), is(connectionUrl));
+  }
+
+  @Test
+  public void testGetServiceType() throws Exception {
+    assertThat(new ClusteringServiceConfiguration("myalias", URI.create("http://localhost:9450")).getServiceType(),
+        is(equalTo(ClusteringService.class)));
+  }
+
+  @Test
+  public void testBuilder() throws Exception {
+    assertThat(new ClusteringServiceConfiguration("myalias", URI.create("http://localhost:9450"))
+        .builder(CacheManagerBuilder.newCacheManagerBuilder()), is(instanceOf(ClusteredCacheManagerBuilder.class)));
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParserTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParserTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config.xml;
+
+import org.ehcache.core.util.ClassLoading;
+import org.ehcache.xml.CacheManagerServiceConfigurationParser;
+import org.junit.Test;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+
+import java.util.ServiceLoader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.stream.StreamSource;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+/**
+ * @author Clifford W. Johnson
+ */
+public class ClusteringServiceConfigurationParserTest {
+
+  /**
+   * Ensures the {@link ClusteringServiceConfigurationParser} is locatable as a
+   * {@link CacheManagerServiceConfigurationParser} instance.
+   */
+  @Test
+  public void testServiceLocator() throws Exception {
+    final String expectedParser = ClusteringServiceConfigurationParser.class.getName();
+    final ServiceLoader<CacheManagerServiceConfigurationParser> parsers =
+        ClassLoading.libraryServiceLoaderFor(CacheManagerServiceConfigurationParser.class);
+    foundParser: {
+      for (final CacheManagerServiceConfigurationParser parser : parsers) {
+        if (parser.getClass().getName().equals(expectedParser)) {
+          break foundParser;
+        }
+      }
+      fail("Expected parser not found");
+    }
+  }
+
+  /**
+   * Ensures the namespace declared by {@link ClusteringServiceConfigurationParser} and its
+   * schema are the same.
+   */
+  @Test
+  public void testSchema() throws Exception {
+    final ClusteringServiceConfigurationParser parser = new ClusteringServiceConfigurationParser();
+    final StreamSource schemaSource = (StreamSource) parser.getXmlSchema();
+
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    factory.setIgnoringComments(true);
+    factory.setIgnoringElementContentWhitespace(true);
+
+    final DocumentBuilder domBuilder = factory.newDocumentBuilder();
+    final Element schema = domBuilder.parse(schemaSource.getInputStream()).getDocumentElement();
+    final Attr targetNamespaceAttr = schema.getAttributeNode("targetNamespace");
+    assertThat(targetNamespaceAttr, is(not(nullValue())));
+    assertThat(targetNamespaceAttr.getValue(), is(parser.getNamespace().toString()));
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
@@ -40,7 +40,7 @@ public class GettingStarted {
     // tag::clusteredCacheManagerExample
     final CacheManagerBuilder<ClusteredCacheManager> clusteredCacheManagerBuilder =
         CacheManagerBuilder.newCacheManagerBuilder()
-            .with(new ClusteringServiceConfiguration("clusterAlias", URI.create("http://localhost:9540")))
+            .with(new ClusteringServiceConfiguration(URI.create("http://localhost:9540")))
             .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                     .heap(10, EntryUnit.ENTRIES))

--- a/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.docs;
+
+import org.ehcache.clustered.ClusteredCacheManager;
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.junit.Test;
+
+import java.net.URI;
+
+/**
+ * Samples demonstrating use of a clustered cache.
+ *
+ * @author Clifford W. Johnson
+ *
+ * @see org.ehcache.docs.GettingStarted
+ */
+public class GettingStarted {
+
+  @Test
+  public void clusteredCacheManagerExample() throws Exception {
+    // tag::clusteredCacheManagerExample
+    final CacheManagerBuilder<ClusteredCacheManager> clusteredCacheManagerBuilder =
+        CacheManagerBuilder.newCacheManagerBuilder()
+            .with(new ClusteringServiceConfiguration("clusterAlias", URI.create("http://localhost:9540")))
+            .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+                .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
+                    .heap(10, EntryUnit.ENTRIES))
+                .build());
+    final ClusteredCacheManager cacheManager = clusteredCacheManagerBuilder.build(true);
+
+    cacheManager.close();
+    // end::clusteredCacheManagerExample
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/service/ClusteringServiceFactoryTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/service/ClusteringServiceFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.service;
+
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.ehcache.core.util.ClassLoading;
+import org.junit.Test;
+
+import java.util.ServiceLoader;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Clifford W. Johnson
+ */
+public class ClusteringServiceFactoryTest {
+
+  @Test
+  public void testServiceLocator() throws Exception {
+    final String expectedFactory = ClusteringServiceFactory.class.getName();
+    final ServiceLoader<ServiceFactory> factories = ClassLoading.libraryServiceLoaderFor(ServiceFactory.class);
+    foundParser: {
+      for (final ServiceFactory factory : factories) {
+        if (factory.getClass().getName().equals(expectedFactory)) {
+          break foundParser;
+        }
+      }
+      fail("Expected factory not found");
+    }
+  }
+
+}

--- a/clustered/client/src/test/resources/configs/simple-cluster.xml
+++ b/clustered/client/src/test/resources/configs/simple-cluster.xml
@@ -3,7 +3,7 @@
     xmlns:tc="http://www.ehcache.org/v3/clustered">
 
   <ehcache:service>
-    <tc:cluster alias="SimpleCluster">
+    <tc:cluster>
       <tc:connection url="http://localhost:9540"/>
     </tc:cluster>
   </ehcache:service>

--- a/clustered/client/src/test/resources/configs/simple-cluster.xml
+++ b/clustered/client/src/test/resources/configs/simple-cluster.xml
@@ -1,0 +1,17 @@
+<ehcache:config
+    xmlns:ehcache="http://www.ehcache.org/v3"
+    xmlns:tc="http://www.ehcache.org/v3/clustered">
+
+  <ehcache:service>
+    <tc:cluster alias="SimpleCluster">
+      <tc:connection url="http://localhost:9540"/>
+    </tc:cluster>
+  </ehcache:service>
+
+  <ehcache:cache alias="simple-cache">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.String</ehcache:value-type>
+    <ehcache:heap unit="entries">10</ehcache:heap>
+  </ehcache:cache>
+
+</ehcache:config>

--- a/core/src/main/java/org/ehcache/core/BaseCacheManager.java
+++ b/core/src/main/java/org/ehcache/core/BaseCacheManager.java
@@ -32,6 +32,7 @@ import org.ehcache.core.events.CacheEventDispatcherFactory;
 import org.ehcache.core.events.CacheManagerListener;
 import org.ehcache.core.spi.LifeCycledAdapter;
 import org.ehcache.core.spi.ServiceLocator;
+import org.ehcache.core.spi.cache.InternalCacheManager;
 import org.ehcache.core.spi.cache.Store;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
 import org.ehcache.core.util.ClassLoading;
@@ -39,7 +40,6 @@ import org.ehcache.event.CacheEventListener;
 import org.ehcache.event.CacheEventListenerConfiguration;
 import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.spi.LifeCycled;
-import org.ehcache.spi.cache.ObservableCacheManager;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
 import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
@@ -70,7 +70,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @author Clifford W. Johnson
  */
-public abstract class BaseCacheManager implements CacheManager, ObservableCacheManager {
+public abstract class BaseCacheManager implements CacheManager, InternalCacheManager {
 
   private final DefaultConfiguration configuration;
   private final ClassLoader cacheManagerClassLoader;

--- a/core/src/main/java/org/ehcache/core/BaseCacheManager.java
+++ b/core/src/main/java/org/ehcache/core/BaseCacheManager.java
@@ -1,0 +1,634 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.core;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.Status;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.Configuration;
+import org.ehcache.config.ResourceType;
+import org.ehcache.config.RuntimeConfiguration;
+import org.ehcache.core.config.BaseCacheConfiguration;
+import org.ehcache.core.config.DefaultConfiguration;
+import org.ehcache.core.config.events.StoreEventSourceConfiguration;
+import org.ehcache.core.config.store.StoreConfigurationImpl;
+import org.ehcache.core.events.CacheEventDispatcher;
+import org.ehcache.core.events.CacheEventDispatcherFactory;
+import org.ehcache.core.events.CacheManagerListener;
+import org.ehcache.core.spi.LifeCycledAdapter;
+import org.ehcache.core.spi.ServiceLocator;
+import org.ehcache.core.spi.cache.Store;
+import org.ehcache.core.spi.service.CacheManagerProviderService;
+import org.ehcache.core.util.ClassLoading;
+import org.ehcache.event.CacheEventListener;
+import org.ehcache.event.CacheEventListenerConfiguration;
+import org.ehcache.event.CacheEventListenerProvider;
+import org.ehcache.spi.LifeCycled;
+import org.ehcache.spi.cache.ObservableCacheManager;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
+import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
+import org.ehcache.spi.loaderwriter.WriteBehindProvider;
+import org.ehcache.spi.serialization.SerializationProvider;
+import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.serialization.UnsupportedTypeException;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Support the common core of {@code CacheManager} functionality.
+ *
+ * @author Clifford W. Johnson
+ */
+public abstract class BaseCacheManager implements CacheManager, ObservableCacheManager {
+
+  private final DefaultConfiguration configuration;
+  private final ClassLoader cacheManagerClassLoader;
+  private final boolean useLoaderInAtomics;
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final ConcurrentMap<String, CacheHolder> caches = new ConcurrentHashMap<String, CacheHolder>();
+  private final CopyOnWriteArrayList<CacheManagerListener> listeners = new CopyOnWriteArrayList<CacheManagerListener>();
+
+  protected final StatusTransitioner statusTransitioner = new StatusTransitioner(this.logger);
+  protected final String simpleName;
+  protected final ServiceLocator serviceLocator;
+
+  protected BaseCacheManager(Configuration config, Collection<Service> services, boolean useLoaderInAtomics) {
+    final String simpleName = this.getClass().getSimpleName();
+    this.simpleName = (simpleName.isEmpty() ? this.getClass().getName() : simpleName);
+    this.configuration = new DefaultConfiguration(config);
+    this.cacheManagerClassLoader = config.getClassLoader() != null ? config.getClassLoader() : ClassLoading.getDefaultClassLoader();
+    this.serviceLocator = new ServiceLocator(services.toArray(new Service[services.size()]));
+    this.useLoaderInAtomics = useLoaderInAtomics;
+    validateServicesConfigs();
+  }
+
+  private void validateServicesConfigs() {
+    HashSet<Class> classes = new HashSet<Class>();
+    for (ServiceCreationConfiguration<?> service : configuration.getServiceCreationConfigurations()) {
+      if (!classes.add(service.getServiceType())) {
+        throw new IllegalStateException("Duplicate creation configuration for service " + service.getServiceType());
+      }
+    }
+  }
+
+  /**
+   * Gets the class-identified {@code Logger} instance.
+   *
+   * @return the {@code Logger} to use
+   */
+  protected Logger getLogger() {
+    return this.logger;
+  }
+
+  /**
+   * Gets the {@code Class} definition holding the {@link org.ehcache.spi.service.ServiceDependencies ServiceDependencies}
+   * annotations for this {@code CacheManager} implementation.
+   *
+   * @return the {@code Class} definition from which the service dependencies are identified
+   */
+  protected abstract Class<?> getServiceDependencyMarkerClass();
+
+  @Override
+  public <K, V> Cache<K, V> getCache(String alias, Class<K> keyType, Class<V> valueType) {
+    statusTransitioner.checkAvailable();
+    final CacheHolder cacheHolder = caches.get(alias);
+    if(cacheHolder == null) {
+      return null;
+    } else {
+      try {
+        return cacheHolder.retrieve(keyType, valueType);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Cache '" + alias + "' type is <" + cacheHolder.keyType.getName() + ", "
+                                           + cacheHolder.valueType.getName() + ">, but you retrieved it with <"
+                                           + keyType.getName() + ", " + valueType.getName() +">");
+      }
+    }
+  }
+
+  @Override
+  public void removeCache(final String alias) {
+    removeCache(alias, true);
+  }
+
+  /**
+   * Closes and removes a cache, by alias, from this cache manager.
+   *
+   * @param alias the alias of the cache to remove
+   * @param removeFromConfig if {@code true}, the cache configuration is altered to remove the cache
+   */
+  private void removeCache(final String alias, final boolean removeFromConfig) {
+    statusTransitioner.checkAvailable();
+    final CacheHolder cacheHolder = caches.remove(alias);
+    if(cacheHolder != null) {
+      final Ehcache<?, ?> ehcache = cacheHolder.retrieve(cacheHolder.keyType, cacheHolder.valueType);
+      if(!statusTransitioner.isTransitioning()) {
+        for (CacheManagerListener listener : listeners) {
+          listener.cacheRemoved(alias, ehcache);
+        }
+      }
+      closeCache(alias, ehcache);
+      if (removeFromConfig) {
+        configuration.removeCacheConfiguration(alias);
+      }
+      this.getLogger().info("Cache '{}' is removed from {}.", alias, simpleName);
+    }
+  }
+
+  private void closeCache(final String alias, final Ehcache<?, ?> ehcache) {
+    ehcache.close();
+    closeEhcache(alias, ehcache);
+    this.getLogger().info("Cache '{}' is closed from {}.", alias, simpleName);
+  }
+
+  /**
+   * Perform cache closure actions specific to a cache manager implementation.
+   * This method is called <i>after</i> the {@code Ehcache} instance is closed.
+   *
+   * @param alias the cache alias
+   * @param ehcache the {@code Ehcache} instance for the cache to close
+   */
+  protected abstract void closeEhcache(final String alias, final Ehcache<?, ?> ehcache);
+
+  @Override
+  public <K, V> Cache<K, V> createCache(final String alias, CacheConfiguration<K, V> config) throws IllegalArgumentException {
+    return createCache(alias, config, true);
+  }
+
+  private <K, V> Cache<K, V> createCache(final String alias, CacheConfiguration<K, V> originalConfig, boolean addToConfig) throws IllegalArgumentException {
+    statusTransitioner.checkAvailable();
+
+    this.getLogger().info("Cache '{}' is getting created in {}.", alias, simpleName);
+
+    CacheConfiguration<K, V> config = adjustConfigurationWithCacheManagerDefaults(originalConfig);
+    Class<K> keyType = config.getKeyType();
+    Class<V> valueType = config.getValueType();
+
+    final CacheHolder value = new CacheHolder(keyType, valueType, null);
+    if (caches.putIfAbsent(alias, value) != null) {
+      throw new IllegalArgumentException("Cache '" + alias +"' already exists");
+    }
+
+    Ehcache<K, V> cache = null;
+
+    RuntimeException failure = null;
+    try {
+      cache = createNewEhcache(alias, config, keyType, valueType);
+      cache.init();
+      if (addToConfig) {
+        configuration.addCacheConfiguration(alias, cache.getRuntimeConfiguration());
+      } else {
+        configuration.replaceCacheConfiguration(alias, originalConfig, cache.getRuntimeConfiguration());
+      }
+    } catch (RuntimeException e) {
+      failure = e;
+    }
+
+    if(failure == null) {
+      try {
+        if(!statusTransitioner.isTransitioning()) {
+          for (CacheManagerListener listener : listeners) {
+            listener.cacheAdded(alias, cache);
+          }
+        }
+      } finally {
+        value.setCache(cache);
+      }
+    } else {
+      caches.remove(alias);
+      value.setCache(null);
+      throw new IllegalStateException("Cache '"+alias+"' creation in " + simpleName +
+          " failed.", failure);
+    }
+    this.getLogger().info("Cache '{}' created in {}.", alias, simpleName);
+    return cache;
+  }
+
+  <K, V> Ehcache<K, V> createNewEhcache(final String alias, final CacheConfiguration<K, V> config,
+                                        final Class<K> keyType, final Class<V> valueType) {
+    Collection<ServiceConfiguration<?>> adjustedServiceConfigs = new ArrayList<ServiceConfiguration<?>>(config.getServiceConfigurations());
+
+    List<ServiceConfiguration> unknownServiceConfigs = new ArrayList<ServiceConfiguration>();
+    for (ServiceConfiguration serviceConfig : adjustedServiceConfigs) {
+      if (!serviceLocator.knowsServiceFor(serviceConfig)) {
+        unknownServiceConfigs.add(serviceConfig);
+      }
+    }
+    if (!unknownServiceConfigs.isEmpty()) {
+      throw new IllegalStateException("Cannot find service(s) that can handle following configuration(s) : " + unknownServiceConfigs);
+    }
+
+    List<LifeCycled> lifeCycledList = new ArrayList<LifeCycled>();
+
+    final Store<K, V> store = getStore(alias, config, keyType, valueType, adjustedServiceConfigs, lifeCycledList);
+
+    final CacheLoaderWriterProvider cacheLoaderWriterProvider = serviceLocator.getService(CacheLoaderWriterProvider.class);
+    final CacheLoaderWriter<? super K, V> decorator ;
+    if(cacheLoaderWriterProvider != null) {
+      final CacheLoaderWriter<? super K, V> loaderWriter;
+      loaderWriter = cacheLoaderWriterProvider.createCacheLoaderWriter(alias, config);
+      WriteBehindConfiguration writeBehindConfiguration =
+          ServiceLocator.findSingletonAmongst(WriteBehindConfiguration.class, config.getServiceConfigurations().toArray());
+      if(writeBehindConfiguration == null) {
+        decorator = loaderWriter;
+      } else {
+        final WriteBehindProvider factory = serviceLocator.getService(WriteBehindProvider.class);
+        decorator = factory.createWriteBehindLoaderWriter(loaderWriter, writeBehindConfiguration);
+        if(decorator != null) {
+          lifeCycledList.add(new LifeCycledAdapter() {
+            @Override
+            public void close() {
+              factory.releaseWriteBehindLoaderWriter(decorator);
+            }
+          });
+        }
+      }
+
+      if (loaderWriter != null) {
+        lifeCycledList.add(new LifeCycledAdapter() {
+          @Override
+          public void close() throws Exception {
+            cacheLoaderWriterProvider.releaseCacheLoaderWriter(loaderWriter);
+          }
+        });
+      }
+    } else {
+      decorator = null;
+    }
+
+    final CacheEventDispatcherFactory cenlProvider = serviceLocator.getService(CacheEventDispatcherFactory.class);
+    final CacheEventDispatcher<K, V> evtService =
+        cenlProvider.createCacheEventDispatcher(store, adjustedServiceConfigs.toArray(new ServiceConfiguration[adjustedServiceConfigs.size()]));
+    lifeCycledList.add(new LifeCycledAdapter() {
+      @Override
+      public void close() {
+        cenlProvider.releaseCacheEventDispatcher(evtService);
+      }
+    });
+    evtService.setStoreEventSource(store.getStoreEventSource());
+
+    final Ehcache<K, V> ehCache = new Ehcache<K, V>(config, store, decorator, evtService,
+        useLoaderInAtomics, LoggerFactory.getLogger(Ehcache.class + "-" + alias));
+
+    final CacheEventListenerProvider evntLsnrFactory = serviceLocator.getService(CacheEventListenerProvider.class);
+    if (evntLsnrFactory != null) {
+      Collection<CacheEventListenerConfiguration> evtLsnrConfigs =
+          ServiceLocator.findAmongst(CacheEventListenerConfiguration.class, config.getServiceConfigurations());
+      for (CacheEventListenerConfiguration lsnrConfig: evtLsnrConfigs) {
+        final CacheEventListener<K, V> lsnr = evntLsnrFactory.createEventListener(alias, lsnrConfig);
+        if (lsnr != null) {
+          ehCache.getRuntimeConfiguration().registerCacheEventListener(lsnr, lsnrConfig.orderingMode(), lsnrConfig.firingMode(),
+              lsnrConfig.fireOn());
+          lifeCycledList.add(new LifeCycled() {
+            @Override
+            public void init() throws Exception {
+              // no-op for now
+            }
+
+            @Override
+            public void close() throws Exception {
+              evntLsnrFactory.releaseEventListener(lsnr);
+            }
+          });
+        }
+      }
+      evtService.setListenerSource(ehCache);
+    }
+
+    for (LifeCycled lifeCycled : lifeCycledList) {
+      ehCache.addHook(lifeCycled);
+    }
+
+    return ehCache;
+  }
+
+  /**
+   * Instantiates a {@code Store} used for the cache data.
+   *
+   * @param alias the alias assigned to the cache
+   * @param config the configuration used for the cache
+   * @param keyType the cache key type
+   * @param valueType the cache value type
+   * @param serviceConfigs the {@code List} of {@code ServiceConfiguration} instances available to the cache;
+   *                       this list may be augmented by the implementation of this method
+   * @param lifeCycledList the {@code List} of {@code LifeCycled} instances used to manage components of the
+   *                       cache; this list may be augmented by the implementation of this method
+   * @param <K> the cache key type
+   * @param <V> the cache value type
+   *
+   * @return the {@code Store} instance used to create the cache
+   */
+  protected <K, V> Store<K,V> getStore(final String alias, final CacheConfiguration<K, V> config,
+                                       final Class<K> keyType, final Class<V> valueType,
+                                       final Collection<ServiceConfiguration<?>> serviceConfigs,
+                                       final List<LifeCycled> lifeCycledList) {
+
+    final Store.Provider storeProvider = serviceLocator.getService(Store.Provider.class);
+    Serializer<K> keySerializer = null;
+    Serializer<V> valueSerializer = null;
+    final SerializationProvider serialization = serviceLocator.getService(SerializationProvider.class);
+    Set<ResourceType> resources = config.getResourcePools().getResourceTypeSet();
+    ServiceConfiguration<?>[] serviceConfigArray = serviceConfigs.toArray(new ServiceConfiguration[serviceConfigs.size()]);
+    if (serialization != null) {
+      try {
+        final Serializer<K> keySer = serialization.createKeySerializer(keyType, config.getClassLoader(), serviceConfigArray);
+        lifeCycledList.add(new LifeCycledAdapter() {
+          @Override
+          public void close() throws Exception {
+            serialization.releaseSerializer(keySer);
+          }
+        });
+        keySerializer = keySer;
+      } catch (UnsupportedTypeException e) {
+        for (ResourceType resource : resources) {
+          if (resource.requiresSerialization()) {
+            throw new RuntimeException(e);
+          }
+        }
+        this.getLogger().debug("Could not create serializers for " + alias, e);
+      }
+      try {
+        final Serializer<V> valueSer = serialization.createValueSerializer(valueType, config.getClassLoader(), serviceConfigArray);
+        lifeCycledList.add(new LifeCycledAdapter() {
+          @Override
+          public void close() throws Exception {
+            serialization.releaseSerializer(valueSer);
+          }
+        });
+        valueSerializer = valueSer;
+      } catch (UnsupportedTypeException e) {
+        for (ResourceType resource : resources) {
+          if (resource.requiresSerialization()) {
+            throw new RuntimeException(e);
+          }
+        }
+        this.getLogger().debug("Could not create serializers for " + alias, e);
+      }
+    }
+
+    int eventParallelism;
+    StoreEventSourceConfiguration eventSourceConfiguration = ServiceLocator.findSingletonAmongst(StoreEventSourceConfiguration.class, config
+        .getServiceConfigurations()
+        .toArray());
+    if (eventSourceConfiguration != null) {
+      eventParallelism = eventSourceConfiguration.getOrderedEventParallelism();
+    } else {
+      eventParallelism = StoreEventSourceConfiguration.DEFAULT_EVENT_PARALLELISM;
+    }
+
+    Store.Configuration<K, V> storeConfiguration = new StoreConfigurationImpl<K, V>(config, eventParallelism, keySerializer, valueSerializer);
+    final Store<K, V> store = storeProvider.createStore(storeConfiguration, serviceConfigArray);
+
+    lifeCycledList.add(new LifeCycled() {
+      @Override
+      public void init() throws Exception {
+        storeProvider.initStore(store);
+      }
+
+      @Override
+      public void close() {
+        storeProvider.releaseStore(store);
+      }
+    });
+
+    return store;
+  }
+
+  /**
+   *  adjusts the config to reflect new classloader & serialization provider
+   */
+  private <K, V> CacheConfiguration<K, V> adjustConfigurationWithCacheManagerDefaults(CacheConfiguration<K, V> config) {
+    ClassLoader cacheClassLoader = config.getClassLoader();
+    if (cacheClassLoader == null) {
+      cacheClassLoader = cacheManagerClassLoader;
+    }
+    if (cacheClassLoader != config.getClassLoader() ) {
+      config = new BaseCacheConfiguration<K, V>(config.getKeyType(), config.getValueType(),
+          config.getEvictionVeto(), cacheClassLoader, config.getExpiry(),
+          config.getResourcePools(), config.getServiceConfigurations().toArray(
+          new ServiceConfiguration<?>[config.getServiceConfigurations().size()]));
+    }
+    return config;
+  }
+
+  @Override
+  public void registerListener(CacheManagerListener listener) {
+    if(!listeners.contains(listener)) {
+      listeners.add(listener);
+      statusTransitioner.registerListener(listener);
+    }
+  }
+
+  @Override
+  public void deregisterListener(CacheManagerListener listener) {
+    if(listeners.remove(listener)) {
+      statusTransitioner.deregisterListener(listener);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void init() {
+    final StatusTransitioner.Transition st = statusTransitioner.init();
+
+    if (serviceLocator.getService(CacheManagerProviderService.class) == null) {
+      this.serviceLocator.addService(new DefaultCacheManagerProviderService(this));
+    }
+
+    try {
+      for (ServiceCreationConfiguration<? extends Service> serviceConfig : configuration.getServiceCreationConfigurations()) {
+        Service service = serviceLocator.getOrCreateServiceFor(serviceConfig);
+        if (service == null) {
+          throw new IllegalArgumentException("Couldn't resolve Service " + serviceConfig.getServiceType().getName());
+        }
+      }
+      serviceLocator.loadDependenciesOf(this.getServiceDependencyMarkerClass());
+      try {
+        serviceLocator.startAllServices();
+      } catch (Exception e) {
+        throw st.failed(e);
+      }
+
+      Deque<String> initiatedCaches = new ArrayDeque<String>();
+      try {
+        for (Map.Entry<String, CacheConfiguration<?, ?>> cacheConfigurationEntry : configuration.getCacheConfigurations()
+            .entrySet()) {
+          final String alias = cacheConfigurationEntry.getKey();
+          createCache(alias, cacheConfigurationEntry.getValue(), false);
+          initiatedCaches.push(alias);
+        }
+      } catch (RuntimeException e) {
+        while (!initiatedCaches.isEmpty()) {
+          String toBeClosed = initiatedCaches.pop();
+          try {
+            removeCache(toBeClosed, false);
+          } catch (Exception exceptionClosingCache) {
+              this.getLogger().error("Cache '{}' could not be removed due to ", toBeClosed, exceptionClosingCache);
+          }
+        }
+        try {
+          serviceLocator.stopAllServices();
+        } catch (Exception exceptionStoppingServices) {
+          this.getLogger().error("Stopping services failed due to ", exceptionStoppingServices);
+        }
+        throw e;
+      }
+    } catch (Exception e) {
+      throw st.failed(e);
+    }
+    st.succeeded();
+  }
+
+  @Override
+  public Status getStatus() {
+    return statusTransitioner.currentStatus();
+  }
+
+  @Override
+  public void close() {
+    final StatusTransitioner.Transition st = statusTransitioner.close();
+
+    Exception firstException = null;
+    try {
+      for (String alias : caches.keySet()) {
+        try {
+          removeCache(alias, false);
+        } catch (Exception e) {
+          if(firstException == null) {
+            firstException = e;
+          } else {
+            this.getLogger().error("Cache '{}' could not be removed due to ", alias, e);
+          }
+        }
+      }
+
+      serviceLocator.stopAllServices();
+    } catch (Exception e) {
+      if(firstException == null) {
+        firstException = e;
+      }
+    }
+    if(firstException != null) {
+      throw st.failed(firstException);
+    }
+    st.succeeded();
+  }
+
+  @Override
+  public RuntimeConfiguration getRuntimeConfiguration() {
+    return configuration;
+  }
+
+  /**
+   * Removes and closes a cache without performing {@link CacheManagerListener#cacheRemoved(String, Cache)}
+   * notifications.
+   *
+   * @param alias the alias of the cache to remove
+   */
+  protected void removeAndCloseWithoutNotice(final String alias) {
+    final CacheHolder cacheHolder = caches.remove(alias);
+    if(cacheHolder != null) {
+      final Ehcache<?, ?> ehcache = cacheHolder.retrieve(cacheHolder.keyType, cacheHolder.valueType);
+      if(ehcache.getStatus() == Status.AVAILABLE) {
+        ehcache.close();
+      }
+    }
+  }
+
+  // for tests at the moment
+  ClassLoader getClassLoader() {
+    return cacheManagerClassLoader;
+  }
+
+  void create() {
+    statusTransitioner.checkMaintenance();
+  }
+
+  void destroy() {
+    statusTransitioner.checkMaintenance();
+  }
+
+
+  private static final class CacheHolder {
+    private final Class<?> keyType;
+    private final Class<?> valueType;
+    private volatile Ehcache<?, ?> cache;
+    private volatile boolean isValueSet = false;
+
+    CacheHolder(Class<?> keyType, Class<?> valueType, Ehcache<?, ?> cache) {
+      this.keyType = keyType;
+      this.valueType = valueType;
+      this.cache = cache;
+    }
+
+    <K, V> Ehcache<K, V> retrieve(Class<K> refKeyType, Class<V> refValueType) {
+      if (!isValueSet) {
+        synchronized (this) {
+          boolean interrupted = false;
+          try {
+            while(!isValueSet) {
+              try {
+                wait();
+              } catch (InterruptedException e) {
+                interrupted = true;
+              }
+            }
+          } finally {
+            if(interrupted) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        }
+      }
+      if (keyType == refKeyType && valueType == refValueType) {
+        return cast(cache);
+      } else {
+        throw new IllegalArgumentException();
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <K, V> Ehcache<K, V> cast(Ehcache<?, ?> cache) {
+      return (Ehcache<K, V>)cache;
+    }
+
+    public synchronized void setCache(final Ehcache<?, ?> cache) {
+      this.cache = cache;
+      this.isValueSet = true;
+      notifyAll();
+    }
+  }
+}

--- a/core/src/main/java/org/ehcache/core/DefaultCacheManagerProviderService.java
+++ b/core/src/main/java/org/ehcache/core/DefaultCacheManagerProviderService.java
@@ -16,23 +16,23 @@
 
 package org.ehcache.core;
 
-import org.ehcache.CacheManager;
-import org.ehcache.spi.ServiceProvider;
+import org.ehcache.core.spi.cache.InternalCacheManager;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
+import org.ehcache.spi.ServiceProvider;
 
 /**
  * @author Mathieu Carbou
  */
 public class DefaultCacheManagerProviderService implements CacheManagerProviderService {
 
-  private final CacheManager cacheManager;
+  private final InternalCacheManager cacheManager;
 
-  public DefaultCacheManagerProviderService(CacheManager cacheManager) {
+  public DefaultCacheManagerProviderService(InternalCacheManager cacheManager) {
     this.cacheManager = cacheManager;
   }
 
   @Override
-  public CacheManager getCacheManager() {
+  public InternalCacheManager getCacheManager() {
     return cacheManager;
   }
 

--- a/core/src/main/java/org/ehcache/core/DefaultCacheManagerProviderService.java
+++ b/core/src/main/java/org/ehcache/core/DefaultCacheManagerProviderService.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.core;
 
+import org.ehcache.CacheManager;
 import org.ehcache.spi.ServiceProvider;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
 
@@ -24,15 +25,15 @@ import org.ehcache.core.spi.service.CacheManagerProviderService;
  */
 public class DefaultCacheManagerProviderService implements CacheManagerProviderService {
 
-  private final EhcacheManager ehcacheManager;
+  private final CacheManager cacheManager;
 
-  public DefaultCacheManagerProviderService(EhcacheManager ehcacheManager) {
-    this.ehcacheManager = ehcacheManager;
+  public DefaultCacheManagerProviderService(CacheManager cacheManager) {
+    this.cacheManager = cacheManager;
   }
 
   @Override
-  public EhcacheManager getCacheManager() {
-    return ehcacheManager;
+  public CacheManager getCacheManager() {
+    return cacheManager;
   }
 
   @Override

--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -16,69 +16,32 @@
 
 package org.ehcache.core;
 
-import org.ehcache.Cache;
 import org.ehcache.Maintainable;
 import org.ehcache.PersistentCacheManager;
-import org.ehcache.Status;
-import org.ehcache.core.config.BaseCacheConfiguration;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.Configuration;
-import org.ehcache.core.config.DefaultConfiguration;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
-import org.ehcache.config.RuntimeConfiguration;
-import org.ehcache.core.config.store.StoreConfigurationImpl;
-import org.ehcache.core.config.events.StoreEventSourceConfiguration;
-import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
-import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.core.events.CacheEventDispatcherFactory;
-import org.ehcache.core.events.CacheEventDispatcher;
-import org.ehcache.core.events.CacheManagerListener;
+import org.ehcache.core.spi.cache.Store;
+import org.ehcache.core.spi.service.LocalPersistenceService;
+import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.exceptions.CachePersistenceException;
 import org.ehcache.spi.LifeCycled;
-import org.ehcache.core.spi.LifeCycledAdapter;
-import org.ehcache.core.spi.ServiceLocator;
-import org.ehcache.core.spi.cache.Store;
-import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriterProvider;
-import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
 import org.ehcache.spi.loaderwriter.WriteBehindProvider;
-import org.ehcache.spi.serialization.SerializationProvider;
-import org.ehcache.spi.serialization.Serializer;
-import org.ehcache.spi.serialization.UnsupportedTypeException;
-import org.ehcache.core.spi.service.CacheManagerProviderService;
-import org.ehcache.spi.service.ServiceConfiguration;
-import org.ehcache.core.spi.service.LocalPersistenceService;
-import org.ehcache.core.spi.service.LocalPersistenceService.PersistenceSpaceIdentifier;
 import org.ehcache.spi.service.Service;
-import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.ServiceDependencies;
-import org.ehcache.core.util.ClassLoading;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Deque;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import static org.ehcache.config.ResourceType.Core.DISK;
-import static org.ehcache.config.ResourceType.Core.OFFHEAP;
 
 /**
  * @author Alex Snaps
  */
-public class EhcacheManager implements PersistentCacheManager {
+public class EhcacheManager extends BaseCacheManager implements PersistentCacheManager {
 
   @ServiceDependencies({ Store.Provider.class,
       CacheLoaderWriterProvider.class,
@@ -91,19 +54,6 @@ public class EhcacheManager implements PersistentCacheManager {
     }
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheManager.class);
-
-  private final StatusTransitioner statusTransitioner = new StatusTransitioner(LOGGER);
-
-  private final ServiceLocator serviceLocator;
-  private final boolean useLoaderInAtomics;
-  private final DefaultConfiguration configuration;
-
-  private final ConcurrentMap<String, CacheHolder> caches = new ConcurrentHashMap<String, CacheHolder>();
-  private final ClassLoader cacheManagerClassLoader;
-
-  private final CopyOnWriteArrayList<CacheManagerListener> listeners = new CopyOnWriteArrayList<CacheManagerListener>();
-
   public EhcacheManager(Configuration config) {
     this(config, Collections.<Service>emptyList(), true);
   }
@@ -111,76 +61,26 @@ public class EhcacheManager implements PersistentCacheManager {
   public EhcacheManager(Configuration config, Collection<Service> services) {
     this(config, services, true);
   }
+
   public EhcacheManager(Configuration config, Collection<Service> services, boolean useLoaderInAtomics) {
-    this.serviceLocator = new ServiceLocator(services.toArray(new Service[services.size()]));
-    this.useLoaderInAtomics = useLoaderInAtomics;
-    this.cacheManagerClassLoader = config.getClassLoader() != null ? config.getClassLoader() : ClassLoading.getDefaultClassLoader();
-    this.configuration = new DefaultConfiguration(config);
-    validateServicesConfigs();
-  }
-
-
-  private void validateServicesConfigs() {
-    HashSet<Class> classes = new HashSet<Class>();
-    for (ServiceCreationConfiguration<?> service : configuration.getServiceCreationConfigurations()) {
-      if (!classes.add(service.getServiceType())) {
-        throw new IllegalStateException("Duplicate creation configuration for service " + service.getServiceType());
-      }
-    }
-  }
-
-
-  @Override
-  public <K, V> Cache<K, V> getCache(String alias, Class<K> keyType, Class<V> valueType) {
-    statusTransitioner.checkAvailable();
-    final CacheHolder cacheHolder = caches.get(alias);
-    if(cacheHolder == null) {
-      return null;
-    } else {
-      try {
-        return cacheHolder.retrieve(keyType, valueType);
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("Cache '" + alias + "' type is <" + cacheHolder.keyType.getName() + ", "
-                                           + cacheHolder.valueType.getName() + ">, but you retrieved it with <"
-                                           + keyType.getName() + ", " + valueType.getName() +">");
-      }
-    }
+    super(config, services, useLoaderInAtomics);
   }
 
   @Override
-  public void removeCache(final String alias) {
-    removeCache(alias, true);
+  protected Class<?> getServiceDependencyMarkerClass() {
+    return EhcacheManager.ServiceDeps.class;
   }
 
-  private void removeCache(final String alias, final boolean removeFromConfig) {
-    statusTransitioner.checkAvailable();
-    final CacheHolder cacheHolder = caches.remove(alias);
-    if(cacheHolder != null) {
-      final Ehcache<?, ?> ehcache = cacheHolder.retrieve(cacheHolder.keyType, cacheHolder.valueType);
-      if(!statusTransitioner.isTransitioning()) {
-        for (CacheManagerListener listener : listeners) {
-          listener.cacheRemoved(alias, ehcache);
-        }
-      }
-      closeEhcache(alias, ehcache);
-      if (removeFromConfig) {
-        configuration.removeCacheConfiguration(alias);
-      }
-      LOGGER.info("Cache '{}' is removed from EhcacheManager.", alias);
-    }
-  }
-
-  void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
+  @Override
+  protected void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
     boolean diskTransient = isDiskTransient(ehcache);
-    ehcache.close();
     if (diskTransient) {
       try {
         destroyPersistenceSpace(alias);
       } catch (CachePersistenceException e) {
-        LOGGER.debug("Unable to clear persistence space for cache {}", alias, e);
+        this.getLogger().debug("Unable to clear persistence space for cache {}", alias, e);
       }
     }
-    LOGGER.info("Cache '{}' is closed from EhcacheManager.", alias);
   }
 
   private boolean isDiskTransient(Ehcache<?, ?> ehcache) {
@@ -195,93 +95,11 @@ public class EhcacheManager implements PersistentCacheManager {
   }
 
   @Override
-  public <K, V> Cache<K, V> createCache(final String alias, CacheConfiguration<K, V> config) throws IllegalArgumentException {
-    return createCache(alias, config, true);
-  }
+  protected <K, V> Store<K, V> getStore(final String alias, final CacheConfiguration<K, V> config,
+                                        final Class<K> keyType, final Class<V> valueType,
+                                        final Collection<ServiceConfiguration<?>> adjustedServiceConfigs,
+                                        final List<LifeCycled> lifeCycledList) {
 
-  private <K, V> Cache<K, V> createCache(final String alias, CacheConfiguration<K, V> originalConfig, boolean addToConfig) throws IllegalArgumentException {
-    statusTransitioner.checkAvailable();
-
-    LOGGER.info("Cache '{}' is getting created in EhcacheManager.", alias);
-
-    CacheConfiguration<K, V> config = adjustConfigurationWithCacheManagerDefaults(originalConfig);
-    Class<K> keyType = config.getKeyType();
-    Class<V> valueType = config.getValueType();
-
-    final CacheHolder value = new CacheHolder(keyType, valueType, null);
-    if (caches.putIfAbsent(alias, value) != null) {
-      throw new IllegalArgumentException("Cache '" + alias +"' already exists");
-    }
-
-    Ehcache<K, V> cache = null;
-
-    RuntimeException failure = null;
-    try {
-      cache = createNewEhcache(alias, config, keyType, valueType);
-      cache.init();
-      if (addToConfig) {
-        configuration.addCacheConfiguration(alias, cache.getRuntimeConfiguration());
-      } else {
-        configuration.replaceCacheConfiguration(alias, originalConfig, cache.getRuntimeConfiguration());
-      }
-    } catch (RuntimeException e) {
-      failure = e;
-    }
-
-    if(failure == null) {
-      try {
-        if(!statusTransitioner.isTransitioning()) {
-          for (CacheManagerListener listener : listeners) {
-            listener.cacheAdded(alias, cache);
-          }
-        }
-      } finally {
-        value.setCache(cache);
-      }
-    } else {
-      caches.remove(alias);
-      value.setCache(null);
-      throw new IllegalStateException("Cache '"+alias+"' creation in EhcacheManager failed.", failure);
-    }
-    LOGGER.info("Cache '{}' created in EhcacheManager.", alias);
-    return cache;
-  }
-
-  /**
-   *  adjusts the config to reflect new classloader & serialization provider
-   */
-  private <K, V> CacheConfiguration<K, V> adjustConfigurationWithCacheManagerDefaults(CacheConfiguration<K, V> config) {
-    ClassLoader cacheClassLoader = config.getClassLoader();
-    if (cacheClassLoader == null) {
-      cacheClassLoader = cacheManagerClassLoader;
-    }
-    if (cacheClassLoader != config.getClassLoader() ) {
-      config = new BaseCacheConfiguration<K, V>(config.getKeyType(), config.getValueType(),
-          config.getEvictionVeto(), cacheClassLoader, config.getExpiry(),
-          config.getResourcePools(), config.getServiceConfigurations().toArray(
-          new ServiceConfiguration<?>[config.getServiceConfigurations().size()]));
-    }
-    return config;
-  }
-
-  <K, V> Ehcache<K, V> createNewEhcache(final String alias, final CacheConfiguration<K, V> config,
-                                        final Class<K> keyType, final Class<V> valueType) {
-    Collection<ServiceConfiguration<?>> adjustedServiceConfigs = new ArrayList<ServiceConfiguration<?>>(config.getServiceConfigurations());
-    ServiceConfiguration[] serviceConfigs = adjustedServiceConfigs.toArray(new ServiceConfiguration[adjustedServiceConfigs.size()]);
-
-    List<ServiceConfiguration> unknownServiceConfigs = new ArrayList<ServiceConfiguration>();
-    for (ServiceConfiguration serviceConfig : serviceConfigs) {
-      if (!serviceLocator.knowsServiceFor(serviceConfig)) {
-        unknownServiceConfigs.add(serviceConfig);
-      }
-    }
-    if (!unknownServiceConfigs.isEmpty()) {
-      throw new IllegalStateException("Cannot find service(s) that can handle following configuration(s) : " + unknownServiceConfigs);
-    }
-
-    List<LifeCycled> lifeCycledList = new ArrayList<LifeCycled>();
-
-    final Store.Provider storeProvider = serviceLocator.getService(Store.Provider.class);
     if (config.getResourcePools().getResourceTypeSet().contains(ResourceType.Core.DISK)) {
       LocalPersistenceService persistenceService = serviceLocator.getService(LocalPersistenceService.class);
 
@@ -297,260 +115,14 @@ public class EhcacheManager implements PersistentCacheManager {
         }
       }
       try {
-        PersistenceSpaceIdentifier space = persistenceService.getOrCreatePersistenceSpace(alias);
-        serviceConfigs = Arrays.copyOf(serviceConfigs, serviceConfigs.length + 1);
-        serviceConfigs[serviceConfigs.length - 1] = space;
+        LocalPersistenceService.PersistenceSpaceIdentifier space = persistenceService.getOrCreatePersistenceSpace(alias);
+        adjustedServiceConfigs.add(space);
       } catch (CachePersistenceException cpex) {
         throw new RuntimeException("Unable to create persistence space for cache " + alias, cpex);
       }
     }
-    Serializer<K> keySerializer = null;
-    Serializer<V> valueSerializer = null;
-    final SerializationProvider serialization = serviceLocator.getService(SerializationProvider.class);
-    Set<ResourceType> resources = config.getResourcePools().getResourceTypeSet();
-    if (serialization != null) {
-      try {
-        final Serializer<K> keySer = serialization.createKeySerializer(keyType, config.getClassLoader(), serviceConfigs);
-        lifeCycledList.add(new LifeCycledAdapter() {
-          @Override
-          public void close() throws Exception {
-            serialization.releaseSerializer(keySer);
-          }
-        });
-        keySerializer = keySer;
-      } catch (UnsupportedTypeException e) {
-        if (resources.contains(DISK) || resources.contains(OFFHEAP)) {
-          throw new RuntimeException(e);
-        } else {
-          LOGGER.debug("Could not create serializers for " + alias, e);
-        }
-      }
-      try {
-        final Serializer<V> valueSer = serialization.createValueSerializer(valueType, config.getClassLoader(), serviceConfigs);
-        lifeCycledList.add(new LifeCycledAdapter() {
-          @Override
-          public void close() throws Exception {
-            serialization.releaseSerializer(valueSer);
-          }
-        });
-        valueSerializer = valueSer;
-      } catch (UnsupportedTypeException e) {
-        if (resources.contains(DISK) || resources.contains(OFFHEAP)) {
-          throw new RuntimeException(e);
-        } else {
-          LOGGER.debug("Could not create serializers for " + alias, e);
-        }
-      }
-    }
-    int eventParallelism;
-    StoreEventSourceConfiguration eventSourceConfiguration = ServiceLocator.findSingletonAmongst(StoreEventSourceConfiguration.class, config
-        .getServiceConfigurations()
-        .toArray());
-    if (eventSourceConfiguration != null) {
-      eventParallelism = eventSourceConfiguration.getOrderedEventParallelism();
-    } else {
-      eventParallelism = StoreEventSourceConfiguration.DEFAULT_EVENT_PARALLELISM;
-    }
-    Store.Configuration<K, V> storeConfiguration = new StoreConfigurationImpl<K, V>(config, eventParallelism, keySerializer, valueSerializer);
-    final Store<K, V> store = storeProvider.createStore(storeConfiguration, serviceConfigs);
 
-    lifeCycledList.add(new LifeCycled() {
-      @Override
-      public void init() throws Exception {
-        storeProvider.initStore(store);
-      }
-
-      @Override
-      public void close() {
-        storeProvider.releaseStore(store);
-      }
-    });
-
-    final CacheLoaderWriterProvider cacheLoaderWriterProvider = serviceLocator.getService(CacheLoaderWriterProvider.class);
-    final CacheLoaderWriter<? super K, V> loaderWriter;
-    final CacheLoaderWriter<? super K, V> decorator;
-    if(cacheLoaderWriterProvider != null) {
-      loaderWriter = cacheLoaderWriterProvider.createCacheLoaderWriter(alias, config);
-      WriteBehindConfiguration writeBehindConfiguration = ServiceLocator.findSingletonAmongst(WriteBehindConfiguration.class, config.getServiceConfigurations().toArray());
-      if(writeBehindConfiguration == null) {
-        decorator = loaderWriter;
-      } else {
-        final WriteBehindProvider factory = serviceLocator.getService(WriteBehindProvider.class);
-        decorator = factory.createWriteBehindLoaderWriter(loaderWriter, writeBehindConfiguration);
-        if(decorator != null) {
-          lifeCycledList.add(new LifeCycledAdapter() {
-            @Override
-            public void close() {
-              factory.releaseWriteBehindLoaderWriter(decorator);
-            }
-          });
-        }
-      }
-
-      if (loaderWriter != null) {
-        lifeCycledList.add(new LifeCycledAdapter() {
-          @Override
-          public void close() throws Exception {
-            cacheLoaderWriterProvider.releaseCacheLoaderWriter(loaderWriter);
-          }
-        });
-      }
-    } else {
-      loaderWriter = null;
-      decorator = null;
-    }
-
-    final CacheEventDispatcherFactory cenlProvider = serviceLocator.getService(CacheEventDispatcherFactory.class);
-    final CacheEventDispatcher<K, V> evtService = cenlProvider.createCacheEventDispatcher(store, serviceConfigs);
-    lifeCycledList.add(new LifeCycledAdapter() {
-      @Override
-      public void close() {
-        cenlProvider.releaseCacheEventDispatcher(evtService);
-      }
-    });
-
-    final Ehcache<K, V> ehCache = new Ehcache<K, V>(config, store, decorator, evtService,
-        useLoaderInAtomics, LoggerFactory.getLogger(Ehcache.class + "-" + alias));
-
-    evtService.setStoreEventSource(store.getStoreEventSource());
-    final CacheEventListenerProvider evntLsnrFactory = serviceLocator.getService(CacheEventListenerProvider.class);
-    if (evntLsnrFactory != null) {
-      Collection<CacheEventListenerConfiguration> evtLsnrConfigs =
-      ServiceLocator.findAmongst(CacheEventListenerConfiguration.class, config.getServiceConfigurations());
-      for (CacheEventListenerConfiguration lsnrConfig: evtLsnrConfigs) {
-        final CacheEventListener<K, V> lsnr = evntLsnrFactory.createEventListener(alias, lsnrConfig);
-        if (lsnr != null) {
-          ehCache.getRuntimeConfiguration().registerCacheEventListener(lsnr, lsnrConfig.orderingMode(), lsnrConfig.firingMode(),
-          lsnrConfig.fireOn());
-          lifeCycledList.add(new LifeCycled() {
-            @Override
-            public void init() throws Exception {
-              // no-op for now
-            }
-
-            @Override
-            public void close() throws Exception {
-              evntLsnrFactory.releaseEventListener(lsnr);
-            }
-          });
-        }
-      }
-      evtService.setListenerSource(ehCache);
-    }
-
-    for (LifeCycled lifeCycled : lifeCycledList) {
-      ehCache.addHook(lifeCycled);
-    }
-
-    return ehCache;
-  }
-
-  public void registerListener(CacheManagerListener listener) {
-    if(!listeners.contains(listener)) {
-      listeners.add(listener);
-      statusTransitioner.registerListener(listener);
-    }
-  }
-
-  public void deregisterListener(CacheManagerListener listener) {
-    if(listeners.remove(listener)) {
-      statusTransitioner.deregisterListener(listener);
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void init() {
-    final StatusTransitioner.Transition st = statusTransitioner.init();
-
-    if (serviceLocator.getService(CacheManagerProviderService.class) == null) {
-      this.serviceLocator.addService(new DefaultCacheManagerProviderService(this));
-    }
-
-    try {
-      for (ServiceCreationConfiguration<? extends Service> serviceConfig : configuration.getServiceCreationConfigurations()) {
-        Service service = serviceLocator.getOrCreateServiceFor(serviceConfig);
-        if (service == null) {
-          throw new IllegalArgumentException("Couldn't resolve Service " + serviceConfig.getServiceType().getName());
-        }
-      }
-      serviceLocator.loadDependenciesOf(ServiceDeps.class);
-      try {
-        serviceLocator.startAllServices();
-      } catch (Exception e) {
-        throw st.failed(e);
-      }
-
-      Deque<String> initiatedCaches = new ArrayDeque<String>();
-      try {
-        for (Entry<String, CacheConfiguration<?, ?>> cacheConfigurationEntry : configuration.getCacheConfigurations()
-            .entrySet()) {
-          final String alias = cacheConfigurationEntry.getKey();
-          createCache(alias, cacheConfigurationEntry.getValue(), false);
-          initiatedCaches.push(alias);
-        }
-      } catch (RuntimeException e) {
-        while (!initiatedCaches.isEmpty()) {
-          String toBeClosed = initiatedCaches.pop();
-          try {
-            removeCache(toBeClosed, false);
-          } catch (Exception exceptionClosingCache) {
-              LOGGER.error("Cache '{}' could not be removed due to ", toBeClosed, exceptionClosingCache);
-          }
-        }
-        try {
-          serviceLocator.stopAllServices();
-        } catch (Exception exceptionStoppingServices) {
-          LOGGER.error("Stopping services failed due to ", exceptionStoppingServices);
-        }
-        throw e;
-      }
-    } catch (Exception e) {
-      throw st.failed(e);
-    }
-    st.succeeded();
-  }
-
-  @Override
-  public Status getStatus() {
-    return statusTransitioner.currentStatus();
-  }
-
-  @Override
-  public void close() {
-    final StatusTransitioner.Transition st = statusTransitioner.close();
-
-    Exception firstException = null;
-    try {
-      for (String alias : caches.keySet()) {
-        try {
-          removeCache(alias, false);
-        } catch (Exception e) {
-          if(firstException == null) {
-            firstException = e;
-          } else {
-            LOGGER.error("Cache '{}' could not be removed due to ", alias, e);
-          }
-        }
-      }
-
-      serviceLocator.stopAllServices();
-    } catch (Exception e) {
-      if(firstException == null) {
-        firstException = e;
-      }
-    }
-    if(firstException != null) {
-      throw st.failed(firstException);
-    }
-    st.succeeded();
-  }
-
-  @Override
-  public RuntimeConfiguration getRuntimeConfiguration() {
-    return configuration;
+    return super.getStore(alias, config, keyType, valueType, adjustedServiceConfigs, lifeCycledList);
   }
 
   @Override
@@ -585,91 +157,22 @@ public class EhcacheManager implements PersistentCacheManager {
     }
   }
 
+  @Override
+  public void destroyCache(final String alias) throws CachePersistenceException {
+    this.getLogger().info("Destroying Cache '{}' in {}.", alias, simpleName);
+    removeAndCloseWithoutNotice(alias);
+    destroyPersistenceSpace(alias);
+    this.getLogger().info("Cache '{}' is successfully destroyed in {}.", alias, simpleName);
+  }
+
   private LocalPersistenceService startPersistenceService() {
     LocalPersistenceService persistenceService = serviceLocator.getService(LocalPersistenceService.class);
     persistenceService.start(serviceLocator);
     return persistenceService;
   }
 
-  void create() {
-    statusTransitioner.checkMaintenance();
-  }
-
-  void destroy() {
-    statusTransitioner.checkMaintenance();
-  }
-
-  @Override
-  public void destroyCache(final String alias) throws CachePersistenceException {
-    LOGGER.info("Destroying Cache '{}' in EhcacheManager.", alias);
-    final CacheHolder cacheHolder = caches.remove(alias);
-    if(cacheHolder != null) {
-      final Ehcache<?, ?> ehcache = cacheHolder.retrieve(cacheHolder.keyType, cacheHolder.valueType);
-      if(ehcache.getStatus() == Status.AVAILABLE) {
-        ehcache.close();
-      }
-    }
-    destroyPersistenceSpace(alias);
-    LOGGER.info("Cache '{}' is successfully destroyed in EhcacheManager.", alias);
-  }
-
   private void destroyPersistenceSpace(String alias) throws CachePersistenceException {
     LocalPersistenceService persistenceService = serviceLocator.getService(LocalPersistenceService.class);
     persistenceService.destroyPersistenceSpace(alias);
-  }
-
-  // for tests at the moment
-  ClassLoader getClassLoader() {
-    return cacheManagerClassLoader;
-  }
-
-  private static final class CacheHolder {
-    private final Class<?> keyType;
-    private final Class<?> valueType;
-    private volatile Ehcache<?, ?> cache;
-    private volatile boolean isValueSet = false;
-
-    CacheHolder(Class<?> keyType, Class<?> valueType, Ehcache<?, ?> cache) {
-      this.keyType = keyType;
-      this.valueType = valueType;
-      this.cache = cache;
-    }
-
-    <K, V> Ehcache<K, V> retrieve(Class<K> refKeyType, Class<V> refValueType) {
-      if (!isValueSet) {
-        synchronized (this) {
-          boolean interrupted = false;
-          try {
-            while(!isValueSet) {
-              try {
-                wait();
-              } catch (InterruptedException e) {
-                interrupted = true;
-              }
-            }
-          } finally {
-            if(interrupted) {
-              Thread.currentThread().interrupt();
-            }
-          }
-        }
-      }
-      if (keyType == refKeyType && valueType == refValueType) {
-        return cast(cache);
-      } else {
-        throw new IllegalArgumentException();
-      }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <K, V> Ehcache<K, V> cast(Ehcache<?, ?> cache) {
-      return (Ehcache<K, V>)cache;
-    }
-
-    public synchronized void setCache(final Ehcache<?, ?> cache) {
-      this.cache = cache;
-      this.isValueSet = true;
-      notifyAll();
-    }
   }
 }

--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -78,7 +78,7 @@ public class EhcacheManager extends BaseCacheManager implements PersistentCacheM
       try {
         destroyPersistenceSpace(alias);
       } catch (CachePersistenceException e) {
-        this.getLogger().debug("Unable to clear persistence space for cache {}", alias, e);
+        this.getLogger().warn("Unable to clear persistence space for cache {}", alias, e);
       }
     }
   }

--- a/core/src/main/java/org/ehcache/core/spi/cache/InternalCacheManager.java
+++ b/core/src/main/java/org/ehcache/core/spi/cache/InternalCacheManager.java
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package org.ehcache.spi.cache;
+package org.ehcache.core.spi.cache;
 
 
 import org.ehcache.CacheManager;
 import org.ehcache.core.events.CacheManagerListener;
 
 /**
- * Adds methods to a {@code CacheManager} making it observable by the management framework.
+ * The {@code Service}-facing version of a {@code CacheManager}.  This interface adds
+ * methods used internally by service implementations.
  *
  * @author Clifford W. Johnson
  */
-public interface ObservableCacheManager extends CacheManager {
+public interface InternalCacheManager extends CacheManager {
   void registerListener(CacheManagerListener listener);
 
   void deregisterListener(CacheManagerListener listener);

--- a/core/src/main/java/org/ehcache/core/spi/service/CacheManagerProviderService.java
+++ b/core/src/main/java/org/ehcache/core/spi/service/CacheManagerProviderService.java
@@ -17,6 +17,7 @@
 package org.ehcache.core.spi.service;
 
 import org.ehcache.CacheManager;
+import org.ehcache.core.spi.cache.InternalCacheManager;
 import org.ehcache.spi.service.Service;
 
 /**
@@ -26,6 +27,6 @@ import org.ehcache.spi.service.Service;
  */
 public interface CacheManagerProviderService extends Service {
 
-  CacheManager getCacheManager();
+  InternalCacheManager getCacheManager();
 
 }

--- a/core/src/main/java/org/ehcache/spi/cache/ObservableCacheManager.java
+++ b/core/src/main/java/org/ehcache/spi/cache/ObservableCacheManager.java
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package org.ehcache.core.spi.service;
+package org.ehcache.spi.cache;
 
-import org.ehcache.CacheManager;
-import org.ehcache.spi.service.Service;
+
+import org.ehcache.core.events.CacheManagerListener;
 
 /**
- * Special service that services can depend onto to be able to recover the instance of the current {@link CacheManager}
+ * Specifies methods for a cache manager observable by the management framework.
  *
- * @author Mathieu Carbou
+ * @author Clifford W. Johnson
  */
-public interface CacheManagerProviderService extends Service {
+public interface ObservableCacheManager {
+  void registerListener(CacheManagerListener listener);
 
-  CacheManager getCacheManager();
-
+  void deregisterListener(CacheManagerListener listener);
 }

--- a/core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
@@ -476,7 +476,7 @@ public class EhcacheManagerTest {
       }
 
       @Override
-      void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
+      protected void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
         super.closeEhcache(alias, ehcache);
         caches.remove(ehcache);
       }
@@ -487,9 +487,10 @@ public class EhcacheManagerTest {
       fail();
     } catch (StateTransitionException e) {
       assertThat(cacheManager.getStatus(), is(Status.UNINITIALIZED));
-      assertThat(e.getCause().getMessage(), CoreMatchers.startsWith("Cache '"));
-      assertThat(e.getCause().getMessage(), CoreMatchers.endsWith("' creation in EhcacheManager failed."));
-
+      final String message = e.getCause().getMessage();
+      assertThat(message, CoreMatchers.startsWith("Cache '"));
+      assertThat(message, containsString("' creation in "));
+      assertThat(message, CoreMatchers.endsWith(" failed."));
     }
     assertThat(caches.isEmpty(), is(true));
   }
@@ -523,7 +524,7 @@ public class EhcacheManagerTest {
       }
 
       @Override
-      void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
+      protected void closeEhcache(final String alias, final Ehcache<?, ?> ehcache) {
         super.closeEhcache(alias, ehcache);
         if(alias.equals("foobar")) {
           throw thrown;

--- a/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistryService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistryService.java
@@ -16,10 +16,10 @@
 package org.ehcache.management.registry;
 
 import org.ehcache.Cache;
-import org.ehcache.CacheManager;
 import org.ehcache.Status;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.core.events.CacheManagerListener;
+import org.ehcache.core.spi.cache.InternalCacheManager;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
 import org.ehcache.core.spi.service.ExecutionService;
 import org.ehcache.management.ManagementRegistryService;
@@ -29,7 +29,6 @@ import org.ehcache.management.providers.EhcacheStatisticCollectorProvider;
 import org.ehcache.management.providers.actions.EhcacheActionProvider;
 import org.ehcache.management.providers.statistics.EhcacheStatisticsProvider;
 import org.ehcache.spi.ServiceProvider;
-import org.ehcache.spi.cache.ObservableCacheManager;
 import org.ehcache.spi.service.ServiceDependencies;
 import org.terracotta.management.context.ContextContainer;
 import org.terracotta.management.registry.AbstractManagementRegistry;
@@ -52,7 +51,7 @@ public class DefaultManagementRegistryService extends AbstractManagementRegistry
 
   private final ManagementRegistryServiceConfiguration configuration;
   private volatile ScheduledExecutorService statisticsExecutor;
-  private volatile CacheManager cacheManager;
+  private volatile InternalCacheManager cacheManager;
 
   public DefaultManagementRegistryService() {
     this(new DefaultManagementRegistryConfiguration());
@@ -75,9 +74,7 @@ public class DefaultManagementRegistryService extends AbstractManagementRegistry
         statisticsExecutor));
     addManagementProvider(new EhcacheStatisticCollectorProvider(getConfiguration().getContext()));
 
-    if (this.cacheManager instanceof ObservableCacheManager) {
-      ((ObservableCacheManager)this.cacheManager).registerListener(this);
-    }
+    this.cacheManager.registerListener(this);
   }
 
   @Override
@@ -123,9 +120,7 @@ public class DefaultManagementRegistryService extends AbstractManagementRegistry
         break;
 
       case UNINITIALIZED:
-        if (this.cacheManager instanceof ObservableCacheManager) {
-          ((ObservableCacheManager)this.cacheManager).deregisterListener(this);
-        }
+        this.cacheManager.deregisterListener(this);
         break;
 
       case MAINTENANCE:

--- a/management/src/main/java/org/ehcache/management/registry/DefaultSharedManagementService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultSharedManagementService.java
@@ -16,7 +16,7 @@
 package org.ehcache.management.registry;
 
 import org.ehcache.Cache;
-import org.ehcache.core.EhcacheManager;
+import org.ehcache.CacheManager;
 import org.ehcache.Status;
 import org.ehcache.core.events.CacheManagerListener;
 import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
@@ -24,6 +24,7 @@ import org.ehcache.management.ManagementRegistryService;
 import org.ehcache.management.SharedManagementService;
 import org.ehcache.spi.ServiceProvider;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
+import org.ehcache.spi.cache.ObservableCacheManager;
 import org.ehcache.spi.service.ServiceDependencies;
 import org.terracotta.management.capabilities.Capability;
 import org.terracotta.management.context.Context;
@@ -53,39 +54,42 @@ public class DefaultSharedManagementService implements SharedManagementService {
   public void start(final ServiceProvider serviceProvider) {
     final ManagementRegistryService managementRegistry = serviceProvider.getService(ManagementRegistryService.class);
     final Context cmContext = managementRegistry.getConfiguration().getContext();
-    final EhcacheManager ehcacheManager = serviceProvider.getService(CacheManagerProviderService.class).getCacheManager();
+    final CacheManager cacheManager = serviceProvider.getService(CacheManagerProviderService.class).getCacheManager();
 
-    ehcacheManager.registerListener(new CacheManagerListener() {
-      @Override
-      public void cacheAdded(String alias, Cache<?, ?> cache) {
-      }
-
-      @Override
-      public void cacheRemoved(String alias, Cache<?, ?> cache) {
-      }
-
-      @Override
-      public void stateTransition(Status from, Status to) {
-        switch (to) {
-
-          case AVAILABLE:
-            delegates.put(cmContext, managementRegistry);
-            break;
-
-          case UNINITIALIZED:
-            delegates.remove(cmContext);
-            ehcacheManager.deregisterListener(this);
-            break;
-
-          case MAINTENANCE:
-            // in case we need management capabilities in maintenance mode
-            break;
-
-          default:
-            throw new AssertionError(to);
+    if (cacheManager instanceof ObservableCacheManager) {
+      final ObservableCacheManager observableCacheManager = (ObservableCacheManager)cacheManager;
+      observableCacheManager.registerListener(new CacheManagerListener() {
+        @Override
+        public void cacheAdded(String alias, Cache<?, ?> cache) {
         }
-      }
-    });
+
+        @Override
+        public void cacheRemoved(String alias, Cache<?, ?> cache) {
+        }
+
+        @Override
+        public void stateTransition(Status from, Status to) {
+          switch (to) {
+
+            case AVAILABLE:
+              delegates.put(cmContext, managementRegistry);
+              break;
+
+            case UNINITIALIZED:
+              delegates.remove(cmContext);
+              observableCacheManager.deregisterListener(this);
+              break;
+
+            case MAINTENANCE:
+              // in case we need management capabilities in maintenance mode
+              break;
+
+            default:
+              throw new AssertionError(to);
+          }
+        }
+      });
+    }
   }
 
   @Override

--- a/xml/src/main/java/org/ehcache/xml/exceptions/XmlConfigurationException.java
+++ b/xml/src/main/java/org/ehcache/xml/exceptions/XmlConfigurationException.java
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package org.ehcache.spi.cache;
-
-
-import org.ehcache.CacheManager;
-import org.ehcache.core.events.CacheManagerListener;
+package org.ehcache.xml.exceptions;
 
 /**
- * Adds methods to a {@code CacheManager} making it observable by the management framework.
+ * Thrown to reflect an error in an XML configuration.
  *
  * @author Clifford W. Johnson
  */
-public interface ObservableCacheManager extends CacheManager {
-  void registerListener(CacheManagerListener listener);
+public class XmlConfigurationException extends RuntimeException {
+  private static final long serialVersionUID = 4797841652996371653L;
 
-  void deregisterListener(CacheManagerListener listener);
+  public XmlConfigurationException(final String message) {
+    super(message);
+  }
+
+  public XmlConfigurationException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
This PR is in two parts:

1. Refactors EhcacheManager to split CachePersistenceManager methods out.  This creates a BaseCacheManager abstract class holding the non-persistent methods leaving EhcacheManager as a subclass maintaining the current functionality. This is a positioning move for supporting clustering.

  * Adds requiresSerialization method to ResourceType
  * Splits EhcacheManager.newStore into BaseCacheManager (non-DISK)
  * Generalizes CacheManagerBuilder to
    * return builder-designated CacheManager type (subclass)
    * return CacheManagerConfiguration-driven CacheManagerBuilder subclass
    * adds newSpecializedCacheManager method to obtain type-specific CacheManager from configuration

1. Adds interfaces and concrete classes in support of configuring and
building a clustered CacheManager.

  * ehcache-clustered-ext.xsd defining the <service> element extension
  * ClusteringServiceConfigurationParser for parsing XML <service> extension
  * ClusteringServiceConfiguration providing both ServiceCreationConfiguration and CacheManagerConfiguration support
  * ClusteringService, DefaultClusteringService and ClusteringServiceFactory providing the anchor for the clustering service configured with the ClusteringServiceConfiguration
  * ClusteredCacheManager, ClusteredCacheManagerImpl, and ClusteredCacheManagerBuilder providing support for a clustered CacheManager