### PR TITLE
Issue #798 Add underlying Provider discovery to XAStore.Provider

### DIFF
--- a/impl/src/main/java/org/ehcache/impl/internal/store/DefaultStoreProvider.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/DefaultStoreProvider.java
@@ -104,9 +104,7 @@ public class DefaultStoreProvider implements Store.Provider {
       enhancedServiceConfigs.add(new CacheStoreServiceConfiguration().cachingTierProvider(OnHeapStore.Provider.class)
           .authoritativeTierProvider(OffHeapStore.Provider.class));
     } else {
-      // TODO: Remove once XAStore has proper underlying Store.Provider selection support
-      // default to on-heap cache
-      provider = serviceProvider.getService(OnHeapStore.Provider.class);
+      throw new IllegalStateException("DefaultStoreProvider does not support heap-only stores");
     }
 
     Store<K, V> store = provider.createStore(storeConfig, enhancedServiceConfigs.toArray(new ServiceConfiguration<?>[0]));


### PR DESCRIPTION
This commit changes the 'rank' and 'createStore' methods in XAStore.Provider
to use discover the proper Store.Provider to use for the underlying provider
instead of being tied to DefaultStoreProvider.

This commit **does not** close this issue.