### PR TITLE
Issue #791 Extract MapWrapper from OnHeapStore

### DIFF
--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/Backend.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/Backend.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.heap;
+
+import org.ehcache.config.EvictionVeto;
+import org.ehcache.core.spi.cache.Store;
+import org.ehcache.function.BiFunction;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapKey;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * The idea of this backend is to let all the store code deal in terms of {@code <K>} and hide the potentially different
+ * key type of the underlying {@link org.ehcache.impl.internal.concurrent.ConcurrentHashMap}.
+ */
+interface Backend<K, V> {
+  OnHeapValueHolder<V> remove(K key);
+
+  OnHeapValueHolder<V> computeIfPresent(K key, BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>> biFunction);
+
+  OnHeapValueHolder<V> compute(K key, BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>> biFunction);
+
+  void clear();
+
+  Iterable<K> keySet();
+
+  Iterator<Map.Entry<K,OnHeapValueHolder<V>>> entrySetIterator();
+
+  OnHeapValueHolder<V> get(K key);
+
+  OnHeapValueHolder<V> putIfAbsent(K key, OnHeapValueHolder<V> value);
+
+  boolean remove(K key, OnHeapValueHolder<V> value);
+
+  boolean replace(K key, OnHeapValueHolder<V> oldValue, OnHeapValueHolder<V> newValue);
+
+  int size();
+
+  Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(Random random, int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionVeto<Object, OnHeapValueHolder<?>> evictionVeto);
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/KeyCopyBackend.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/KeyCopyBackend.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.heap;
+
+import org.ehcache.config.EvictionVeto;
+import org.ehcache.core.spi.cache.Store;
+import org.ehcache.function.BiFunction;
+import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
+import org.ehcache.impl.internal.store.heap.holders.CopiedOnHeapKey;
+import org.ehcache.impl.internal.store.heap.holders.LookupOnlyOnHeapKey;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapKey;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
+import org.ehcache.spi.copy.Copier;
+
+import java.util.AbstractMap;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Backend dealing with a key copier and storing keys as {@code OnHeapKey<K>}
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ */
+class KeyCopyBackend<K, V> implements Backend<K, V> {
+
+  private final ConcurrentHashMap<OnHeapKey<K>, OnHeapValueHolder<V>> keyCopyMap;
+  private final Copier<K> keyCopier;
+
+  KeyCopyBackend(Copier<K> keyCopier) {
+    this.keyCopier = keyCopier;
+    keyCopyMap = new ConcurrentHashMap<OnHeapKey<K>, OnHeapValueHolder<V>>();
+  }
+
+  @Override
+  public boolean remove(K key, OnHeapValueHolder<V> value) {
+    return keyCopyMap.remove(lookupOnlyKey(key), value);
+  }
+
+  @Override
+  public Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(Random random, int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionVeto<Object, OnHeapValueHolder<?>> evictionVeto) {
+    Map.Entry<OnHeapKey<K>, OnHeapValueHolder<V>> candidate = keyCopyMap.getEvictionCandidate(random, size, prioritizer, evictionVeto);
+
+    if (candidate == null) {
+      return null;
+    } else {
+      return new AbstractMap.SimpleEntry<K, OnHeapValueHolder<V>>(candidate.getKey().getActualKeyObject(), candidate.getValue());
+    }
+  }
+
+  @Override
+  public int size() {
+    return keyCopyMap.size();
+  }
+
+  @Override
+  public Iterable<K> keySet() {
+    final Iterator<OnHeapKey<K>> iter = keyCopyMap.keySet().iterator();
+    return new Iterable<K>() {
+      @Override
+      public Iterator<K> iterator() {
+        return new Iterator<K>() {
+          @Override
+          public boolean hasNext() {
+            return iter.hasNext();
+          }
+
+          @Override
+          public K next() {
+            return iter.next().getActualKeyObject();
+          }
+
+          @Override
+          public void remove() {
+            iter.remove();
+          }
+        };
+      }
+    };
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, OnHeapValueHolder<V>>> entrySetIterator() {
+
+    final java.util.Iterator<Map.Entry<OnHeapKey<K>, OnHeapValueHolder<V>>> iter = keyCopyMap.entrySet().iterator();
+    return new java.util.Iterator<Map.Entry<K, OnHeapValueHolder<V>>>() {
+      @Override
+      public boolean hasNext() {
+        return iter.hasNext();
+      }
+
+      @Override
+      public Map.Entry<K, OnHeapValueHolder<V>> next() {
+        Map.Entry<OnHeapKey<K>, OnHeapValueHolder<V>> entry = iter.next();
+        return new AbstractMap.SimpleEntry<K, OnHeapValueHolder<V>>(entry.getKey().getActualKeyObject(), entry.getValue());
+      }
+
+      @Override
+      public void remove() {
+        iter.remove();
+      }
+    };
+  }
+
+  @Override
+  public OnHeapValueHolder<V> compute(final K key, final BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>> computeFunction) {
+
+    return keyCopyMap.compute(makeKey(key), new BiFunction<OnHeapKey<K>, OnHeapValueHolder<V>, OnHeapValueHolder<V>>() {
+      @Override
+      public OnHeapValueHolder<V> apply(OnHeapKey<K> mappedKey, OnHeapValueHolder<V> mappedValue) {
+        return computeFunction.apply(mappedKey.getActualKeyObject(), mappedValue);
+      }
+    });
+  }
+
+  @Override
+  public void clear() {
+    keyCopyMap.clear();
+  }
+
+  @Override
+  public OnHeapValueHolder<V> remove(K key) {
+    return keyCopyMap.remove(lookupOnlyKey(key));
+  }
+
+  @Override
+  public OnHeapValueHolder<V> computeIfPresent(final K key, final BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>> computeFunction) {
+
+    return keyCopyMap.computeIfPresent(makeKey(key), new BiFunction<OnHeapKey<K>, OnHeapValueHolder<V>, OnHeapValueHolder<V>>() {
+      @Override
+      public OnHeapValueHolder<V> apply(OnHeapKey<K> mappedKey, OnHeapValueHolder<V> mappedValue) {
+        return computeFunction.apply(mappedKey.getActualKeyObject(), mappedValue);
+      }
+    });
+  }
+
+  private OnHeapKey<K> makeKey(K key) {
+    return new CopiedOnHeapKey<K>(key, keyCopier);
+  }
+
+  private OnHeapKey<K> lookupOnlyKey(K key) {
+    return new LookupOnlyOnHeapKey<K>(key);
+  }
+
+  @Override
+  public OnHeapValueHolder<V> get(K key) {
+    return keyCopyMap.get(lookupOnlyKey(key));
+  }
+
+  @Override
+  public OnHeapValueHolder<V> putIfAbsent(K key, OnHeapValueHolder<V> valueHolder) {
+    return keyCopyMap.putIfAbsent(makeKey(key), valueHolder);
+  }
+
+  @Override
+  public boolean replace(K key, OnHeapValueHolder<V> oldValue, OnHeapValueHolder<V> newValue) {
+    return keyCopyMap.replace(lookupOnlyKey(key), oldValue, newValue);
+  }
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/SimpleBackend.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/SimpleBackend.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.heap;
+
+import org.ehcache.config.EvictionVeto;
+import org.ehcache.core.spi.cache.Store;
+import org.ehcache.function.BiFunction;
+import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Simple passthrough backend, no key translation
+ */
+class SimpleBackend<K, V> implements Backend<K, V> {
+
+  private final ConcurrentHashMap<K, OnHeapValueHolder<V>> realMap;
+
+  SimpleBackend() {
+    realMap = new ConcurrentHashMap<K, OnHeapValueHolder<V>>();
+  }
+
+  @Override
+  public boolean remove(K key, OnHeapValueHolder<V> value) {
+    return realMap.remove(key, value);
+  }
+
+  @Override
+  public Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(Random random, int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionVeto<Object, OnHeapValueHolder<?>> evictionVeto) {
+    return realMap.getEvictionCandidate(random, size, prioritizer, evictionVeto);
+  }
+
+  @Override
+  public int size() {
+    return realMap.size();
+  }
+
+  @Override
+  public Iterable<K> keySet() {
+    return realMap.keySet();
+  }
+
+  @Override
+  public java.util.Iterator<Map.Entry<K, OnHeapValueHolder<V>>> entrySetIterator() {
+    return realMap.entrySet().iterator();
+  }
+
+  @Override
+  public OnHeapValueHolder<V> compute(final K key, final BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>> computeFunction) {
+    return realMap.compute(key, computeFunction);
+  }
+
+  @Override
+  public void clear() {
+    realMap.clear();
+  }
+
+  @Override
+  public OnHeapValueHolder<V> remove(K key) {
+    return realMap.remove(key);
+  }
+
+  @Override
+  public OnHeapValueHolder<V> computeIfPresent(final K key, final BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>> computeFunction) {
+    return realMap.computeIfPresent(key, computeFunction);
+  }
+
+  @Override
+  public OnHeapValueHolder<V> get(K key) {
+    return realMap.get(key);
+  }
+
+  @Override
+  public OnHeapValueHolder<V> putIfAbsent(K key, OnHeapValueHolder<V> valueHolder) {
+    return realMap.putIfAbsent(key, valueHolder);
+  }
+
+  @Override
+  public boolean replace(K key, OnHeapValueHolder<V> oldValue, OnHeapValueHolder<V> newValue) {
+    return realMap.replace(key, oldValue, newValue);
+  }
+}


### PR DESCRIPTION
This enables two different implementation:
* Existing one which store OnHeapKey<K> to handle copy semantics
for the key
* New one which acts as a passthrough when the key copier is an
IdentityCopier