### PR TITLE
Suggestion: use standard logger name for logging

### DIFF
--- a/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -296,9 +296,9 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> imp
     } else {
       String loggerName;
       if (id != null) {
-        loggerName = Ehcache.class.getName() + "-" + id;
+        loggerName = Ehcache.class.getName() + "." + id;
       } else {
-        loggerName = Ehcache.class.getName() + "-UserManaged" + instanceId.incrementAndGet();
+        loggerName = Ehcache.class.getName() + ".UserManaged." + instanceId.incrementAndGet();
       }
       Ehcache<K, V> cache = new Ehcache<K, V>(cacheConfig, store, cacheLoaderWriter, eventDispatcher, LoggerFactory.getLogger(loggerName));
       registerListeners(cache, serviceLocator, lifeCycledList);


### PR DESCRIPTION
Logging systems use package separator to filter

`<logger name="org.ehcache.spi" level="WARN"/>`

So a suggestion would be to use that so that we can filter the different cache names in logs, if you are using cache names in logger names.

I saw it in `UserManagedCacheBuilder `. I don't know if other classes needs to be changed though...