### PR TITLE
Suggestion: use standard logger name for logging (replaces #801)

### DIFF
--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -335,7 +335,7 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
     evtService.setStoreEventSource(store.getStoreEventSource());
 
     final Ehcache<K, V> ehCache = new Ehcache<K, V>(config, store, decorator, evtService,
-        useLoaderInAtomics, LoggerFactory.getLogger(Ehcache.class + "-" + alias));
+        useLoaderInAtomics, LoggerFactory.getLogger(Ehcache.class.getName() + "." + alias));
 
     final CacheEventListenerProvider evntLsnrFactory = serviceLocator.getService(CacheEventListenerProvider.class);
     if (evntLsnrFactory != null) {

--- a/core/src/main/java/org/ehcache/core/PersistentUserManagedEhcache.java
+++ b/core/src/main/java/org/ehcache/core/PersistentUserManagedEhcache.java
@@ -51,7 +51,7 @@ public class PersistentUserManagedEhcache<K, V> implements PersistentUserManaged
   private final String id;
 
   public PersistentUserManagedEhcache(CacheConfiguration<K, V> configuration, Store<K, V> store, Store.Configuration<K, V> storeConfig, LocalPersistenceService localPersistenceService, CacheLoaderWriter<? super K, V> cacheLoaderWriter, CacheEventDispatcher<K, V> eventNotifier, String id) {
-    this.logger = LoggerFactory.getLogger(PersistentUserManagedEhcache.class.getName() + "-" + id);
+    this.logger = LoggerFactory.getLogger(PersistentUserManagedEhcache.class.getName() + "." + id);
     this.statusTransitioner = new StatusTransitioner(logger);
     this.ehcache = new Ehcache<K, V>(new EhcacheRuntimeConfiguration<K, V>(configuration), store, cacheLoaderWriter, eventNotifier, true, logger, statusTransitioner);
     this.localPersistenceService = localPersistenceService;

--- a/core/src/test/java/org/ehcache/core/CacheConfigurationChangeListenerTest.java
+++ b/core/src/test/java/org/ehcache/core/CacheConfigurationChangeListenerTest.java
@@ -55,7 +55,7 @@ public class CacheConfigurationChangeListenerTest {
     CacheLoaderWriter<Object, Object> loaderWriter = mock(CacheLoaderWriter.class);
     this.config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null, null, null, ResourcePoolsHelper.createHeapDiskPools(2, 10));
     this.cache = new Ehcache<Object, Object>(config, store, loaderWriter, eventNotifier,
-        LoggerFactory.getLogger(Ehcache.class + "-" + "CacheConfigurationListenerTest"));
+        LoggerFactory.getLogger(Ehcache.class.getName() + ".CacheConfigurationListenerTest"));
     cache.init();
     this.runtimeConfiguration = (EhcacheRuntimeConfiguration<Object, Object>)cache.getRuntimeConfiguration();
   }
