### PR TITLE
Made management objects serializable and removed duplicate naming for…

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
@@ -37,7 +37,6 @@ import org.terracotta.statistics.jsr166e.LongAdder;
 
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -169,9 +168,9 @@ public class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cac
   }
 
   private float getMostRecentNotClearedValue(StatisticHistory<Double, ?> ratio) {
-    List<Sample<Double>> samples = ratio.getValue();
-    for (int i=samples.size() - 1 ; i>=0 ; i--) {
-      Sample<Double> doubleSample = samples.get(i);
+    Sample<Double>[] samples = ratio.getValue();
+    for (int i=samples.length - 1 ; i>=0 ; i--) {
+      Sample<Double> doubleSample = samples[i];
       if (doubleSample.getTimestamp() >= compensatingCounters.timestamp) {
         return (float) (doubleSample.getValue() / 1000.0);
       }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ import scripts.*
 ext {
   baseVersion = '3.0.0-SNAPSHOT'
   offheapVersion = '2.1.2'
-  managementVersion = '2.1.0'
+  managementVersion = '2.2.0'
   statisticVersion = '1.1.0'
   jcacheVersion = '1.0.0'
   slf4jVersion = '1.7.7'

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
@@ -134,38 +134,38 @@ class EhcacheStatistics implements ExposedObject<CacheBinding> {
 
         if ((name + "Count").equals(statisticName)) {
           SampledStatistic<Long> count = result.count();
-          return Collections.singletonMap(statisticName, new CounterHistory(statisticName, buildHistory(count, since), NumberUnit.COUNT));
+          return Collections.singletonMap(statisticName, new CounterHistory(buildHistory(count, since), NumberUnit.COUNT));
 
         } else if ((name + "Rate").equals(statisticName)) {
           SampledStatistic<Double> rate = result.rate();
-          return Collections.singletonMap(statisticName, new RateHistory(statisticName, buildHistory(rate, since), TimeUnit.SECONDS));
+          return Collections.singletonMap(statisticName, new RateHistory(buildHistory(rate, since), TimeUnit.SECONDS));
 
         } else if ((name + "LatencyMinimum").equals(statisticName)) {
           SampledStatistic<Long> minimum = result.latency().minimum();
-          return Collections.singletonMap(statisticName, new DurationHistory(statisticName, buildHistory(minimum, since), TimeUnit.NANOSECONDS));
+          return Collections.singletonMap(statisticName, new DurationHistory(buildHistory(minimum, since), TimeUnit.NANOSECONDS));
 
         } else if ((name + "LatencyMaximum").equals(statisticName)) {
           SampledStatistic<Long> maximum = result.latency().maximum();
-          return Collections.singletonMap(statisticName, new DurationHistory(statisticName, buildHistory(maximum, since), TimeUnit.NANOSECONDS));
+          return Collections.singletonMap(statisticName, new DurationHistory(buildHistory(maximum, since), TimeUnit.NANOSECONDS));
 
         } else if ((name + "LatencyAverage").equals(statisticName)) {
           SampledStatistic<Double> average = result.latency().average();
-          return Collections.singletonMap(statisticName, new AverageHistory(statisticName, buildHistory(average, since), TimeUnit.NANOSECONDS));
+          return Collections.singletonMap(statisticName, new AverageHistory(buildHistory(average, since), TimeUnit.NANOSECONDS));
 
         } else if (name.equals(statisticName)) {
           Map<String, Statistic<?, ?>> resultStats = new HashMap<String, Statistic<?, ?>>();
-          resultStats.put(statisticName + "Count",  new CounterHistory(statisticName + "Count", buildHistory(result.count(), since), NumberUnit.COUNT));
-          resultStats.put(statisticName + "Rate", new RateHistory(statisticName + "Rate", buildHistory(result.rate(), since), TimeUnit.SECONDS));
-          resultStats.put(statisticName + "LatencyMinimum", new DurationHistory(statisticName + "LatencyMinimum", buildHistory(result.latency().minimum(), since), TimeUnit.NANOSECONDS));
-          resultStats.put(statisticName + "LatencyMaximum", new DurationHistory(statisticName + "LatencyMaximum", buildHistory(result.latency().maximum(), since), TimeUnit.NANOSECONDS));
-          resultStats.put(statisticName + "LatencyAverage",  new AverageHistory(statisticName + "LatencyAverage", buildHistory(result.latency().average(), since), TimeUnit.NANOSECONDS));
+          resultStats.put(statisticName + "Count",  new CounterHistory(buildHistory(result.count(), since), NumberUnit.COUNT));
+          resultStats.put(statisticName + "Rate", new RateHistory(buildHistory(result.rate(), since), TimeUnit.SECONDS));
+          resultStats.put(statisticName + "LatencyMinimum", new DurationHistory(buildHistory(result.latency().minimum(), since), TimeUnit.NANOSECONDS));
+          resultStats.put(statisticName + "LatencyMaximum", new DurationHistory(buildHistory(result.latency().maximum(), since), TimeUnit.NANOSECONDS));
+          resultStats.put(statisticName + "LatencyAverage",  new AverageHistory(buildHistory(result.latency().average(), since), TimeUnit.NANOSECONDS));
           return resultStats;
         }
 
       } else if ("Ratio".equals(type)) {
         if ((name + "Ratio").equals(statisticName)) {
           SampledStatistic<Double> ratio = (SampledStatistic) registration.getStat();
-          return Collections.singletonMap(statisticName, new RatioHistory(statisticName, buildHistory(ratio, since), NumberUnit.PERCENT));
+          return Collections.singletonMap(statisticName, new RatioHistory(buildHistory(ratio, since), NumberUnit.RATIO));
         }
       }
     }
@@ -173,7 +173,7 @@ class EhcacheStatistics implements ExposedObject<CacheBinding> {
     OperationStatistic<?> operationStatistic = countStatistics.get(statisticName);
     if (operationStatistic != null) {
       long sum = operationStatistic.sum();
-      return Collections.singletonMap(statisticName, new Counter(statisticName, sum, NumberUnit.COUNT));
+      return Collections.singletonMap(statisticName, new Counter(sum, NumberUnit.COUNT));
     }
 
     return Collections.emptyMap();

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
@@ -36,6 +36,7 @@ import org.terracotta.management.stats.history.CounterHistory;
 import org.terracotta.management.stats.primitive.Counter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
@@ -201,13 +202,13 @@ public class DefaultManagementRegistryServiceTest {
       Thread.sleep(100);
       statistics = builder.build().execute().getResult(context);
       putCount = statistics.getStatistic(CounterHistory.class);
-    } while (putCount.getValue().size() < 1);
+    } while (putCount.getValue().length < 1);
 
     // within 1 second of history there has been 3 puts
-    assertThat(putCount.getValue().get(0).getValue(), equalTo(3L));
+    assertThat(putCount.getValue()[0].getValue(), equalTo(3L));
 
     // keep time for next call (since)
-    timestamp = putCount.getValue().get(0).getTimestamp();
+    timestamp = putCount.getValue()[0].getTimestamp();
 
     // ------
     // 2 puts and we wait more than 1 second (history frequency) to be sure the scheduler thread has computed a new stat in the history
@@ -225,7 +226,7 @@ public class DefaultManagementRegistryServiceTest {
       Thread.sleep(100);
       statistics = builder.build().execute().getResult(context);
       putCount = statistics.getStatistic(CounterHistory.class);
-    } while (putCount.getValue().size() < 2);
+    } while (putCount.getValue().length < 2);
 
     // ------
     // WITH since: the history will have 1 value
@@ -235,7 +236,7 @@ public class DefaultManagementRegistryServiceTest {
     putCount = statistics.getStatistic(CounterHistory.class);
 
     // get the counter for each computation at each 1 second
-    assertThat(putCount.getValue(), everyItem(Matchers.<Sample<Long>>hasProperty("timestamp", greaterThan(timestamp))));
+    assertThat(Arrays.asList(putCount.getValue()), everyItem(Matchers.<Sample<Long>>hasProperty("timestamp", greaterThan(timestamp))));
 
     cacheManager1.close();
   }


### PR DESCRIPTION
… stats

I had to update management model objects to make them properly deserializable, plus improved some little things like removing duplicate naming for stats and renamed PERCENT to RATIO.

Depends on https://github.com/Terracotta-OSS/terracotta-management/pull/19

@anthonydahanne : once PR #19 will be reviewed / merged / released, you'll be able to review and merge this one :-)