### PR TITLE
Issue #507 Remove not needed call to backing map

### DIFF
--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -803,8 +803,6 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
     ValueHolder<V> mappedValue = null;
     final StoreEventSink<K, V> eventSink = eventDispatcher.eventSink();
     try {
-      mappedValue = backingMap().getAndPin(key);
-
       mappedValue = backingMap().compute(key, new BiFunction<K, OffHeapValueHolder<V>, OffHeapValueHolder<V>>() {
         @Override
         public OffHeapValueHolder<V> apply(K mappedKey, OffHeapValueHolder<V> mappedValue) {


### PR DESCRIPTION
When investigating performance and churn, AbstractOffHeapStore.getAndFault
was found slower than AbstractOffHeapStore.computeIfAbsentAndFault.
 The issue was a remaining call to backingMap.getAndPin. This is now
 removed.