### PR TITLE
Issue #762

### DIFF
--- a/107/src/main/resources/ehcache-107ext.xsd
+++ b/107/src/main/resources/ehcache-107ext.xsd
@@ -15,9 +15,14 @@
   ~ limitations under the License.
   -->
 
-<xs:schema version="1.0" xmlns:jsr107="http://www.ehcache.org/v3/jsr107" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.ehcache.org/v3/jsr107">
+<xs:schema version="1.0"
+           xmlns:jsr107="http://www.ehcache.org/v3/jsr107"
+           xmlns:eh="http://www.ehcache.org/v3"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified" targetNamespace="http://www.ehcache.org/v3/jsr107">
+  <xs:import namespace="http://www.ehcache.org/v3"/>
 
-  <xs:element name="defaults" type="jsr107:defaults-type">
+  <xs:element name="defaults" type="jsr107:defaults-type" substitutionGroup="eh:service-creation-configuration">
     <xs:key name="default-template-ref">
       <xs:selector xpath="cache-template"/>
       <xs:field xpath="@name"/>

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/builder/ClusteringServiceConfigurationBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/builder/ClusteringServiceConfigurationBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.config.builder;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.config.ClusteringServiceConfiguration.PoolDefinition;
+import org.ehcache.config.builders.Builder;
+import org.terracotta.offheapstore.util.MemoryUnit;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ *
+ * @author cdennis
+ */
+public class ClusteringServiceConfigurationBuilder implements Builder<ClusteringServiceConfiguration> {
+
+  public static ClusteringServiceConfigurationBuilder cluster(URI clusterUri) {
+    return new ClusteringServiceConfigurationBuilder(clusterUri);
+  }
+
+  private final URI clusterUri;
+  private final Map<String, PoolDefinition> pools;
+
+  private ClusteringServiceConfigurationBuilder(URI clusterUri) {
+    this.clusterUri = clusterUri;
+    this.pools = emptyMap();
+  }
+
+  private ClusteringServiceConfigurationBuilder(ClusteringServiceConfigurationBuilder original, String poolName, PoolDefinition poolDefinition) {
+    this.clusterUri = original.clusterUri;
+    Map<String, PoolDefinition> pools = new HashMap<String, PoolDefinition>(original.pools);
+    if (pools.put(poolName, poolDefinition) != null) {
+      throw new IllegalArgumentException("Pool '" + poolName + "' already defined");
+    }
+    this.pools = unmodifiableMap(pools);
+  }
+
+  public Defaulted defaultResource(String resource) {
+    return new Defaulted(this, resource);
+  }
+
+  public ClusteringServiceConfigurationBuilder resourcePool(String name, long size, MemoryUnit unit, String from) {
+    return new ClusteringServiceConfigurationBuilder(this, name, new PoolDefinition(size, unit, from));
+  }
+
+  @Override
+  public ClusteringServiceConfiguration build() {
+    return new ClusteringServiceConfiguration(clusterUri, pools);
+  }
+
+  public class Defaulted implements Builder<ClusteringServiceConfiguration> {
+
+    private final URI clusterUri;
+    private final String defaultResource;
+    private final Map<String, PoolDefinition> pools;
+
+    private Defaulted(ClusteringServiceConfigurationBuilder original, String defaultResource) {
+      this.clusterUri = original.clusterUri;
+      this.pools = unmodifiableMap(original.pools);
+      this.defaultResource = defaultResource;
+    }
+
+    private Defaulted(Defaulted original, String poolName, PoolDefinition poolDefinition) {
+      this.clusterUri = original.clusterUri;
+      this.defaultResource = original.defaultResource;
+      Map<String, PoolDefinition> pools = new HashMap<String, PoolDefinition>(original.pools);
+      if (pools.put(poolName, poolDefinition) != null) {
+        throw new IllegalArgumentException("Pool '" + poolName + "' already defined");
+      }
+      this.pools = unmodifiableMap(pools);
+    }
+
+    public Defaulted resourcePool(String name, long size, MemoryUnit unit) {
+      return new Defaulted(this, name, new PoolDefinition(size, unit));
+    }
+
+    public Defaulted resourcePool(String name, long size, MemoryUnit unit, String from) {
+      return new Defaulted(this, name, new PoolDefinition(size, unit, from));
+    }
+
+    @Override
+    public ClusteringServiceConfiguration build() {
+      return new ClusteringServiceConfiguration(clusterUri, defaultResource, pools);
+    }
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
@@ -17,6 +17,7 @@
 package org.ehcache.clustered.config.xml;
 
 import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.config.ClusteringServiceConfiguration.PoolDefinition;
 import org.ehcache.clustered.service.ClusteringService;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
 import org.ehcache.xml.CacheManagerServiceConfigurationParser;
@@ -29,6 +30,7 @@ import org.w3c.dom.NodeList;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
@@ -94,7 +96,7 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
         }
       }
       // TODO: Validate connectionUri is valid URL with proper content
