### PR TITLE
Issue #797 Update computeIfPinned to leverage offheap 2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ import scripts.*
 
 ext {
   baseVersion = '3.0.0-SNAPSHOT'
-  offheapVersion = '2.2.0'
+  offheapVersion = '2.2.1'
   managementVersion = '2.2.0'
   statisticVersion = '1.1.0'
   jcacheVersion = '1.0.0'

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/EhcacheOffHeapBackingMap.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/EhcacheOffHeapBackingMap.java
@@ -25,11 +25,43 @@ import org.terracotta.offheapstore.Segment;
 
 public interface EhcacheOffHeapBackingMap<K, V> extends ConcurrentMap<K, V> {
 
+  /**
+   * Computes a new mapping for the given key by calling the function passed in. It will pin the mapping
+   * if the flag is true, it will however not unpin an existing pinned mapping in case the function returns
+   * the existing value.
+   *
+   * @param key the key to compute the mapping for
+   * @param mappingFunction the function to compute the mapping
+   * @param pin pins the mapping if {code true}
+   *
+   * @return the mapped value
+   */
   V compute(K key, BiFunction<K, V, V> mappingFunction, boolean pin);
 
+  /**
+   * Computes a new mapping for the given key by calling the function passed in only if a mapping existed already.
+   *
+   * @param key the key to compute the mapping for
+   * @param mappingFunction the function to compute the mapping
+   *
+   * @return the mapped value
+   */
   V computeIfPresent(K key, BiFunction<K, V, V> mappingFunction);
 
-  boolean computeIfPinned(K key, BiFunction<K,V,V> remappingFunction, Function<V,Boolean> pinningFunction);
+  /**
+   * Computes a new mapping for the given key by calling the function passed in only if a mapping existed already and
+   * was pinned.
+   * <P>
+   *   The unpin function indicates if the mapping is to be unpinned or not after the operation.
+   * </P>
+   *
+   * @param key the key to operate on
+   * @param remappingFunction the function returning the new value
+   * @param unpinFunction the function indicating the final pin status
+   *
+   * @return {@code true} if an existing mapping was unpinned, {@code false} otherwise
+   */
+  boolean computeIfPinned(K key, BiFunction<K,V,V> remappingFunction, Function<V,Boolean> unpinFunction);
 
   long nextIdFor(K key);
 

--- a/impl/src/test/java/org/ehcache/impl/config/serializer/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/config/serializer/SerializerCountingTest.java
@@ -161,7 +161,7 @@ public class SerializerCountingTest {
     printSerializationCounters("Get DiskOffHeapOnHeapCopy faulted");
 
     cache.put(42L, "Wrong ...");
-    assertCounters(3, 2, 2, 1, 1, 0);
+    assertCounters(3, 2, 2, 1, 2, 0);
     printSerializationCounters("Put DiskOffHeapOnHeapCopy (update faulted)");
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractEhcacheOffHeapBackingMapTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractEhcacheOffHeapBackingMapTest.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.offheap;
+
+import org.ehcache.config.EvictionVeto;
+import org.ehcache.function.BiFunction;
+import org.ehcache.function.Function;
+import org.ehcache.impl.internal.store.offheap.factories.EhcacheSegmentFactory;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * AbstractEhcacheOffHeapBackingMapTest
+ */
+public abstract class AbstractEhcacheOffHeapBackingMapTest {
+  protected abstract EhcacheOffHeapBackingMap<String, String> createTestSegment() throws IOException;
+
+  protected abstract EhcacheOffHeapBackingMap<String, String> createTestSegment(EvictionVeto<? super String, ? super String> evictionPredicate) throws IOException;
+
+  protected abstract void destroySegment(EhcacheOffHeapBackingMap<String, String> segment);
+
+  protected abstract void putPinned(String key, String value, EhcacheOffHeapBackingMap<String, String> segment);
+
+  protected abstract boolean isPinned(String key, EhcacheOffHeapBackingMap<String, String> segment);
+
+  protected abstract int getMetadata(String key, int mask, EhcacheOffHeapBackingMap<String, String> segment);
+
+  @Test
+  public void testComputeFunctionCalledWhenNoMapping() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return "value";
+        }
+      }, false);
+      assertThat(value, is("value"));
+      assertThat(segment.get("key"), is(value));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsSameNoPin() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return s2;
+        }
+      }, false);
+      assertThat(value, is("value"));
+      assertThat(isPinned("key", segment), is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsSamePins() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return s2;
+        }
+      }, true);
+      assertThat(value, is("value"));
+      assertThat(isPinned("key", segment), is(true));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsSamePreservesPinWhenNoPin() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      putPinned("key", "value", segment);
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return s2;
+        }
+      }, false);
+      assertThat(value, is("value"));
+      assertThat(isPinned("key", segment), is(true));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsDifferentNoPin() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return "otherValue";
+        }
+      }, false);
+      assertThat(value, is("otherValue"));
+      assertThat(isPinned("key", segment), is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsDifferentPins() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return "otherValue";
+        }
+      }, true);
+      assertThat(value, is("otherValue"));
+      assertThat(isPinned("key", segment), is(true));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsDifferentClearsPin() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      putPinned("key", "value", segment);
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return "otherValue";
+        }
+      }, false);
+      assertThat(value, is("otherValue"));
+      assertThat(isPinned("key", segment), is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeFunctionReturnsNullRemoves() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      putPinned("key", "value", segment);
+      String value = segment.compute("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return null;
+        }
+      }, false);
+      assertThat(value, nullValue());
+      assertThat(segment.containsKey("key"), is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPresentNotCalledOnNotContainedKey() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      try {
+        segment.computeIfPresent("key", new BiFunction<String, String, String>() {
+          @Override
+          public String apply(String s, String s2) {
+            throw new UnsupportedOperationException("Should not have been called!");
+          }
+        });
+      } catch (UnsupportedOperationException e) {
+        fail("Mapping function should not have been called.");
+      }
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPresentReturnsSameValue() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return s2;
+        }
+      });
+      assertThat(segment.get("key"), is(value));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPresentReturnsDifferentValue() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return "newValue";
+        }
+      });
+      assertThat(segment.get("key"), is(value));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPresentReturnsNullRemovesMapping() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      String value = segment.computeIfPresent("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          return null;
+        }
+      });
+      assertThat(segment.containsKey("key"), is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedNoOpUnpinned() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    try {
+      segment.put("key", "value");
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          fail("Method should not be invoked");
+          return null;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          fail("Method should not be invoked");
+          return false;
+        }
+      });
+      assertThat(isPinned("key", segment), is(false));
+      assertThat(result, is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedClearsMappingOnNullReturnWithPinningFalse() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    final String value = "value";
+    try {
+      putPinned("key", value, segment);
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          assertThat(s2, is(value));
+          return null;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          assertThat(s, is(value));
+          return false;
+        }
+      });
+      assertThat(segment.containsKey("key"), is(false));
+      assertThat(result, is(true));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedClearsMappingOnNullReturnWithPinningTrue() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    final String value = "value";
+    try {
+      putPinned("key", value, segment);
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          assertThat(s2, is(value));
+          return null;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          assertThat(s, is(value));
+          return true;
+        }
+      });
+      assertThat(segment.containsKey("key"), is(false));
+      assertThat(result, is(true));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedClearsPinWithoutChangingValue() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    final String value = "value";
+    try {
+      putPinned("key", value, segment);
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          assertThat(s2, is(value));
+          return s2;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          assertThat(s, is(value));
+          return true;
+        }
+      });
+      assertThat(isPinned("key", segment), is(false));
+      assertThat(result, is(true));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedPreservesPinWithoutChangingValue() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    final String value = "value";
+    try {
+      putPinned("key", value, segment);
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          assertThat(s2, is(value));
+          return s2;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          assertThat(s, is(value));
+          return false;
+        }
+      });
+      assertThat(isPinned("key", segment), is(true));
+      assertThat(result, is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedReplacesValueUnpinnedWhenUnpinFunctionFalse() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    final String value = "value";
+    final String newValue = "newValue";
+    try {
+      putPinned("key", value, segment);
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          assertThat(s2, is(value));
+          return newValue;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          assertThat(s, is(value));
+          return false;
+        }
+      });
+      assertThat(segment.get("key"), is(newValue));
+      assertThat(isPinned("key", segment), is(false));
+      assertThat(result, is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testComputeIfPinnedReplacesValueUnpinnedWhenUnpinFunctionTrue() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment();
+    final String value = "value";
+    final String newValue = "newValue";
+    try {
+      putPinned("key", value, segment);
+      boolean result = segment.computeIfPinned("key", new BiFunction<String, String, String>() {
+        @Override
+        public String apply(String s, String s2) {
+          assertThat(s2, is(value));
+          return newValue;
+        }
+      }, new Function<String, Boolean>() {
+        @Override
+        public Boolean apply(String s) {
+          assertThat(s, is(value));
+          return true;
+        }
+      });
+      assertThat(segment.get("key"), is(newValue));
+      assertThat(isPinned("key", segment), is(false));
+      assertThat(result, is(false));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testPutVetoedComputesMetadata() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment(new EvictionVeto<String, String>() {
+      @Override
+      public boolean vetoes(String key, String value) {
+        return "vetoed".equals(key);
+      }
+    });
+    try {
+      segment.put("vetoed", "value");
+      assertThat(getMetadata("vetoed", EhcacheSegmentFactory.EhcacheSegment.VETOED, segment), is(EhcacheSegmentFactory.EhcacheSegment.VETOED));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+
+  @Test
+  public void testPutPinnedVetoedComputesMetadata() throws Exception {
+    EhcacheOffHeapBackingMap<String, String> segment = createTestSegment(new EvictionVeto<String, String>() {
+      @Override
+      public boolean vetoes(String key, String value) {
+        return "vetoed".equals(key);
+      }
+    });
+    try {
+      putPinned("vetoed", "value", segment);
+      assertThat(getMetadata("vetoed", EhcacheSegmentFactory.EhcacheSegment.VETOED, segment), is(EhcacheSegmentFactory.EhcacheSegment.VETOED));
+    } finally {
+      destroySegment(segment);
+    }
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/EhcacheConcurrentOffHeapClockCacheTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/EhcacheConcurrentOffHeapClockCacheTest.java
@@ -18,14 +18,12 @@ package org.ehcache.impl.internal.store.offheap;
 
 import org.ehcache.config.Eviction;
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.function.BiFunction;
 import org.ehcache.impl.internal.spi.serialization.DefaultSerializationProvider;
 import org.ehcache.impl.internal.store.offheap.factories.EhcacheSegmentFactory;
 import org.ehcache.impl.internal.store.offheap.portability.SerializerPortability;
 import org.ehcache.spi.serialization.SerializationProvider;
 import org.ehcache.spi.serialization.Serializer;
 import org.ehcache.spi.serialization.UnsupportedTypeException;
-import org.junit.Test;
 import org.terracotta.offheapstore.paging.PageSource;
 import org.terracotta.offheapstore.paging.UpfrontAllocatingPageSource;
 import org.terracotta.offheapstore.storage.OffHeapBufferStorageEngine;
@@ -35,28 +33,22 @@ import org.terracotta.offheapstore.util.Factory;
 
 import static org.ehcache.impl.internal.spi.TestServiceProvider.providerContaining;
 import static org.ehcache.impl.internal.store.offheap.OffHeapStoreUtils.getBufferSource;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 /**
  *
  * @author cdennis
  */
-public class EhcacheConcurrentOffHeapClockCacheTest {
+public class EhcacheConcurrentOffHeapClockCacheTest extends AbstractEhcacheOffHeapBackingMapTest {
 
-  private EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment() {
+  @Override
+  protected EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment() {
     return createTestSegment(Eviction.none(), mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class));
   }
 
-  private EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment(EvictionVeto<? super String, ? super String> evictionPredicate) {
+  @Override
+  protected EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment(EvictionVeto<? super String, ? super String> evictionPredicate) {
     return createTestSegment(evictionPredicate, mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class));
-  }
-
-  private EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment(EhcacheSegmentFactory.EhcacheSegment.EvictionListener<String, String> evictionListener) {
-    return createTestSegment(Eviction.none(), evictionListener);
   }
 
   private EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment(EvictionVeto<? super String, ? super String> evictionPredicate, EhcacheSegmentFactory.EhcacheSegment.EvictionListener<String, String> evictionListener) {
@@ -77,248 +69,23 @@ public class EhcacheConcurrentOffHeapClockCacheTest {
     }
   }
 
-  @Test
-  public void testComputeFunctionCalledWhenNoMapping() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return "value";
-        }
-      }, false);
-      assertThat(value, is("value"));
-      assertThat(segment.get("key"), is(value));
-    } finally {
-      segment.destroy();
-    }
+  @Override
+  protected void destroySegment(EhcacheOffHeapBackingMap<String, String> segment) {
+    ((EhcacheConcurrentOffHeapClockCache<String, String>)segment).destroy();
   }
 
-  @Test
-  public void testComputeFunctionReturnsSameNoPin() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return s2;
-        }
-      }, false);
-      assertThat(value, is("value"));
-      assertThat(segment.isPinned("key"), is(false));
-    } finally {
-      segment.destroy();
-    }
+  @Override
+  protected void putPinned(String key, String value, EhcacheOffHeapBackingMap<String, String> segment) {
+    ((EhcacheConcurrentOffHeapClockCache<String, String>) segment).putPinned(key, value);
   }
 
