### PR TITLE
Issue #825: inline expiry

### DIFF
--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -18,13 +18,17 @@ package org.ehcache.internal.store;
 
 import org.ehcache.core.spi.cache.Store;
 import org.ehcache.exceptions.CacheAccessException;
+import org.ehcache.expiry.Duration;
+import org.ehcache.expiry.Expiry;
+import org.ehcache.internal.TestTimeSource;
 import org.ehcache.spi.test.After;
 import org.ehcache.spi.test.LegalSPITesterException;
 import org.ehcache.spi.test.SPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 
 /**
@@ -93,7 +97,7 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   @SPITest
-  public void valueHolderCanBeRetrievedWithEqualKey()
+  public void indicatesValuePutAndCanBeRetrievedWithEqualKey()
       throws IllegalAccessException, InstantiationException, CacheAccessException, LegalSPITesterException {
     kvStore = factory.newStore();
 
@@ -101,12 +105,13 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     V value = factory.createValue(1);
 
     try {
-      kvStore.put(key, value);
+      Store.PutStatus putStatus = kvStore.put(key, value);
+      assertThat(putStatus, is(Store.PutStatus.PUT));
     } catch (CacheAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
 
-    assertThat(kvStore.get(key), is(instanceOf(Store.ValueHolder.class)));
+    assertThat(kvStore.get(key), notNullValue());
   }
 
   @SPITest
@@ -148,6 +153,89 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
       throw new AssertionError("Expected ClassCastException because the value is of the wrong type");
     } catch (ClassCastException e) {
       // expected
+    } catch (CacheAccessException e) {
+      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
+    }
+  }
+
+  @SPITest
+  public void indicatesValueReplaced() throws LegalSPITesterException {
+    Store<K, V> store = factory.newStore();
+
+    K key = factory.createKey(42L);
+    V value = factory.createValue(42L);
+    V newValue = factory.createValue(256L);
+
+    try {
+      store.put(key, value);
+      Store.PutStatus putStatus = store.put(key, newValue);
+      assertThat(putStatus, is(Store.PutStatus.UPDATE));
+      assertThat(store.get(key), notNullValue());
+    } catch (CacheAccessException e) {
+      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
+    }
+  }
+
+  @SPITest
+  public void indicatesValueReplacedWhenUpdateExpires() throws LegalSPITesterException {
+    TestTimeSource timeSource = new TestTimeSource(1000L);
+    Store<K, V> store = factory.newStoreWithExpiry(new Expiry<K, V>() {
+      @Override
+      public Duration getExpiryForCreation(K key, V value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(K key, V value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(K key, V oldValue, V newValue) {
+        return Duration.ZERO;
+      }
+    }, timeSource);
+
+    K key = factory.createKey(42L);
+    V value = factory.createValue(42L);
+    V newValue = factory.createValue(256L);
+
+    try {
+      store.put(key, value);
+      Store.PutStatus putStatus = store.put(key, newValue);
+      assertThat(putStatus, is(Store.PutStatus.UPDATE));
+      assertThat(store.get(key), nullValue());
+    } catch (CacheAccessException e) {
+      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
+    }
+
+  }
+
+  @SPITest
+  public void indicatesOperationNoOp() throws LegalSPITesterException {
+    TestTimeSource timeSource = new TestTimeSource(1000L);
+    Store<K, V> store = factory.newStoreWithExpiry(new Expiry<K, V>() {
+      @Override
+      public Duration getExpiryForCreation(K key, V value) {
+        return Duration.ZERO;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(K key, V value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(K key, V oldValue, V newValue) {
+        return Duration.FOREVER;
+      }
+    }, timeSource);
+
+    K key = factory.createKey(42L);
+    try {
+      Store.PutStatus putStatus = store.put(key, factory.createValue(42L));
+      assertThat(putStatus, is(Store.PutStatus.NOOP));
+      assertThat(store.get(key), nullValue());
     } catch (CacheAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core/src/main/java/org/ehcache/core/spi/cache/Store.java
+++ b/core/src/main/java/org/ehcache/core/spi/cache/Store.java
@@ -372,7 +372,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
    *       }
    *       return newValue;
    *     }
-   *     return null;
+   *     return store.get(key);
    *   </PRE>
    * except that the action is performed atomically.
    * </P>

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -1033,7 +1033,9 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
             return null;
           } else if ((eq(existingValue, computedValue)) && (!replaceEqual.apply())) {
             if (mappedValue != null) {
-              return setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+              OnHeapValueHolder<V> holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+              write.set(holder == null);
+              return holder;
             }
           }
 
@@ -1052,7 +1054,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
           decrementCurrentUsageInBytesIfRequired(replacedOrRemovedValue.get().size());
         }
       } else if (write.get()) {
-        long delta = replacedOrRemovedValue.get() == null ? computeResult.size() : computeResult.size() - replacedOrRemovedValue.get().size();
+        long delta = replacedOrRemovedValue.get() == null ? computeResult.size() : (computeResult.size() - replacedOrRemovedValue.get().size());
         replaceByteCapacity(delta, eventSink);
       }
       storeEventDispatcher.releaseEventSink(eventSink);
@@ -1172,7 +1174,9 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
           }
 
           if ((eq(existingValue, computedValue)) && (!replaceEqual.apply())) {
-            return setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+            OnHeapValueHolder<V> holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+            write.set(holder == null);
+            return holder;
           }
 
           checkValue(computedValue);

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -294,10 +294,6 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
 
   @Override
   public PutStatus put(final K key, final V value) throws CacheAccessException {
-    return putReturnHolder(key, value);
-  }
-
-  private PutStatus putReturnHolder(final K key, final V value) throws CacheAccessException {
     putObserver.begin();
     checkKey(key);
     checkValue(value);
@@ -331,7 +327,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       if (entryActuallyAdded.get()) {
         enforceCapacity(valuePut.size(), eventSink);
       } else {
-        long replacedDelta = valuePut == null ? 0 : valuePut.size() - (replacedValue.get() == null ? 0 : replacedValue.get().size());
+        long replacedDelta = (valuePut == null ? 0 : valuePut.size()) - (replacedValue.get() == null ? 0 : replacedValue.get().size());
         replaceByteCapacity(replacedDelta, eventSink);
       }
 
@@ -1368,7 +1364,8 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
     }
     if (Duration.ZERO.equals(duration)) {
-      eventSink.removed(key, oldValue);
+      eventSink.updated(key, oldValue, newValue);
+      eventSink.expired(key, newValue);
       return null;
     }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -278,11 +278,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       if (updateAccess) {
         setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, mapping, now);
       }
-      if (mapping != null) {
-        getObserver.end(StoreOperationOutcomes.GetOutcome.HIT);
-      } else {
-        getObserver.end(StoreOperationOutcomes.GetOutcome.MISS);
-      }
+      getObserver.end(StoreOperationOutcomes.GetOutcome.HIT);
       return mapping;
     } catch (RuntimeException re) {
       handleRuntimeException(re);
@@ -779,10 +775,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
           return null;
         }
         // TODO find a way to increment hit count on a fault
-        if (setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, cachedValue, now) == null) {
-          getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.MISS);
-          return null;
-        }
+        setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, cachedValue, now);
       }
 
       getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.HIT);
@@ -1306,10 +1299,13 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       duration = expiry.getExpiryForAccess(key, valueHolder.value());
     } catch (RuntimeException re) {
       LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+      duration = Duration.ZERO;
+    }
+    valueHolder.accessed(now, duration);
+    if (Duration.ZERO.equals(duration)) {
       expireMapping(key, valueHolder);
       return null;
     }
-    valueHolder.accessed(now, duration);
     return valueHolder;
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -397,7 +397,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
     return putIfAbsent(key, value, false);
   }
 
-  private OnHeapValueHolder<V> putIfAbsent(final K key, final V value, boolean returnInCacheHolder) throws CacheAccessException {
+  private OnHeapValueHolder<V> putIfAbsent(final K key, final V value, boolean returnCurrentMapping) throws CacheAccessException {
     putIfAbsentObserver.begin();
     checkKey(key);
     checkValue(value);
@@ -428,6 +428,8 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
 
       if (entryActuallyAdded.get()) {
         enforceCapacity(inCache.size(), eventSink);
+      } else if (inCache == null && returnValue.get() != null) {
+        decrementCurrentUsageInBytesIfRequired(returnValue.get().size());
       }
 
       storeEventDispatcher.releaseEventSink(eventSink);
@@ -438,7 +440,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
         putIfAbsentObserver.end(StoreOperationOutcomes.PutIfAbsentOutcome.HIT);
       }
 
-      if (returnInCacheHolder) {
+      if (returnCurrentMapping) {
         return inCache;
       }
     } catch (RuntimeException re) {
@@ -1095,6 +1097,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       final long now = timeSource.getTimeMillis();
 
       final AtomicBoolean write = new AtomicBoolean(false);
+      final AtomicReference<OnHeapValueHolder<V>> previousValue = new AtomicReference<OnHeapValueHolder<V>>();
       OnHeapValueHolder<V> computeResult = map.compute(key, new BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>>() {
         @Override
         public OnHeapValueHolder<V> apply(K mappedKey, OnHeapValueHolder<V> mappedValue) {
@@ -1111,15 +1114,20 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
             checkValue(computedValue);
             return newCreateValueHolder(key, computedValue, now, eventSink);
           } else {
+            previousValue.set(mappedValue);
             return setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
           }
         }
       });
+      OnHeapValueHolder<V> previousValueHolder = previousValue.get();
       if (write.get()) {
         if (computeResult != null) {
           enforceCapacity(computeResult.size(), eventSink);
         }
+      } else if (computeResult == null && previousValueHolder != null) {
+        decrementCurrentUsageInBytesIfRequired(previousValueHolder.size());
       }
+
       storeEventDispatcher.releaseEventSink(eventSink);
       if (write.get()) {
         if (computeResult != null) {
@@ -1129,6 +1137,10 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
         }
       } else {
         computeIfAbsentObserver.end(StoreOperationOutcomes.ComputeIfAbsentOutcome.HIT);
+      }
+      if (computeResult == null && previousValueHolder != null) {
+        // There was a value - it expired on access
+        return previousValueHolder;
       }
       return computeResult;
     } catch (RuntimeException re) {
@@ -1307,15 +1319,17 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
 
   private OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
                                                                        StoreEventSink<K, V> eventSink) {
-    Duration duration;
+    Duration duration = Duration.ZERO;
     try {
       duration = expiry.getExpiryForAccess(key, valueHolder.value());
     } catch (RuntimeException re) {
       LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+    }
+    valueHolder.accessed(now, duration);
+    if (Duration.ZERO.equals(duration)) {
       onExpiration(key, valueHolder, eventSink);
       return null;
     }
-    valueHolder.accessed(now, duration);
     return valueHolder;
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -712,20 +712,11 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
             final ValueHolder<V> value = fault.get();
             final OnHeapValueHolder<V> newValue;
             if(value != null) {
-              try {
-                newValue = importValueFromLowerTier(key, value, now);
-              } catch (RuntimeException re) {
-                LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
-                invalidateInGetorComputeIfAbsent(backEnd, key, value, fault, now);
-                getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.FAULT_FAILED);
-                return null;
-              } catch (LimitExceededException e) {
-                LOG.warn(e.getMessage());
-                OnHeapValueHolder<V> toReturn = invalidateInGetorComputeIfAbsent(backEnd, key, value, fault, now);
-                getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.FAULT_FAILED);
-                return toReturn;
+              newValue = importValueFromLowerTier(key, value, now, backEnd, fault);
+              if (newValue == null) {
+                // Inline expiry or sizing failure
+                return value;
               }
-
             } else {
               backEnd.remove(key, fault);
               getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.MISS);
@@ -784,24 +775,21 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
     }
   }
 
-  private OnHeapValueHolder<V> invalidateInGetorComputeIfAbsent(Backend<K, V> map, final K key, final ValueHolder<V> value, final Fault<V> fault, final long now) {
-    final AtomicReference<OnHeapValueHolder<V>> toInvalidate = new AtomicReference<OnHeapValueHolder<V>>();
+  private void invalidateInGetOrComputeIfAbsent(Backend<K, V> map, final K key, final ValueHolder<V> value, final Fault<V> fault, final long now, final Duration expiration) {
     map.computeIfPresent(key, new BiFunction<K, OnHeapValueHolder<V>, OnHeapValueHolder<V>>() {
       @Override
       public OnHeapValueHolder<V> apply(K mappedKey, final OnHeapValueHolder<V> mappedValue) {
         if(mappedValue.equals(fault)) {
           try {
-            toInvalidate.set(cloneValueHolder(key, value, now, Duration.ZERO, false));
+            invalidationListener.onInvalidation(key, cloneValueHolder(key, value, now, expiration, false));
           } catch (LimitExceededException ex) {
             throw new AssertionError("Sizing is not expected to happen.");
           }
-          invalidationListener.onInvalidation(key, toInvalidate.get());
           return null;
         }
         return mappedValue;
       }
     });
-    return toInvalidate.get();
   }
 
   @Override
@@ -1433,10 +1421,29 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
     return holder;
   }
 
-  private OnHeapValueHolder<V> importValueFromLowerTier(K key, ValueHolder<V> valueHolder, long now) throws LimitExceededException {
+  private OnHeapValueHolder<V> importValueFromLowerTier(K key, ValueHolder<V> valueHolder, long now, Backend<K, V> backEnd, Fault<V> fault) {
     V realValue = valueHolder.value();
-    Duration expiration = expiry.getExpiryForAccess(key, realValue);
-    return cloneValueHolder(key, valueHolder, now, expiration, true);
+    Duration expiration = Duration.ZERO;
+    try {
+      expiration = expiry.getExpiryForAccess(key, realValue);
+    } catch (RuntimeException re) {
+      LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+    }
+
+    if (Duration.ZERO.equals(expiration)) {
+      invalidateInGetOrComputeIfAbsent(backEnd, key, valueHolder, fault, now, Duration.ZERO);
+      getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.FAULT_FAILED);
+      return null;
+    }
+
+    try{
+      return cloneValueHolder(key, valueHolder, now, expiration, true);
+    } catch (LimitExceededException e) {
+      LOG.warn(e.getMessage());
+      invalidateInGetOrComputeIfAbsent(backEnd, key, valueHolder, fault, now, expiration);
+      getOrComputeIfAbsentObserver.end(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.FAULT_FAILED);
+      return null;
+    }
   }
 
   private OnHeapValueHolder<V> cloneValueHolder(K key, ValueHolder<V> valueHolder, long now, Duration expiration, boolean sizingEnabled) throws LimitExceededException {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/BaseOnHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/BaseOnHeapStoreTest.java
@@ -870,6 +870,7 @@ public abstract class BaseOnHeapStoreTest {
     });
 
     store.put("key", "value");
+    assertThat(store.get("key").value(), is("value"));
     assertNull(store.get("key"));
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/BaseOnHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/BaseOnHeapStoreTest.java
@@ -849,8 +849,9 @@ public abstract class BaseOnHeapStoreTest {
   }
 
   @Test
-  public void testExpiryAccessException() throws Exception {
+  public void testExpiryAccessExceptionReturnsValueAndExpiresIt() throws Exception {
     TestTimeSource timeSource = new TestTimeSource();
+    timeSource.advanceTime(5);
     OnHeapStore<String, String> store = newStore(timeSource, new Expiry<String, String>() {
 
       @Override
@@ -870,7 +871,7 @@ public abstract class BaseOnHeapStoreTest {
     });
 
     store.put("key", "value");
-    assertThat(store.get("key").value(), is("value"));
+    assertThat(store.get("key"), valueHeld("value"));
     assertNull(store.get("key"));
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
@@ -355,6 +355,38 @@ public class ByteAccountingTest {
   }
 
   @Test
+  public void testComputeIfAbsentExpiryOnAccess() throws CacheAccessException {
+    TestTimeSource timeSource = new TestTimeSource(100L);
+    OnHeapStoreForTests<String, String> store = newStore(timeSource, new Expiry<String, String>() {
+      @Override
+      public Duration getExpiryForCreation(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(String key, String value) {
+        return Duration.ZERO;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(String key, String oldValue, String newValue) {
+        return Duration.FOREVER;
+      }
+    });
+
+    store.put(KEY, VALUE);
+    store.computeIfAbsent(KEY, new Function<String, String>() {
+      @Override
+      public String apply(String s) {
+        fail("should not be called");
+        return s;
+      }
+    });
+
+    assertThat(store.getCurrentUsageInBytes(), is(0L));
+  }
+
+  @Test
   public void testComputeIfPresentRemove() throws CacheAccessException {
     OnHeapStoreForTests<String, String> store = newStore();
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
@@ -19,6 +19,7 @@ import org.ehcache.config.Eviction;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.spi.function.NullaryFunction;
 import org.ehcache.event.EventType;
 import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.exceptions.CacheAccessException;
@@ -329,6 +330,73 @@ public class ByteAccountingTest {
   }
 
   @Test
+  public void testComputeExpiryOnAccess() throws CacheAccessException {
+    TestTimeSource timeSource = new TestTimeSource(100L);
+    OnHeapStoreForTests<String, String> store = newStore(timeSource, new Expiry<String, String>() {
+      @Override
+      public Duration getExpiryForCreation(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(String key, String value) {
+        return Duration.ZERO;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(String key, String oldValue, String newValue) {
+        return Duration.FOREVER;
+      }
+    });
+
+    store.put(KEY, VALUE);
+    store.compute(KEY, new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        return s2;
+      }
+    }, new NullaryFunction<Boolean>() {
+      @Override
+      public Boolean apply() {
+        return false;
+      }
+    });
+
+    assertThat(store.getCurrentUsageInBytes(), is(0L));
+  }
+
+  @Test
+  public void testComputeExpiryOnUpdate() throws CacheAccessException {
+    TestTimeSource timeSource = new TestTimeSource(100L);
+    OnHeapStoreForTests<String, String> store = newStore(timeSource, new Expiry<String, String>() {
+      @Override
+      public Duration getExpiryForCreation(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(String key, String oldValue, String newValue) {
+        return Duration.ZERO;
+      }
+    });
+
+    store.put(KEY, VALUE);
+    store.compute(KEY, new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        return s2;
+      }
+    });
+
+    assertThat(store.getCurrentUsageInBytes(), is(0L));
+  }
+
+  @Test
   public void testComputeIfAbsent() throws CacheAccessException {
     OnHeapStoreForTests<String, String> store = newStore();
 
@@ -453,6 +521,73 @@ public class ByteAccountingTest {
 
     assertThat(store.getCurrentUsageInBytes(), is(SIZE_OF_KEY_VALUE_PAIR + delta));
 
+  }
+
+  @Test
+  public void testComputeIfPresentExpiryOnAccess() throws CacheAccessException {
+    TestTimeSource timeSource = new TestTimeSource(100L);
+    OnHeapStoreForTests<String, String> store = newStore(timeSource, new Expiry<String, String>() {
+      @Override
+      public Duration getExpiryForCreation(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(String key, String value) {
+        return Duration.ZERO;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(String key, String oldValue, String newValue) {
+        return Duration.FOREVER;
+      }
+    });
+
+    store.put(KEY, VALUE);
+    store.computeIfPresent(KEY, new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        return s2;
+      }
+    }, new NullaryFunction<Boolean>() {
+      @Override
+      public Boolean apply() {
+        return false;
+      }
+    });
+
+    assertThat(store.getCurrentUsageInBytes(), is(0L));
+  }
+
+  @Test
+  public void testComputeIfPresentExpiryOnUpdate() throws CacheAccessException {
+    TestTimeSource timeSource = new TestTimeSource(100L);
+    OnHeapStoreForTests<String, String> store = newStore(timeSource, new Expiry<String, String>() {
+      @Override
+      public Duration getExpiryForCreation(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForAccess(String key, String value) {
+        return Duration.FOREVER;
+      }
+
+      @Override
+      public Duration getExpiryForUpdate(String key, String oldValue, String newValue) {
+        return Duration.ZERO;
+      }
+    });
+
+    store.put(KEY, VALUE);
+    store.computeIfPresent(KEY, new BiFunction<String, String, String>() {
+      @Override
+      public String apply(String s, String s2) {
+        return s2;
+      }
+    });
+
+    assertThat(store.getCurrentUsageInBytes(), is(0L));
   }
 
   @Test

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
@@ -1297,7 +1297,11 @@ public class XAStoreTest {
 
     testTimeSource.advanceTime(1000);
     testTransactionManager.begin();
-    assertThat(xaStore.get(1L), is(nullValue()));
+    assertThat(xaStore.get(1L).value(), is("one"));
+    testTransactionManager.commit();
+
+    testTransactionManager.begin();
+    assertThat(xaStore.get(1L), nullValue());
     testTransactionManager.commit();
   }
 


### PR DESCRIPTION
This PR takes care of the inline expiry in `OnHeapStore`. It also fixes a number of issues with byte size accounting (see #823).

`AbstractOffHeapStore` will be handled in a future PR, as well as more general `Store` tests on this.