-      return new ClusteringServiceConfiguration(connectionUri);
+      return new ClusteringServiceConfiguration(connectionUri, Collections.<String, PoolDefinition>emptyMap());
     }
     throw new XmlConfigurationException(String.format("XML configuration element <%s> in <%s> is not supported",
         fragment.getTagName(), (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName())));

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -17,14 +17,17 @@
 
 <xs:schema version="1.0"
            xmlns:tc="http://www.ehcache.org/v3/clustered"
+           xmlns:eh="http://www.ehcache.org/v3"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified"
            targetNamespace="http://www.ehcache.org/v3/clustered">
 
+  <xs:import namespace="http://www.ehcache.org/v3"/>
+
   <!--
     Service configuration elements
   -->
-  <xs:element name="cluster" type="tc:cluster-spec">
+  <xs:element name="cluster" type="tc:cluster-spec" substitutionGroup="eh:service-creation-configuration">
     <xs:annotation>
       <xs:documentation xml:lang="en">
         Used within the /config/service element of an Ehcache configuration, this element

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -16,8 +16,8 @@
   -->
 
 <xs:schema version="1.0"
-           xmlns:tc="http://www.ehcache.org/v3/clustered"
            xmlns:eh="http://www.ehcache.org/v3"
+           xmlns:tc="http://www.ehcache.org/v3/clustered"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified"
            targetNamespace="http://www.ehcache.org/v3/clustered">
@@ -36,10 +36,16 @@
     </xs:annotation>
   </xs:element>
 
+  <xs:element name="server-side-config" type="tc:server-side-config-spec">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies the server-side configuration of the entity to be accessed and or created.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
   <xs:complexType name="cluster-spec">
-
     <xs:sequence minOccurs="1" maxOccurs="1">
-
       <xs:element name="connection" type="tc:connection-spec" minOccurs="1" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>
@@ -47,9 +53,8 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-
+      <xs:element ref="tc:server-side-config" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
-
   </xs:complexType>
 
   <xs:complexType name="connection-spec">
@@ -68,4 +73,94 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:complexType name="server-side-config-spec">
+    <xs:sequence>
+      <xs:element name="default-resource" type="tc:resource-link-spec" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the default server-side storage resource to use for storing cache data.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="shared-pool" type="tc:shared-pool-spec" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Defines a pool of server-side storage resource to be shared amongst multiple caches.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="resource-link-spec">
+    <xs:attribute name="from" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Reference to a server-side storage resource.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="shared-pool-spec">
+    <xs:complexContent>
+      <xs:extension base="eh:memory-type">
+        <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+            <xs:documentation>
+              Shared pool name.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="from" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              Reference to a server-side storage resource.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="cluster-fixed" type="tc:cluster-fixed-resource-type" substitutionGroup="eh:resource">
+    <xs:annotation>
+      <xs:documentation>
+        Clustered cache resource with a fixed size.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:complexType name="cluster-fixed-resource-type">
+    <xs:complexContent>
+      <xs:extension base="eh:memory-type">
+        <xs:attribute name="from" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              Reference to a server-side storage resource.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="cluster-shared" type="tc:cluster-shared-resource-type" substitutionGroup="eh:resource">
+    <xs:annotation>
+      <xs:documentation>
+        Clustered cache resource sharing a pool with other cache resources.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:complexType name="cluster-shared-resource-type">
+    <xs:attribute name="sharing" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Name of the shared pool this resource uses.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
 </xs:schema>