-  @Test
-  public void testComputeFunctionReturnsSamePins() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return s2;
-        }
-      }, true);
-      assertThat(value, is("value"));
-      assertThat(segment.isPinned("key"), is(true));
-    } finally {
-      segment.destroy();
-    }
+  @Override
+  protected boolean isPinned(String key, EhcacheOffHeapBackingMap<String, String> segment) {
+    return ((EhcacheConcurrentOffHeapClockCache<String, String>) segment).isPinned(key);
   }
 
-  @Test
-  public void testComputeFunctionReturnsSamePreservesPinWhenNoPin() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.putPinned("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return s2;
-        }
-      }, false);
-      assertThat(value, is("value"));
-      assertThat(segment.isPinned("key"), is(true));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeFunctionReturnsDifferentNoPin() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return "otherValue";
-        }
-      }, false);
-      assertThat(value, is("otherValue"));
-      assertThat(segment.isPinned("key"), is(false));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeFunctionReturnsDifferentPins() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return "otherValue";
-        }
-      }, true);
-      assertThat(value, is("otherValue"));
-      assertThat(segment.isPinned("key"), is(true));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeFunctionReturnsDifferentClearsPin() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.putPinned("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return "otherValue";
-        }
-      }, false);
-      assertThat(value, is("otherValue"));
-      assertThat(segment.isPinned("key"), is(false));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeFunctionReturnsNullRemoves() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.putPinned("key", "value");
-      String value = segment.compute("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return null;
-        }
-      }, false);
-      assertThat(value, nullValue());
-      assertThat(segment.containsKey("key"), is(false));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeIfPresentNotCalledOnNotContainedKey() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      try {
-        segment.computeIfPresent("key", new BiFunction<String, String, String>() {
-          @Override
-          public String apply(String s, String s2) {
-            throw new UnsupportedOperationException("Should not have been called!");
-          }
-        });
-      } catch (UnsupportedOperationException e) {
-        fail("Mapping function should not have been called.");
-      }
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeIfPresentReturnsSameValue() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.computeIfPresent("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return s2;
-        }
-      });
-      assertThat(segment.get("key"), is(value));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeIfPresentReturnsDifferentValue() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.computeIfPresent("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return "newValue";
-        }
-      });
-      assertThat(segment.get("key"), is(value));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testComputeIfPresentReturnsNullRemovesMapping() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment();
-    try {
-      segment.put("key", "value");
-      String value = segment.computeIfPresent("key", new BiFunction<String, String, String>() {
-        @Override
-        public String apply(String s, String s2) {
-          return null;
-        }
-      });
-      assertThat(segment.containsKey("key"), is(false));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testPutVetoedComputesMetadata() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment(new EvictionVeto<String, String>() {
-      @Override
-      public boolean vetoes(String key, String value) {
-        return "vetoed".equals(key);
-      }
-    });
-    try {
-      segment.put("vetoed", "value");
-      assertThat(segment.getMetadata("vetoed", EhcacheSegmentFactory.EhcacheSegment.VETOED), is(EhcacheSegmentFactory.EhcacheSegment.VETOED));
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  @Test
-  public void testPutPinnedVetoedComputesMetadata() {
-    EhcacheConcurrentOffHeapClockCache<String, String> segment = createTestSegment(new EvictionVeto<String, String>() {
-      @Override
-      public boolean vetoes(String key, String value) {
-        return "vetoed".equals(key);
-      }
-    });
-    try {
-      segment.putPinned("vetoed", "value");
-      assertThat(segment.getMetadata("vetoed", EhcacheSegmentFactory.EhcacheSegment.VETOED), is(EhcacheSegmentFactory.EhcacheSegment.VETOED));
-    } finally {
-      segment.destroy();
-    }
+  @Override
+  protected int getMetadata(String key, int mask, EhcacheOffHeapBackingMap<String, String> segment) {
+    return ((EhcacheConcurrentOffHeapClockCache<String, String>) segment).getMetadata(key, mask);
   }
 }


### PR DESCRIPTION
* Bump offheap-store to 2.2.1
* Replace EhcachePersistentSegmentFactory.computeIfPinned with an
impl in EhcachePersistentConcurrentOffHeapClockCache
* Further specify the contract of the method with tests
* Extract abstract test class to reduce duplication
* Javadoc cleanup