@@ -96,7 +96,7 @@ public class CacheConfigurationChangeListenerTest {
     @Override
     public void cacheConfigurationChange(CacheConfigurationChangeEvent event) {
       this.eventSet.add(event);
-      Logger logger = LoggerFactory.getLogger(Ehcache.class + "-" + "GettingStarted");
+      Logger logger = LoggerFactory.getLogger(Ehcache.class.getName() + "." + "GettingStarted");
       logger.info("Setting size: "+event.getNewValue().toString());
     }
   }

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicClearTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicClearTest.java
@@ -133,7 +133,7 @@ public class EhcacheBasicClearTest extends EhcacheBasicCrudBase {
   private Ehcache<String, String> getEhcache()
       throws Exception {
     final Ehcache<String, String> ehcache =
-        new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, this.cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicClearTest"));
+        new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, this.cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicClearTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicContainsKeyTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicContainsKeyTest.java
@@ -184,7 +184,7 @@ public class EhcacheBasicContainsKeyTest extends EhcacheBasicCrudBase {
   private Ehcache<String, String> getEhcache()
       throws Exception {
     final Ehcache<String, String> ehcache =
-        new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, this.cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicContainsKeyTest"));
+        new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, this.cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicContainsKeyTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicGetAllTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicGetAllTest.java
@@ -3688,7 +3688,7 @@ public class EhcacheBasicGetAllTest extends EhcacheBasicCrudBase {
    * @return a new {@code Ehcache} instance
    */
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicGetAllTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicGetAllTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicGetTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicGetTest.java
@@ -477,7 +477,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
    * @return a new {@code Ehcache} instance
    */
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicGetTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicGetTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), CoreMatchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicIteratorTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicIteratorTest.java
@@ -414,7 +414,7 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
    * @return a new {@code Ehcache} instance
    */
   private Ehcache<String, String> getEhcache(CacheLoaderWriter<String, String> cacheLoaderWriter) throws Exception {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicIteratorTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicIteratorTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicPutAllTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicPutAllTest.java
@@ -2139,7 +2139,7 @@ public class EhcacheBasicPutAllTest extends EhcacheBasicCrudBase {
   }
 
   private Ehcache<String, String> getEhcache(CacheLoaderWriter<String, String> cacheLoaderWriter, CacheConfiguration<String, String> config) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicPutAllTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicPutAllTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicPutIfAbsentTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicPutIfAbsentTest.java
@@ -530,7 +530,7 @@ public class EhcacheBasicPutIfAbsentTest extends EhcacheBasicCrudBase {
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter, Expiry<? super String, ? super String> expiry) {
     CacheConfiguration<String, String> config = new BaseCacheConfiguration<String, String>(String.class, String.class, null, null,
         expiry, ResourcePoolsHelper.createHeapOnlyPools());
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicPutIfAbsentTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicPutIfAbsentTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicPutTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicPutTest.java
@@ -527,7 +527,7 @@ public class EhcacheBasicPutTest extends EhcacheBasicCrudBase {
   }
 
   private Ehcache<String, String> getEhcache(CacheLoaderWriter<String, String> cacheLoaderWriter, CacheConfiguration<String, String> config) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicPutTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicPutTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), CoreMatchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
@@ -2033,7 +2033,7 @@ public class EhcacheBasicRemoveAllTest extends EhcacheBasicCrudBase {
    * @return a new {@code Ehcache} instance
    */
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicRemoveAllTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicRemoveAllTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveTest.java
@@ -488,7 +488,7 @@ public class EhcacheBasicRemoveTest extends EhcacheBasicCrudBase {
    * @return a new {@code Ehcache} instance
    */
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicRemoveTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicRemoveTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), CoreMatchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveValueTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveValueTest.java
@@ -840,7 +840,7 @@ public class EhcacheBasicRemoveValueTest extends EhcacheBasicCrudBase {
    * @return a new {@code Ehcache} instance
    */
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter) {
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicRemoveValueTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicRemoveValueTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), CoreMatchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicReplaceTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicReplaceTest.java
@@ -551,7 +551,7 @@ public class EhcacheBasicReplaceTest extends EhcacheBasicCrudBase {
     CacheConfiguration<String, String> config = new BaseCacheConfiguration<String, String>(String.class, String.class, null, null,
         expiry, ResourcePoolsHelper.createHeapOnlyPools());
     final Ehcache<String, String> ehcache
-        = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicReplaceTest"));
+        = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicReplaceTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), CoreMatchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicReplaceValueTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicReplaceValueTest.java
@@ -928,7 +928,7 @@ public class EhcacheBasicReplaceValueTest extends EhcacheBasicCrudBase {
   private Ehcache<String, String> getEhcache(final CacheLoaderWriter<String, String> cacheLoaderWriter, Expiry<? super String, ? super String> expiry) {
     CacheConfiguration<String, String> config = new BaseCacheConfiguration<String, String>(String.class, String.class, null, null,
         expiry, ResourcePoolsHelper.createHeapOnlyPools());
-    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicReplaceValueTest"));
+    final Ehcache<String, String> ehcache = new Ehcache<String, String>(config, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBasicReplaceValueTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), CoreMatchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);

--- a/core/src/test/java/org/ehcache/core/EhcacheBulkMethodsTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBulkMethodsTest.java
@@ -64,7 +64,7 @@ public class EhcacheBulkMethodsTest {
     Store<Number, CharSequence> store = mock(Store.class);
     CacheEventDispatcher<Number, CharSequence> cacheEventDispatcher = mock(CacheEventDispatcher.class);
 
-    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBulkMethodsTest"));
+    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBulkMethodsTest"));
     ehcache.init();
 
     ehcache.putAll(new HashMap<Number, CharSequence>() {{
@@ -90,7 +90,7 @@ public class EhcacheBulkMethodsTest {
     CacheLoaderWriter<Number, CharSequence> cacheLoaderWriter = mock(CacheLoaderWriter.class);
     CacheEventDispatcher<Number, CharSequence> notifier = mock(CacheEventDispatcher.class);
 
-    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheLoaderWriter, notifier, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBulkMethodsTest1"));
+    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheLoaderWriter, notifier, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBulkMethodsTest1"));
     ehcache.init();
 
     ehcache.putAll(new LinkedHashMap<Number, CharSequence>() {{
@@ -118,7 +118,7 @@ public class EhcacheBulkMethodsTest {
     });
     CacheEventDispatcher<Number, CharSequence> cacheEventDispatcher = mock(CacheEventDispatcher.class);
 
-    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBulkMethodsTest2"));
+    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBulkMethodsTest2"));
     ehcache.init();
     Map<Number, CharSequence> result = ehcache.getAll(new HashSet<Number>(Arrays.asList(1, 2, 3)));
 
@@ -149,7 +149,7 @@ public class EhcacheBulkMethodsTest {
     CacheLoaderWriter<Number, CharSequence> cacheLoaderWriter = mock(CacheLoaderWriter.class);
     CacheEventDispatcher<Number, CharSequence> cacheEventDispatcher = mock(CacheEventDispatcher.class);
 
-    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBulkMethodsTest3"));
+    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBulkMethodsTest3"));
     ehcache.init();
     Map<Number, CharSequence> result = ehcache.getAll(new HashSet<Number>(Arrays.asList(1, 2, 3)));
 
@@ -165,7 +165,7 @@ public class EhcacheBulkMethodsTest {
     Store<Number, CharSequence> store = mock(Store.class);
     CacheEventDispatcher<Number, CharSequence> cacheEventDispatcher = mock(CacheEventDispatcher.class);
 
-    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBulkMethodsTest4"));
+    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBulkMethodsTest4"));
     ehcache.init();
     ehcache.removeAll(new HashSet<Number>(Arrays.asList(1, 2, 3)));
 
@@ -186,7 +186,7 @@ public class EhcacheBulkMethodsTest {
     CacheLoaderWriter<Number, CharSequence> cacheLoaderWriter = mock(CacheLoaderWriter.class);
     CacheEventDispatcher<Number, CharSequence> notifier = mock(CacheEventDispatcher.class);
 
-    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheLoaderWriter, notifier, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBulkMethodsTest5"));
+    Ehcache<Number, CharSequence> ehcache = new Ehcache<Number, CharSequence>(cacheConfig, store, cacheLoaderWriter, notifier, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheBulkMethodsTest5"));
     ehcache.init();
     ehcache.removeAll(new LinkedHashSet<Number>(Arrays.asList(1, 2, 3)));
 

--- a/core/src/test/java/org/ehcache/core/EhcacheLoaderWriterTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheLoaderWriterTest.java
@@ -64,7 +64,7 @@ public class EhcacheLoaderWriterTest {
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Number, String> notifier = mock(CacheEventDispatcher.class);
     cache = new Ehcache<Number, String>(
-        config, store, loaderWriter, notifier, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheLoaderWriterTest"));
+        config, store, loaderWriter, notifier, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheLoaderWriterTest"));
     cache.init();
   }
 

--- a/core/src/test/java/org/ehcache/core/EhcacheTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheTest.java
@@ -73,7 +73,7 @@ public class EhcacheTest {
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
 
-    Ehcache ehcache = new Ehcache(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest"));
+    Ehcache ehcache = new Ehcache(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest"));
     assertThat(ehcache.getStatus(), CoreMatchers.is(Status.UNINITIALIZED));
     ehcache.init();
     assertThat(ehcache.getStatus(), is(Status.AVAILABLE));
@@ -89,7 +89,7 @@ public class EhcacheTest {
     final CacheConfiguration<Object, Object> config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
-    Ehcache ehcache = new Ehcache(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest1"));
+    Ehcache ehcache = new Ehcache(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest1"));
 
     try {
       ehcache.get("foo");
@@ -210,7 +210,7 @@ public class EhcacheTest {
     final CacheConfiguration<Object, Object> config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
-    Ehcache ehcache = new Ehcache(config, mock(Store.class), cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest2"));
+    Ehcache ehcache = new Ehcache(config, mock(Store.class), cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest2"));
     final LifeCycled mock = mock(LifeCycled.class);
     ehcache.addHook(mock);
     ehcache.init();
@@ -225,7 +225,7 @@ public class EhcacheTest {
     final CacheConfiguration<Object, Object> config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
-    Ehcache ehcache = new Ehcache(config, mock(Store.class), cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest3"));
+    Ehcache ehcache = new Ehcache(config, mock(Store.class), cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest3"));
     doThrow(new Exception()).when(mock).init();
     ehcache.addHook(mock);
     try {
@@ -302,7 +302,7 @@ public class EhcacheTest {
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
     Ehcache<Object, Object> ehcache = new Ehcache<Object, Object>(
-        config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest4"));
+        config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest4"));
     ehcache.init();
     assertThat(ehcache.putIfAbsent("foo", value), nullValue());
     assertThat(ehcache.putIfAbsent("foo", "foo"), CoreMatchers.<Object>is(value));
@@ -316,7 +316,7 @@ public class EhcacheTest {
     final CacheConfiguration<Object, Object> config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
-    Ehcache ehcache = new Ehcache(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest5"));
+    Ehcache ehcache = new Ehcache(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest5"));
 
     final LifeCycled hook = mock(LifeCycled.class);
     ehcache.addHook(hook);
@@ -348,7 +348,7 @@ public class EhcacheTest {
     CacheEventDispatcher<String, String> cacheEventDispatcher = mock(CacheEventDispatcher.class);
     CacheConfiguration<String, String> config = new BaseCacheConfiguration<String, String>(String.class, String.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
-    Ehcache<String, String> ehcache = new Ehcache<String, String>(config, store, loader, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest6"));
+    Ehcache<String, String> ehcache = new Ehcache<String, String>(config, store, loader, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class.getName() + ".EhcacheTest6"));
     ehcache.init();
 
     HashSet<String> keys = new HashSet<String>();

--- a/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -296,9 +296,9 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> imp
     } else {
       String loggerName;
       if (id != null) {
-        loggerName = Ehcache.class.getName() + "-" + id;
+        loggerName = Ehcache.class.getName() + "." + id;
       } else {
-        loggerName = Ehcache.class.getName() + "-UserManaged" + instanceId.incrementAndGet();
+        loggerName = Ehcache.class.getName() + ".UserManaged." + instanceId.incrementAndGet();
       }
       Ehcache<K, V> cache = new Ehcache<K, V>(cacheConfig, store, cacheLoaderWriter, eventDispatcher, LoggerFactory.getLogger(loggerName));
       registerListeners(cache, serviceLocator, lifeCycledList);

--- a/impl/src/test/java/org/ehcache/docs/plugs/ListenerObject.java
+++ b/impl/src/test/java/org/ehcache/docs/plugs/ListenerObject.java
@@ -29,7 +29,7 @@ public class ListenerObject implements CacheEventListener<Object, Object> {
   private int evicted;
   @Override
   public void onEvent(CacheEvent<Object, Object> event) {
-    Logger logger = LoggerFactory.getLogger(Ehcache.class + "-" + "GettingStarted");
+    Logger logger = LoggerFactory.getLogger(Ehcache.class.getName() + ".GettingStarted");
     logger.info(event.getType().toString());
     if(event.getType() == EventType.EVICTED){
       evicted++;

--- a/integration-test/src/test/java/org/ehcache/integration/EventNotificationTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/EventNotificationTest.java
@@ -242,7 +242,7 @@ public class EventNotificationTest {
 
   @Test
   public void testEventFiringInCacheIterator() {
-    Logger logger = LoggerFactory.getLogger(Ehcache.class + "-" + "EventNotificationTest");
+    Logger logger = LoggerFactory.getLogger(Ehcache.class.getName() + ".EventNotificationTest");
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
         .withExpiry(Expirations.timeToLiveExpiration(new Duration(1, TimeUnit.SECONDS)))
         .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
@@ -407,7 +407,7 @@ public class EventNotificationTest {
 
     @Override
     public void onEvent(CacheEvent<Object, Object> event) {
-      Logger logger = LoggerFactory.getLogger(Ehcache.class + "-" + "EventNotificationTest");
+      Logger logger = LoggerFactory.getLogger(Ehcache.class.getName() + ".EventNotificationTest");
       logger.info(event.getType().toString());
       eventTypeHashMap.put(event.getType(), eventCounter.get());
       eventCounter.getAndIncrement();


### PR DESCRIPTION
Logging systems use package separator to filter

`<logger name="org.ehcache.spi" level="WARN"/>`

So a suggestion would be to use that so that we can filter the different cache names in logs, if you are using cache names in logger names.

REPLACES PR #801 