--- a/clustered/client/src/test/java/org/ehcache/clustered/SimpleClusteredCacheByXmlTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/SimpleClusteredCacheByXmlTest.java
@@ -63,21 +63,4 @@ public class SimpleClusteredCacheByXmlTest {
       cacheManager.close();
     }
   }
-
-  @Test
-  public void testViaXmlDirect() throws Exception {
-    final Configuration configuration = new XmlConfiguration(this.getClass().getResource(SIMPLE_CLUSTER_XML));
-    final CacheManager cacheManager = CacheManagerBuilder.newCacheManager(configuration);
-
-    assertThat(cacheManager, is(instanceOf(PersistentCacheManager.class)));
-
-    cacheManager.init();
-
-    final Cache<Long, String> cache = cacheManager.getCache("simple-cache", Long.class, String.class);
-    assertThat(cache, is(not(nullValue())));
-
-    if (cacheManager.getStatus() != Status.UNINITIALIZED) {
-      cacheManager.close();
-    }
-  }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
@@ -16,11 +16,13 @@
 
 package org.ehcache.clustered.config;
 
+import org.ehcache.clustered.config.ClusteringServiceConfiguration.PoolDefinition;
 import org.ehcache.clustered.service.ClusteringService;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -34,24 +36,24 @@ public class ClusteringServiceConfigurationTest {
 
   @Test(expected = NullPointerException.class)
   public void testGetConnectionUrlNull() throws Exception {
-    new ClusteringServiceConfiguration(null);
+    new ClusteringServiceConfiguration(null, Collections.<String, PoolDefinition>emptyMap());
   }
 
   @Test
   public void testGetConnectionUrl() throws Exception {
     final URI connectionUrl = URI.create("http://localhost:9450");
-    assertThat(new ClusteringServiceConfiguration(connectionUrl).getConnectionUrl(), is(connectionUrl));
+    assertThat(new ClusteringServiceConfiguration(connectionUrl, Collections.<String, PoolDefinition>emptyMap()).getConnectionUrl(), is(connectionUrl));
   }
 
   @Test
   public void testGetServiceType() throws Exception {
-    assertThat(new ClusteringServiceConfiguration(URI.create("http://localhost:9450")).getServiceType(),
+    assertThat(new ClusteringServiceConfiguration(URI.create("http://localhost:9450"), Collections.<String, PoolDefinition>emptyMap()).getServiceType(),
         is(equalTo(ClusteringService.class)));
   }
 
   @Test
   public void testBuilder() throws Exception {
-    assertThat(new ClusteringServiceConfiguration(URI.create("http://localhost:9450"))
+    assertThat(new ClusteringServiceConfiguration(URI.create("http://localhost:9450"), Collections.<String, PoolDefinition>emptyMap())
         .builder(CacheManagerBuilder.newCacheManagerBuilder()), is(instanceOf(CacheManagerBuilder.class)));
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
@@ -17,7 +17,8 @@
 package org.ehcache.clustered.docs;
 
 import org.ehcache.PersistentCacheManager;
-import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.client.UnitTestConnectionService;
+import org.ehcache.clustered.config.builder.ClusteringServiceConfigurationBuilder;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
@@ -25,8 +26,9 @@ import org.ehcache.config.units.EntryUnit;
 import org.junit.Test;
 
 import java.net.URI;
-import org.ehcache.clustered.client.UnitTestConnectionService;
+
 import org.junit.Before;
+import org.terracotta.offheapstore.util.MemoryUnit;
 
 /**
  * Samples demonstrating use of a clustered cache.
@@ -47,7 +49,7 @@ public class GettingStarted {
     // tag::clusteredCacheManagerExample
     final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder =
         CacheManagerBuilder.newCacheManagerBuilder()
-            .with(new ClusteringServiceConfiguration(URI.create("http://example.com:9540/my-application?auto-create")))
+            .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/my-application?auto-create")).build())
             .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
                     .heap(10, EntryUnit.ENTRIES))
@@ -56,5 +58,25 @@ public class GettingStarted {
 
     cacheManager.close();
     // end::clusteredCacheManagerExample
+  }
+
+  @Test
+  public void clusteredCacheManagerWithServerSideConfigExample() throws Exception {
+    // tag::clusteredCacheManagerWithServerSideConfigExample
+    final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder =
+        CacheManagerBuilder.newCacheManagerBuilder()
+                .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/my-application?auto-create"))
+                        .defaultResource("primary-server-resource")
+                        .resourcePool("resource-pool-a", 128, MemoryUnit.GIGABYTES)
+                        .resourcePool("resource-pool-b", 128, MemoryUnit.GIGABYTES, "secondary-server-resource")
+                        .build())
+                .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+                .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
+                    .heap(10, EntryUnit.ENTRIES))
+                .build());
+    final PersistentCacheManager cacheManager = clusteredCacheManagerBuilder.build(true);
+
+    cacheManager.close();
+    // end::clusteredCacheManagerWithServerSideConfigExample
   }
 }

--- a/clustered/client/src/test/resources/configs/resource-sample.xml
+++ b/clustered/client/src/test/resources/configs/resource-sample.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<eh:config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns:tc='http://www.ehcache.org/v3/clustered'
+  xmlns:eh='http://www.ehcache.org/v3'
+  xsi:schemaLocation='http://www.ehcache.org/v3/clustered file:/Users/cdennis/src/ehcache3/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+   http://www.ehcache.org/v3/clustered-ee file:/Users/cdennis/src/ehcache3/clustered/client/src/main/resources/ehcache-clustered-ee-ext.xsd
+   http://www.ehcache.org/v3 file:/Users/cdennis/src/ehcache3/xml/src/main/resources/ehcache-core.xsd'>
+
+  <eh:service>
+    <tc:cluster>
+      <tc:connection url="http://example.com:9510/myCacheManager?auto-create"/>
+      <tc:server-side-config>
+        <tc:default-resource from="primary"/>
+        <tc:shared-pool name="primary-shared-pool" unit="gb">128</tc:shared-pool>
+        <tc:shared-pool name="secondary-shared-pool" from="secondary" unit="gb">128</tc:shared-pool>
+      </tc:server-side-config>
+    </tc:cluster>
+  </eh:service>
+
+  <eh:cache alias="fixed-size">
+    <eh:resources>
+      <eh:heap unit="mb">64</eh:heap>
+      <eh:offheap unit="mb">512</eh:offheap>
+      <tc:cluster-fixed unit="gb">128</tc:cluster-fixed>
+    </eh:resources>
+  </eh:cache>
+
+  <eh:cache alias="fixed-size-2">
+    <eh:resources>
+      <eh:heap unit="mb">64</eh:heap>
+      <eh:offheap unit="mb">512</eh:offheap>
+      <tc:cluster-fixed unit="gb" from="secondary">128</tc:cluster-fixed>
+    </eh:resources>
+  </eh:cache>
+
+  <eh:cache alias="sharing">
+    <eh:resources>
+      <eh:heap unit="mb">64</eh:heap>
+      <eh:offheap unit="mb">512</eh:offheap>
+      <tc:cluster-shared sharing="primary-shared-pool" />
+    </eh:resources>
+  </eh:cache>
+
+  <eh:cache alias="sharing-2">
+    <eh:resources>
+      <eh:heap unit="mb">64</eh:heap>
+      <eh:offheap unit="mb">512</eh:offheap>
+      <tc:cluster-shared sharing="secondary-shared-pool"/>
+    </eh:resources>
+  </eh:cache>
+</eh:config>

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/PassThroughEhcacheIntegrationTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/PassThroughEhcacheIntegrationTest.java
@@ -23,6 +23,7 @@ import org.ehcache.Maintainable;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.clustered.client.EhcacheClientEntity;
 import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.config.builder.ClusteringServiceConfigurationBuilder;
 import org.ehcache.exceptions.StateTransitionException;
 import org.ehcache.xml.XmlConfiguration;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class PassThroughEhcacheIntegrationTest {
     UnitTestConnectionService.reset();
     assertEntityNotExists(EhcacheClientEntity.class, "myCacheManager");
     PersistentCacheManager manager = newCacheManagerBuilder()
-            .with(new ClusteringServiceConfiguration(URI.create("http://example.com:9540/myCacheManager?auto-create")))
+            .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/myCacheManager?auto-create")).build())
             .build();
     assertEntityNotExists(EhcacheClientEntity.class, "myCacheManager");
     manager.init();
@@ -75,7 +76,7 @@ public class PassThroughEhcacheIntegrationTest {
     UnitTestConnectionService.reset();
     try {
       newCacheManagerBuilder()
-              .with(new ClusteringServiceConfiguration(URI.create("http://example.com:9540/myCacheManager")))
+              .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/myCacheManager")).build())
               .build(true);
       fail("Expected StateTransitionException");
     } catch (StateTransitionException e) {
@@ -87,7 +88,7 @@ public class PassThroughEhcacheIntegrationTest {
   public void testCacheManagerCreatedUsingMaintenance() throws Exception {
     UnitTestConnectionService.reset();
     PersistentCacheManager manager = newCacheManagerBuilder()
-            .with(new ClusteringServiceConfiguration(URI.create("http://example.com:9540/myCacheManager")))
+            .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/myCacheManager")).build())
             .build(false);
     Maintainable m = manager.toMaintenance();
     try {

--- a/xml/build.gradle
+++ b/xml/build.gradle
@@ -22,9 +22,9 @@ apply plugin: EhDeploy
 
 dependencies {
   compile project(':api'), project(':core'), project(':impl')
-  jaxb 'com.sun.xml.bind:jaxb-xjc:2.2.7-b41'
-  jaxb 'com.sun.xml.bind:jaxb-impl:2.2.7-b41'
-  jaxb 'javax.xml.bind:jaxb-api:2.2.7'
+  jaxb 'com.sun.xml.bind:jaxb-xjc:2.1.17'
+  jaxb 'com.sun.xml.bind:jaxb-impl:2.1.17'
+  jaxb 'javax.xml:jaxb-api:2.1'
 }
 
 def generatedSources = "src/generated/java"

--- a/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
@@ -122,6 +122,7 @@ class ConfigurationParser {
     factory.setNamespaceAware(true);
     factory.setIgnoringComments(true);
     factory.setIgnoringElementContentWhitespace(true);
+    factory.setXIncludeAware(true);
     factory.setSchema(XSD_SCHEMA_FACTORY.newSchema(schemaSources.toArray(new Source[schemaSources.size()])));
 
     final DocumentBuilder domBuilder;

--- a/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
@@ -183,7 +183,7 @@ public class XmlConfiguration implements Configuration {
     final ArrayList<ServiceCreationConfiguration<?>> serviceConfigs = new ArrayList<ServiceCreationConfiguration<?>>();
 
     for (ServiceType serviceType : configurationParser.getServiceElements()) {
-      final ServiceCreationConfiguration<?> serviceConfiguration = configurationParser.parseExtension((Element)serviceType.getAny());
+      final ServiceCreationConfiguration<?> serviceConfiguration = configurationParser.parseExtension(serviceType.getServiceCreationConfiguration());
         serviceConfigs.add(serviceConfiguration);
     }
 

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -16,6 +16,7 @@
   -->
 
 <xs:schema version="1.0" xmlns:ehcache="http://www.ehcache.org/v3" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.0"
            elementFormDefault="qualified" targetNamespace="http://www.ehcache.org/v3">
   <xs:element name="config" type="ehcache:config-type"/>
 
@@ -110,10 +111,17 @@
   </xs:complexType>
 
   <xs:complexType name="service-type">
-    <xs:choice>
-      <xs:any namespace="##other" minOccurs="0" maxOccurs="1"/>
-    </xs:choice>
+    <xs:sequence>
+      <xs:element ref="ehcache:service-creation-configuration" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
   </xs:complexType>
+  <xs:element name="service-creation-configuration" abstract="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:dom/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
 
   <xs:complexType name="persistence-type">
     <xs:attribute name="directory" type="xs:string" use="required"/>
@@ -260,10 +268,10 @@
         </xs:annotation>
       </xs:element>
       <xs:choice minOccurs="0" maxOccurs="1">
-        <xs:element name="heap" type="ehcache:resource-type" minOccurs="1" maxOccurs="1">
+        <xs:element ref="ehcache:heap" minOccurs="1" maxOccurs="1">
           <xs:annotation>
             <xs:documentation xml:lang="en">
-              Shortcut for configuring a heap-only Cache.
+              Shortcut for configuring a heap Cache.
             </xs:documentation>
           </xs:annotation>
         </xs:element>
@@ -289,9 +297,16 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="ehcache:service-configuration" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
+  <xs:element name="service-configuration" abstract="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:dom/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
 
   <xs:complexType name="listeners-type">
     <xs:sequence>
@@ -328,7 +343,6 @@
                 </xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -478,12 +492,39 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:element name="resource" abstract="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:dom/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="heap" type="ehcache:resource-type" substitutionGroup="ehcache:resource">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:class/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="offheap" type="ehcache:memory-type" substitutionGroup="ehcache:resource">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:class/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="disk" type="ehcache:persistable-memory-type" substitutionGroup="ehcache:resource">
+    <xs:annotation>
+      <xs:appinfo>
+        <jaxb:class/>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+
   <xs:complexType name="resources-type">
     <xs:sequence>
-      <xs:element name="heap" type="ehcache:resource-type" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="offheap" type="ehcache:memory-type" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="disk" type="ehcache:persistable-memory-type" minOccurs="0" maxOccurs="1"/>
-      <xs:any namespace="##other" minOccurs="0"/>
+      <xs:element ref="ehcache:resource" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/xml/src/test/java/org/ehcache/xml/FancyParser.java
+++ b/xml/src/test/java/org/ehcache/xml/FancyParser.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.xml;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+/**
+ *
+ * @author cdennis
+ */
+public class FancyParser implements CacheServiceConfigurationParser<Service> {
+
+  private static final URI NAMESPACE = URI.create("http://www.example.com/fancy");
+  private static final URL XML_SCHEMA = FooParser.class.getResource("/configs/fancy.xsd");
+
+  @Override
+  public Source getXmlSchema() throws IOException {
+    return new StreamSource(XML_SCHEMA.openStream());
+  }
+
+  @Override
+  public ServiceConfiguration<Service> parseServiceConfiguration(Element fragment) {
+    return new FooConfiguration();
+  }
+
+  @Override
+  public URI getNamespace() {
+    return NAMESPACE;
+  }
+
+}

--- a/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
@@ -638,6 +638,15 @@ public class XmlConfigurationTest {
     assertEquals(sizeOfEngineConfig1.getMaxObjectSize(), 200000);
   }
 
+  @Test
+  public void testCustomResource() throws Exception {
+    try {
+      new XmlConfiguration(XmlConfigurationTest.class.getResource("/configs/custom-resource.xml"));
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("Can't find parser for resource: [fancy:fancy: null]"));
+    }
+  }
+
   private void checkListenerConfigurationExists(Collection<?> configuration) {
     int count = 0;
     for (Object o : configuration) {

--- a/xml/src/test/resources/META-INF/services/org.ehcache.xml.CacheServiceConfigurationParser
+++ b/xml/src/test/resources/META-INF/services/org.ehcache.xml.CacheServiceConfigurationParser
@@ -1,1 +1,2 @@
 org.ehcache.xml.FooParser
+org.ehcache.xml.FancyParser

--- a/xml/src/test/resources/configs/bar.xsd
+++ b/xml/src/test/resources/configs/bar.xsd
@@ -18,7 +18,9 @@
 
 <xs:schema version="1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:eh="http://www.ehcache.org/v3"
            elementFormDefault="qualified"
            targetNamespace="http://www.example.com/bar">
- <xs:element name="bar"/>
+  <xs:import namespace="http://www.ehcache.org/v3"/>
+  <xs:element name="bar" substitutionGroup="eh:service-creation-configuration"/>
 </xs:schema>

--- a/xml/src/test/resources/configs/custom-resource.xml
+++ b/xml/src/test/resources/configs/custom-resource.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <!--
   ~ Copyright Terracotta, Inc.
   ~
@@ -15,12 +14,17 @@
   ~ limitations under the License.
   -->
 
-
-<xs:schema version="1.0"
-           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:eh="http://www.ehcache.org/v3"
-           elementFormDefault="qualified"
-           targetNamespace="http://www.example.com/foo">
-  <xs:import namespace="http://www.ehcache.org/v3"/>
-  <xs:element name="foo" substitutionGroup="eh:service-configuration"/>
-</xs:schema>
+<ehcache:config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns:fancy='http://www.example.com/fancy'
+  xmlns:ehcache='http://www.ehcache.org/v3'
+  xsi:schemaLocation="http://www.example.com/fancy fancy.xsd
+                     http://www.ehcache.org/v3 ../../../main/resources/ehcache-core.xsd">
+  <ehcache:cache alias="fancy">
+    <ehcache:key-type>java.lang.String</ehcache:key-type>
+    <ehcache:value-type>java.lang.String</ehcache:value-type>
+    <ehcache:resources>
+      <fancy:fancy/>
+    </ehcache:resources>
+  </ehcache:cache>
+</ehcache:config>

--- a/xml/src/test/resources/configs/fancy.xsd
+++ b/xml/src/test/resources/configs/fancy.xsd
@@ -16,25 +16,10 @@
   -->
 
 <xs:schema version="1.0"
-           xmlns:tx="http://www.ehcache.org/v3/tx"
-           xmlns:eh="http://www.ehcache.org/v3"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:eh="http://www.ehcache.org/v3"
            elementFormDefault="qualified"
-           targetNamespace="http://www.ehcache.org/v3/tx">
+           targetNamespace="http://www.example.com/fancy">
   <xs:import namespace="http://www.ehcache.org/v3"/>
-
-  <xs:element name="xa-store-provider" substitutionGroup="eh:service-creation-configuration"/>
-
-  <xs:element name="xa-store" type="tx:xa-store-config-type" substitutionGroup="eh:service-configuration"/>
-
-  <xs:element name="jta-tm" type="tx:jta-tm-type" substitutionGroup="eh:service-creation-configuration"/>
-
-  <xs:complexType name="xa-store-config-type">
-    <xs:attribute name="unique-XAResource-id" type="xs:string" use="required"/>
-  </xs:complexType>
-
-  <xs:complexType name="jta-tm-type">
-    <xs:attribute name="transaction-manager-provider-class" type="xs:string" use="required"/>
-  </xs:complexType>
-
+  <xs:element name="fancy" substitutionGroup="eh:resource"/>
 </xs:schema>


### PR DESCRIPTION
This is a first cut at XML based resource configuration for clustered caches.  What's here isn't necessarily ready for merging, but it's indicative of where I am headed.  Also included in here is a slight rework of how we do extensibility in core xsd.  It's a little more strictly typed, and I think things are a little cleaner as a result.