### PR TITLE
Issue #833 Create clustered store in support of clustered cache

### DIFF
--- a/107/src/test/java/org/ehcache/ParsesConfigurationExtensionTest.java
+++ b/107/src/test/java/org/ehcache/ParsesConfigurationExtensionTest.java
@@ -19,6 +19,8 @@ package org.ehcache;
 import com.pany.domain.Customer;
 import com.pany.domain.Product;
 import com.pany.ehcache.integration.ProductCacheLoaderWriter;
+
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.core.EhcacheManager;
@@ -80,7 +82,7 @@ public class ParsesConfigurationExtensionTest {
       // Test the config
       {
         final CacheRuntimeConfiguration<Long, Product> runtimeConfiguration = productCache.getRuntimeConfiguration();
-        assertThat(runtimeConfiguration.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(200L));
+        assertThat(((SizedResourcePool)runtimeConfiguration.getResourcePools().getPoolForResource(ResourceType.Core.HEAP)).getSize(), equalTo(200L));
 
         final Expiry<? super Long, ? super Product> expiry = runtimeConfiguration.getExpiry();
         assertThat(expiry.getClass().getName(), equalTo("org.ehcache.expiry.Expirations$TimeToIdleExpiry"));
@@ -126,7 +128,7 @@ public class ParsesConfigurationExtensionTest {
     {
       final Cache<Long, Customer> customerCache = cacheManager.getCache("customerCache", Long.class, Customer.class);
       final CacheRuntimeConfiguration<Long, Customer> runtimeConfiguration = customerCache.getRuntimeConfiguration();
-      assertThat(runtimeConfiguration.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(200L));
+      assertThat(((SizedResourcePool)runtimeConfiguration.getResourcePools().getPoolForResource(ResourceType.Core.HEAP)).getSize(), equalTo(200L));
     }
   }
 }

--- a/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
+++ b/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
@@ -17,6 +17,7 @@
 package org.ehcache.docs;
 
 import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.config.ResourceType;
@@ -158,7 +159,7 @@ public class EhCache107ConfigurationIntegrationDocTest {
 
     CacheRuntimeConfiguration<Long, String> ehcacheConfig = (CacheRuntimeConfiguration<Long, String>)anyCache.getConfiguration(
         Eh107Configuration.class).unwrap(CacheRuntimeConfiguration.class); // <3>
-    ehcacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(); // <4>
+    ((SizedResourcePool)ehcacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP)).getSize(); // <4>
 
     Cache<Long, String> anotherCache = manager.createCache("byRefCache", mutableConfiguration);
     assertFalse(anotherCache.getConfiguration(Configuration.class).isStoreByValue()); // <5>
@@ -182,7 +183,7 @@ public class EhCache107ConfigurationIntegrationDocTest {
       // Expected
     }
     // end::jsr107SupplementWithTemplatesExample[]
-    assertThat(ehcacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), is(20L));
+    assertThat(((SizedResourcePool)ehcacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP)).getSize(), is(20L));
     assertThat(foosEhcacheConfig.getExpiry().getExpiryForCreation(42L, "Answer!"),
         is(new org.ehcache.expiry.Duration(2, TimeUnit.MINUTES)));
   }

--- a/107/src/test/resources/ehcache-107-serializer.xml
+++ b/107/src/test/resources/ehcache-107-serializer.xml
@@ -15,7 +15,7 @@
     <value-type>java.lang.String</value-type>
     <resources>
       <heap unit="entries">20</heap>
-      <offheap unit="mb">1</offheap>
+      <offheap unit="MB">1</offheap>
     </resources>
   </cache>
 
@@ -24,7 +24,7 @@
     <value-type serializer = "org.ehcache.jsr107.StringSerializer">java.lang.String</value-type>
     <resources>
       <heap unit="entries">20</heap>
-      <offheap unit="mb">1</offheap>
+      <offheap unit="MB">1</offheap>
     </resources>
   </cache>
 </config>

--- a/107/src/test/resources/ehcache-107-stats.xml
+++ b/107/src/test/resources/ehcache-107-stats.xml
@@ -18,14 +18,14 @@
   <cache-template name="diskCache">
     <resources>
       <heap unit="entries">10</heap>
-      <disk unit="mb">10</disk>
+      <disk unit="MB">10</disk>
     </resources>
   </cache-template>
   
   <cache-template name="offheapCache">
     <resources>
       <heap unit="entries">10</heap>
-      <offheap unit="mb">10</offheap>
+      <offheap unit="MB">10</offheap>
     </resources>
   </cache-template>
 

--- a/api/src/main/java/org/ehcache/config/ResourcePool.java
+++ b/api/src/main/java/org/ehcache/config/ResourcePool.java
@@ -27,7 +27,7 @@ public interface ResourcePool {
    *
    * @return the type.
    */
-  ResourceType getType();
+  ResourceType<?> getType();
 
   /**
    * Whether the underlying resource is persistent.

--- a/api/src/main/java/org/ehcache/config/ResourcePool.java
+++ b/api/src/main/java/org/ehcache/config/ResourcePool.java
@@ -16,7 +16,9 @@
 package org.ehcache.config;
 
 /**
- * @author Ludovic Orban
+ * Specifies a resource providing space for cache operations.
+ * <p>
+ * {@code ResourcePool} implementations must be <i>immutable</i>.
  */
 public interface ResourcePool {
 
@@ -28,23 +30,19 @@ public interface ResourcePool {
   ResourceType getType();
 
   /**
-   * Get the value measuring the pool size.
+   * Whether the underlying resource is persistent.
    *
-   * @return the value.
-   */
-  long getSize();
-
-  /**
-   * Get the unit in which the resource is measured.
-   *
-   * @return the unit.
-   */
-  ResourceUnit getUnit();
-
-  /**
-   * Whether the underlying resource is persistent
    * @return <code>true</code>, if persistent
    */
   boolean isPersistent();
+
+  /**
+   * Validates whether or not a new {@code ResourcePool} can replace this {@code ResourcePool}.
+   *
+   * @param newPool the pool which is the candidate for replacing this {@code ResourcePool}
+   *
+   * @throws IllegalArgumentException if {@code newPool} is not a valid replacement for this {@code ResourcePool}
+   */
+  void validateUpdate(ResourcePool newPool);
 
 }

--- a/api/src/main/java/org/ehcache/config/ResourcePools.java
+++ b/api/src/main/java/org/ehcache/config/ResourcePools.java
@@ -30,14 +30,14 @@ public interface ResourcePools {
    * @param resourceType the type of resource the pool is tracking.
    * @return the {@link ResourcePool}, or null if there is no pool tracking the requested type.
    */
-  ResourcePool getPoolForResource(ResourceType resourceType);
+  <P extends ResourcePool> P getPoolForResource(ResourceType<P> resourceType);
 
   /**
    * Get the set of {@link ResourceType} of all the pools present in the ResourcePools
    *
    * @return the set of {@link ResourceType}
    */
-  Set<ResourceType> getResourceTypeSet();
+  Set<ResourceType<?>> getResourceTypeSet();
 
   /**
    * Get a copy of the current {@link ResourcePools} merged with another {@link ResourcePools} and validate that

--- a/api/src/main/java/org/ehcache/config/ResourceType.java
+++ b/api/src/main/java/org/ehcache/config/ResourceType.java
@@ -17,10 +17,15 @@ package org.ehcache.config;
 
 /**
  * The resource pools type interface.
- *
- * @author Ludovic Orban
  */
-public interface ResourceType {
+public interface ResourceType<T extends ResourcePool> {
+
+  /**
+   * Gets the primary {@link ResourcePool} type associated with this {@code ResourceType}.
+   *
+   * @return the {@code ResourcePool} type associated with this type
+   */
+  Class<T> getResourcePoolClass();
 
   /**
    * Whether the resource supports persistence.
@@ -37,7 +42,7 @@ public interface ResourceType {
   /**
    * An enumeration of resource types handled by core ehcache.
    */
-  enum Core implements ResourceType {
+  enum Core implements ResourceType<SizedResourcePool> {
     /**
      * Heap resource.
      */
@@ -58,6 +63,11 @@ public interface ResourceType {
     Core(boolean persistable, final boolean requiresSerialization) {
       this.persistable = persistable;
       this.requiresSerialization = requiresSerialization;
+    }
+
+    @Override
+    public Class<SizedResourcePool> getResourcePoolClass() {
+      return SizedResourcePool.class;
     }
 
     @Override

--- a/api/src/main/java/org/ehcache/config/SizedResourcePool.java
+++ b/api/src/main/java/org/ehcache/config/SizedResourcePool.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.config;
+
+/**
+ * Extends a {@link ResourcePool} to include resource size information.
+ */
+public interface SizedResourcePool extends ResourcePool {
+
+  /**
+   * Get the value measuring the pool size.
+   *
+   * @return the value.
+   */
+  long getSize();
+
+  /**
+   * Get the unit in which the resource is measured.
+   *
+   * @return the unit.
+   */
+  ResourceUnit getUnit();
+}

--- a/api/src/main/java/org/ehcache/spi/service/MaintainableService.java
+++ b/api/src/main/java/org/ehcache/spi/service/MaintainableService.java
@@ -21,6 +21,7 @@ import org.ehcache.spi.ServiceProvider;
 /**
  * Specific {@link Service} interface that indicates that the service participates in maintenance mode
  */
+@PluralService
 public interface MaintainableService extends Service {
   /**
    * Start this service for maintenance, based on its default configuration.

--- a/api/src/main/java/org/ehcache/spi/service/PersistableResourceService.java
+++ b/api/src/main/java/org/ehcache/spi/service/PersistableResourceService.java
@@ -35,7 +35,7 @@ public interface PersistableResourceService extends MaintainableService {
    * @param resourceType the resource type to handle
    * @return {@code true} if this service handles this resource type, {@code false} otherwise
    */
-  boolean handlesResourceType(ResourceType resourceType);
+  boolean handlesResourceType(ResourceType<?> resourceType);
 
   /**
    * Enables this service to create additional configurations to enable support of the passed in resource pool in the

--- a/api/src/main/java/org/ehcache/spi/service/PersistableResourceService.java
+++ b/api/src/main/java/org/ehcache/spi/service/PersistableResourceService.java
@@ -26,6 +26,7 @@ import java.util.Collection;
  * Specific interface for services that are dedicated to handling a {@link ResourceType} which is
  * {@link ResourceType#isPersistable() persistable}.
  */
+@PluralService
 public interface PersistableResourceService extends MaintainableService {
 
   /**

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourcePool.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourcePool.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config;
+
+import org.ehcache.config.ResourcePool;
+
+/**
+ * Defines a resource supported by a server-based resource.
+ */
+public interface ClusteredResourcePool extends ResourcePool {
+
+  @Override
+  ClusteredResourceType getType();
+
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourcePool.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourcePool.java
@@ -24,6 +24,6 @@ import org.ehcache.config.ResourcePool;
 public interface ClusteredResourcePool extends ResourcePool {
 
   @Override
-  ClusteredResourceType getType();
+  ClusteredResourceType<? extends ClusteredResourcePool> getType();
 
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourceType.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourceType.java
@@ -21,25 +21,56 @@ import org.ehcache.config.ResourceType;
 /**
  * Defines the clustered {@link ResourceType}.
  */
-public interface ClusteredResourceType extends ResourceType {
+public interface ClusteredResourceType<P extends ClusteredResourcePool> extends ResourceType<P> {
 
-  enum Types implements ClusteredResourceType {
-    SHARED,
-    FIXED;
+  final class Types {
 
-    @Override
-    public boolean isPersistable() {
-      return true;
-    }
+    /**
+     * Identifies the {@code cluster-fixed} {@link ResourceType}.
+     */
+    public static final ClusteredResourceType<FixedClusteredResourcePool> FIXED =
+        new BaseClusteredResourceType<FixedClusteredResourcePool>("FIXED", FixedClusteredResourcePool.class);
 
-    @Override
-    public boolean requiresSerialization() {
-      return true;
-    }
+    /**
+     * Identifies the {@code cluster-shared} {@link ResourceType}.
+     */
+    public static final ClusteredResourceType<SharedClusteredResourcePool> SHARED =
+        new BaseClusteredResourceType<SharedClusteredResourcePool>("SHARED", SharedClusteredResourcePool.class);
 
-    @Override
-    public String toString() {
-      return "clustered-" + this.name().toLowerCase();
+
+    /**
+     * The base on which {@link ClusteredResourceType} identifiers are built.
+     *
+     * @param <P> the {@link ClusteredResourcePool} type associated with this resource type
+     */
+    private static final class BaseClusteredResourceType<P extends ClusteredResourcePool> implements ClusteredResourceType<P> {
+      private final String name;
+      private final Class<P> resourcePoolClass;
+
+      private BaseClusteredResourceType(final String name, final Class<P> resourcePoolClass) {
+        this.name = name;
+        this.resourcePoolClass = resourcePoolClass;
+      }
+
+      @Override
+      public Class<P> getResourcePoolClass() {
+        return resourcePoolClass;
+      }
+
+      @Override
+      public boolean isPersistable() {
+        return true;
+      }
+
+      @Override
+      public boolean requiresSerialization() {
+        return true;
+      }
+
+      @Override
+      public String toString() {
+        return "clustered-" + this.name.toLowerCase();
+      }
     }
   }
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourceType.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteredResourceType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config;
+
+import org.ehcache.config.ResourceType;
+
+/**
+ * Defines the clustered {@link ResourceType}.
+ */
+public interface ClusteredResourceType extends ResourceType {
+
+  enum Types implements ClusteredResourceType {
+    SHARED,
+    FIXED;
+
+    @Override
+    public boolean isPersistable() {
+      return true;
+    }
+
+    @Override
+    public boolean requiresSerialization() {
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "clustered-" + this.name().toLowerCase();
+    }
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
@@ -21,9 +21,8 @@ import org.ehcache.PersistentCacheManager;
 import org.ehcache.clustered.service.ClusteringService;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.CacheManagerConfiguration;
+import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
-
-import org.terracotta.offheapstore.util.MemoryUnit;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -34,8 +33,6 @@ import static java.util.Collections.unmodifiableMap;
 
 /**
  * Specifies the configuration for a {@link ClusteringService}.
- *
- * @author Clifford W. Johnson
  */
 // TODO: Should this accept/hold a *list* of URIs?
 // TODO: Add validation for cluster URI(s)
@@ -109,9 +106,10 @@ public final class ClusteringServiceConfiguration
     return ClusteringService.class;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public CacheManagerBuilder<PersistentCacheManager> builder(final CacheManagerBuilder<? extends CacheManager> other) {
-    return (CacheManagerBuilder<PersistentCacheManager>) other.using(this);
+    return (CacheManagerBuilder<PersistentCacheManager>) other.using(this);   // unchecked
   }
 
   /**

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/ClusteringServiceConfiguration.java
@@ -35,7 +35,6 @@ import static java.util.Collections.unmodifiableMap;
  * Specifies the configuration for a {@link ClusteringService}.
  */
 // TODO: Should this accept/hold a *list* of URIs?
-// TODO: Add validation for cluster URI(s)
 public final class ClusteringServiceConfiguration
     implements ServiceCreationConfiguration<ClusteringService>,
     CacheManagerConfiguration<PersistentCacheManager> {

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/FixedClusteredResourcePool.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/FixedClusteredResourcePool.java
@@ -34,7 +34,8 @@ public interface FixedClusteredResourcePool extends ClusteredResourcePool, Sized
 
   /**
    * Identifies the server-side clustered resource from which space for this pool is reserved.
-   * If no server resource is identified, TODO: Identify the space source ...
+   * If no server resource is identified, the resource identified in the server configuration as
+   * the default is used.
    *
    * @return the server-side clustered resource id; may be {@code null}
    */

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/FixedClusteredResourcePool.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/FixedClusteredResourcePool.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config;
+
+import org.ehcache.config.SizedResourcePool;
+import org.ehcache.config.units.MemoryUnit;
+
+/**
+ * Specifies a {@link ClusteredResourcePool} reserving space from a server-based clustered resource.
+ * A {@code FixedClusteredResourcePool} uses dedicated space on the server.
+ */
+public interface FixedClusteredResourcePool extends ClusteredResourcePool, SizedResourcePool {
+
+  /**
+   * {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  MemoryUnit getUnit();
+
+  /**
+   * Identifies the server-side clustered resource from which space for this pool is reserved.
+   * If no server resource is identified, TODO: Identify the space source ...
+   *
+   * @return the server-side clustered resource id; may be {@code null}
+   */
+  String getFromResource();
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/SharedClusteredResourcePool.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/SharedClusteredResourcePool.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config;
+
+/**
+ * Specifies a {@link ClusteredResourcePool} sharing space in a server-based clustered resource.
+ * The amount of space used for {@code SharedClusteredResourcePool} is designated only in
+ * server configuration and is shared among all {@code SharedClusteredResourcePool} instances
+ * using the same shared resource name.
+ */
+public interface SharedClusteredResourcePool extends ClusteredResourcePool {
+
+  /**
+   * Identifies the server-side clustered resource shared with this resource pool.
+   *
+   * @return the server-side clustered resource id
+   */
+  String getSharedResource();
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/builders/ClusteredResourcePoolBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/builders/ClusteredResourcePoolBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config.builders;
+
+import org.ehcache.clustered.config.FixedClusteredResourcePool;
+import org.ehcache.clustered.config.SharedClusteredResourcePool;
+import org.ehcache.clustered.internal.config.FixedClusteredResourcePoolImpl;
+import org.ehcache.clustered.internal.config.SharedClusteredResourcePoolImpl;
+import org.ehcache.config.units.MemoryUnit;
+
+/**
+ * Constructs a {@link org.ehcache.config.ResourcePool ResourcePool} for a clustered resource.
+ */
+public final class ClusteredResourcePoolBuilder {
+
+  /** Private, niladic constructor to prevent instantiation. */
+  private ClusteredResourcePoolBuilder() {
+  }
+
+  /**
+   * Creates a new clustered resource pool using fixed clustered resources.
+   *
+   * @param size       the size
+   * @param unit       the unit for the size
+   */
+  public static FixedClusteredResourcePool fixed(long size, MemoryUnit unit) {
+    return new FixedClusteredResourcePoolImpl(null, size, unit);
+  }
+
+  /**
+   * Creates a new clustered resource pool using fixed clustered resources.
+   *
+   * @param fromResource the name of the server-based resource from which this fixed resource pool
+   *                     is reserved; may be {@code null}
+   * @param size       the size
+   * @param unit       the unit for the size
+   */
+  public static FixedClusteredResourcePool fixed(String fromResource, long size, MemoryUnit unit) {
+    return new FixedClusteredResourcePoolImpl(fromResource, size, unit);
+  }
+
+  /**
+   * Creates a new resource pool based on the provided parameters.
+   *
+   * @param sharedResource the non-{@code null} name of the server-based resource pool whose space is shared
+   *                       by this pool
+   */
+  public static SharedClusteredResourcePool shared(String sharedResource) {
+    return new SharedClusteredResourcePoolImpl(sharedResource);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/builders/ClusteringServiceConfigurationBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/builders/ClusteringServiceConfigurationBuilder.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.ehcache.clustered.config.ClusteringServiceConfiguration;
 import org.ehcache.clustered.config.ClusteringServiceConfiguration.PoolDefinition;
 import org.ehcache.config.builders.Builder;
-import org.terracotta.offheapstore.util.MemoryUnit;
+import org.ehcache.config.units.MemoryUnit;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteredResourceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteredResourceConfigurationParser.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config.xml;
+
+import org.ehcache.clustered.internal.config.FixedClusteredResourcePoolImpl;
+import org.ehcache.clustered.internal.config.SharedClusteredResourcePoolImpl;
+import org.ehcache.config.ResourcePool;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.xml.CacheResourceConfigurationParser;
+import org.ehcache.xml.exceptions.XmlConfigurationException;
+import org.w3c.dom.Attr;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+import static org.ehcache.clustered.config.xml.ClusteredCacheConstants.NAMESPACE;
+import static org.ehcache.clustered.config.xml.ClusteredCacheConstants.XML_SCHEMA;
+
+/**
+ * Provides a parser for the {@code /config/cache/resources} extension elements.
+ */
+public class ClusteredResourceConfigurationParser implements CacheResourceConfigurationParser {
+  @Override
+  public Source getXmlSchema() throws IOException {
+    return new StreamSource(XML_SCHEMA.openStream());
+  }
+
+  @Override
+  public URI getNamespace() {
+    return NAMESPACE;
+  }
+
+  @Override
+  public ResourcePool parseResourceConfiguration(final Element fragment) {
+    final String elementName = fragment.getLocalName();
+    if ("cluster-shared".equals(elementName)) {
+      final String sharing = fragment.getAttribute("sharing");
+      return new SharedClusteredResourcePoolImpl(sharing);
+
+    } else if ("cluster-fixed".equals(elementName)) {
+      // 'from' attribute is optional on 'cluster-fixed' element
+      final Attr fromAttr = fragment.getAttributeNode("from");
+      final String from = (fromAttr == null ? null : fromAttr.getValue());
+
+      final String unitValue = fragment.getAttribute("unit").toUpperCase();
+      final MemoryUnit sizeUnits;
+      try {
+        sizeUnits = MemoryUnit.valueOf(unitValue);
+      } catch (IllegalArgumentException e) {
+        throw new XmlConfigurationException(String.format("XML configuration element <%s> 'unit' attribute '%s' is not valid", elementName, unitValue), e);
+      }
+
+      final String sizeValue;
+      try {
+        sizeValue = fragment.getFirstChild().getNodeValue();
+      } catch (DOMException e) {
+        throw new XmlConfigurationException(String.format("XML configuration element <%s> value is not valid", elementName), e);
+      }
+      final long size;
+      try {
+        size = Long.parseLong(sizeValue);
+      } catch (NumberFormatException e) {
+        throw new XmlConfigurationException(String.format("XML configuration element <%s> value '%s' is not valid", elementName, sizeValue), e);
+      }
+
+      return new FixedClusteredResourcePoolImpl(from, size, sizeUnits);
+    }
+
+    throw new XmlConfigurationException(String.format("XML configuration element <%s> in <%s> is not supported",
+        fragment.getTagName(), (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName())));
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/config/xml/ClusteringServiceConfigurationParser.java
@@ -95,7 +95,6 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
           }
         }
       }
-      // TODO: Validate connectionUri is valid URL with proper content
       return new ClusteringServiceConfiguration(connectionUri, Collections.<String, PoolDefinition>emptyMap());
     }
     throw new XmlConfigurationException(String.format("XML configuration element <%s> in <%s> is not supported",

--- a/clustered/client/src/main/java/org/ehcache/clustered/internal/config/FixedClusteredResourcePoolImpl.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/internal/config/FixedClusteredResourcePoolImpl.java
@@ -24,7 +24,8 @@ import org.ehcache.core.config.SizedResourcePoolImpl;
 /**
  * Concrete implementation of a {@link FixedClusteredResourcePool}.
  */
-public class FixedClusteredResourcePoolImpl extends SizedResourcePoolImpl implements FixedClusteredResourcePool {
+public class FixedClusteredResourcePoolImpl extends SizedResourcePoolImpl<FixedClusteredResourcePool>
+    implements FixedClusteredResourcePool {
 
   private final String fromResource;
 
@@ -42,8 +43,8 @@ public class FixedClusteredResourcePoolImpl extends SizedResourcePoolImpl implem
   }
 
   @Override
-  public ClusteredResourceType getType() {
-    return (ClusteredResourceType)super.getType();
+  public ClusteredResourceType<FixedClusteredResourcePool> getType() {
+    return (ClusteredResourceType<FixedClusteredResourcePool>)super.getType();
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/internal/config/FixedClusteredResourcePoolImpl.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/internal/config/FixedClusteredResourcePoolImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.internal.config;
+
+import org.ehcache.clustered.config.ClusteredResourceType;
+import org.ehcache.clustered.config.FixedClusteredResourcePool;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.config.SizedResourcePoolImpl;
+
+/**
+ * Concrete implementation of a {@link FixedClusteredResourcePool}.
+ */
+public class FixedClusteredResourcePoolImpl extends SizedResourcePoolImpl implements FixedClusteredResourcePool {
+
+  private final String fromResource;
+
+  /**
+   * Creates a new resource pool based on the provided parameters.
+   *
+   * @param fromResource the name of the server-based resource from which this fixed resource pool
+   *                     is reserved; may be {@code null}
+   * @param size       the size
+   * @param unit       the unit for the size
+   */
+  public FixedClusteredResourcePoolImpl(final String fromResource, final long size, final MemoryUnit unit) {
+    super(ClusteredResourceType.Types.FIXED, size, unit, true);
+    this.fromResource = fromResource;       // May be null
+  }
+
+  @Override
+  public ClusteredResourceType getType() {
+    return (ClusteredResourceType)super.getType();
+  }
+
+  @Override
+  public MemoryUnit getUnit() {
+    return (MemoryUnit)super.getUnit();
+  }
+
+  @Override
+  public String getFromResource() {
+    return this.fromResource;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("Pool {");
+
+    sb.append(getSize());
+    sb.append(' ');
+    sb.append(getUnit());
+    sb.append(' ');
+    sb.append(getType());
+
+    if (isPersistent()) {
+      sb.append("(persistent)");
+    }
+
+    sb.append(' ');
+    sb.append("from=");
+    if (getFromResource() == null) {
+      sb.append("N/A");
+    } else {
+      sb.append('\'').append(getFromResource()).append('\'');
+    }
+
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/internal/config/SharedClusteredResourcePoolImpl.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/internal/config/SharedClusteredResourcePoolImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.internal.config;
+
+import org.ehcache.clustered.config.ClusteredResourceType;
+import org.ehcache.clustered.config.SharedClusteredResourcePool;
+import org.ehcache.core.config.AbstractResourcePool;
+
+/**
+ * Implementation for {@link SharedClusteredResourcePool}.
+ */
+public class SharedClusteredResourcePoolImpl extends AbstractResourcePool implements SharedClusteredResourcePool {
+
+  private final String sharedResource;
+
+  /**
+   * Creates a new resource pool based on the provided parameters.
+   *
+   * @param sharedResource the non-{@code null} name of the server-based resource pool whose space is shared
+   *                       by this pool
+   */
+  public SharedClusteredResourcePoolImpl(final String sharedResource) {
+    super(ClusteredResourceType.Types.SHARED, true);
+
+    if (sharedResource == null) {
+      throw new NullPointerException("sharedResource identifier can not be null");
+    }
+    this.sharedResource = sharedResource;
+  }
+
+  @Override
+  public ClusteredResourceType getType() {
+    return (ClusteredResourceType)super.getType();
+  }
+
+  @Override
+  public String getSharedResource() {
+    return this.sharedResource;
+  }
+
+  @Override
+  public String toString() {
+    return "Pool {"
+        + "sharedResource='" + sharedResource + '\''
+        + " " + getType() + (isPersistent() ? "(persistent)}" : "}");
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/internal/config/SharedClusteredResourcePoolImpl.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/internal/config/SharedClusteredResourcePoolImpl.java
@@ -23,7 +23,9 @@ import org.ehcache.core.config.AbstractResourcePool;
 /**
  * Implementation for {@link SharedClusteredResourcePool}.
  */
-public class SharedClusteredResourcePoolImpl extends AbstractResourcePool implements SharedClusteredResourcePool {
+public class SharedClusteredResourcePoolImpl
+    extends AbstractResourcePool<SharedClusteredResourcePool, ClusteredResourceType<SharedClusteredResourcePool>>
+    implements SharedClusteredResourcePool {
 
   private final String sharedResource;
 
@@ -43,8 +45,8 @@ public class SharedClusteredResourcePoolImpl extends AbstractResourcePool implem
   }
 
   @Override
-  public ClusteredResourceType getType() {
-    return (ClusteredResourceType)super.getType();
+  public ClusteredResourceType<SharedClusteredResourcePool> getType() {
+    return super.getType();
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/internal/store/ClusteredStore.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.internal.store;
+
+import org.ehcache.Cache;
+import org.ehcache.clustered.config.ClusteredResourceType;
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.service.ClusteringService;
+import org.ehcache.config.ResourceType;
+import org.ehcache.core.CacheConfigurationChangeListener;
+import org.ehcache.core.internal.store.StoreSupport;
+import org.ehcache.core.internal.util.ConcurrentWeakIdentityHashMap;
+import org.ehcache.core.spi.function.BiFunction;
+import org.ehcache.core.spi.function.Function;
+import org.ehcache.core.spi.function.NullaryFunction;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.core.spi.store.events.StoreEventSource;
+import org.ehcache.exceptions.StoreAccessException;
+import org.ehcache.spi.ServiceProvider;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.ehcache.spi.service.ServiceDependencies;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Supports a {@link Store} in a clustered environment.
+ */
+// *********************************************************************************************
+// *********************************************************************************************
+// *                                                                                           *
+// * This is a shell of an implementation that is a placeholder for a real implementation.     *
+// * The methods in this class are, at this point, not expected to function "properly".        *
+// *                                                                                           *
+// * In its present form, the cache configuration must provide some 'core' resource in         *
+// * addition to the clustered resources.                                                      *
+// *                                                                                           *
+// *********************************************************************************************
+// *********************************************************************************************
+public class ClusteredStore<K, V> implements Store<K, V> {
+
+  private final Store<K, V> underlyingStore;
+
+  ClusteredStore(final Configuration<K, V> storeConfig, final ClusteringServiceConfiguration clusteringConfig, final Store<K, V> underlyingStore) {
+    this.underlyingStore = underlyingStore;
+  }
+
+  @Override
+  public ValueHolder<V> get(final K key) throws StoreAccessException {
+    return underlyingStore.get(key);
+  }
+
+  @Override
+  public boolean containsKey(final K key) throws StoreAccessException {
+    return underlyingStore.containsKey(key);
+  }
+
+  @Override
+  public PutStatus put(final K key, final V value) throws StoreAccessException {
+    return underlyingStore.put(key, value);
+  }
+
+  @Override
+  public ValueHolder<V> putIfAbsent(final K key, final V value) throws StoreAccessException {
+    return underlyingStore.putIfAbsent(key, value);
+  }
+
+  @Override
+  public boolean remove(final K key) throws StoreAccessException {
+    return underlyingStore.remove(key);
+  }
+
+  @Override
+  public RemoveStatus remove(final K key, final V value) throws StoreAccessException {
+    return underlyingStore.remove(key, value);
+  }
+
+  @Override
+  public ValueHolder<V> replace(final K key, final V value) throws StoreAccessException {
+    return underlyingStore.replace(key, value);
+  }
+
+  @Override
+  public ReplaceStatus replace(final K key, final V oldValue, final V newValue) throws StoreAccessException {
+    return underlyingStore.replace(key, oldValue, newValue);
+  }
+
+  @Override
+  public void clear() throws StoreAccessException {
+    underlyingStore.clear();
+  }
+
+  @Override
+  public StoreEventSource<K, V> getStoreEventSource() {
+    return underlyingStore.getStoreEventSource();
+  }
+
+  @Override
+  public Iterator<Cache.Entry<K, ValueHolder<V>>> iterator() {
+    return underlyingStore.iterator();
+  }
+
+  @Override
+  public ValueHolder<V> compute(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction)
+      throws StoreAccessException {
+    return underlyingStore.compute(key, mappingFunction);
+  }
+
+  @Override
+  public ValueHolder<V> compute(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction, final NullaryFunction<Boolean> replaceEqual)
+      throws StoreAccessException {
+    return underlyingStore.compute(key, mappingFunction, replaceEqual);
+  }
+
+  @Override
+  public ValueHolder<V> computeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction)
+      throws StoreAccessException {
+    return underlyingStore.computeIfAbsent(key, mappingFunction);
+  }
+
+  @Override
+  public Map<K, ValueHolder<V>> bulkCompute(final Set<? extends K> keys, final Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction)
+      throws StoreAccessException {
+    return underlyingStore.bulkCompute(keys, remappingFunction);
+  }
+
+  @Override
+  public Map<K, ValueHolder<V>> bulkCompute(final Set<? extends K> keys, final Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, final NullaryFunction<Boolean> replaceEqual)
+      throws StoreAccessException {
+    return underlyingStore.bulkCompute(keys, remappingFunction, replaceEqual);
+  }
+
+  @Override
+  public Map<K, ValueHolder<V>> bulkComputeIfAbsent(final Set<? extends K> keys, final Function<Iterable<? extends K>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> mappingFunction)
+      throws StoreAccessException {
+    return underlyingStore.bulkComputeIfAbsent(keys, mappingFunction);
+  }
+
+  @Override
+  public List<CacheConfigurationChangeListener> getConfigurationChangeListeners() {
+    return underlyingStore.getConfigurationChangeListeners();
+  }
+
+
+  /**
+   * Provider of {@link ClusteredStore} instances.
+   */
+  @ServiceDependencies({ClusteringService.class})
+  public static class Provider implements Store.Provider {
+
+    private static final Set<ResourceType> CLUSTER_RESOURCES =
+        Collections.<ResourceType>unmodifiableSet(EnumSet.allOf(ClusteredResourceType.Types.class));
+
+    private volatile ServiceProvider<Service> serviceProvider;
+    private volatile ClusteringService clusteringService;
+    private final Map<Store<?, ?>, Store.Provider> createdStores = new ConcurrentWeakIdentityHashMap<Store<?, ?>, Store.Provider>();
+
+    @Override
+    public <K, V> Store<K, V> createStore(final Configuration<K, V> storeConfig, final ServiceConfiguration<?>... serviceConfigs) {
+      if (clusteringService == null) {
+        throw new IllegalStateException("ClusteredStore.Provider.createStore called without ClusteringServiceConfiguration");
+      }
+      if (Collections.disjoint(storeConfig.getResourcePools().getResourceTypeSet(), CLUSTER_RESOURCES)) {
+        throw new IllegalStateException("ClusteredStoreProvider.createStore called without ClusteredResourcePools");
+      }
+
+      // TODO: Create tiered configuration ala org.ehcache.impl.internal.store.tiering.CacheStore.Provider
+      final ClusteringServiceConfiguration clusterConfiguration = clusteringService.getConfiguration();
+      final Store.Provider underlyingStoreProvider =
+          selectProvider(storeConfig.getResourcePools().getResourceTypeSet(), Arrays.asList(serviceConfigs));
+
+      final Store<K, V> underlyingStore = underlyingStoreProvider.createStore(storeConfig, serviceConfigs);
+      Store<K, V> store = new ClusteredStore<K, V>(storeConfig, clusterConfiguration, underlyingStore);
+
+      createdStores.put(store, underlyingStoreProvider);
+      return store;
+    }
+
+    @Override
+    public void releaseStore(final Store<?, ?> resource) {
+      Store.Provider underlyingStoreProvider = createdStores.remove(resource);
+      if (underlyingStoreProvider == null) {
+        throw new IllegalArgumentException("Given store is not managed by this provider: " + resource);
+      }
+
+      underlyingStoreProvider.releaseStore(((ClusteredStore)resource).underlyingStore);
+    }
+
+    @Override
+    public void initStore(final Store<?, ?> resource) {
+      Store.Provider underlyingStoreProvider = createdStores.get(resource);
+      if (underlyingStoreProvider == null) {
+        throw new IllegalArgumentException("Given store is not managed by this provider: " + resource);
+      }
+
+      underlyingStoreProvider.initStore(((ClusteredStore)resource).underlyingStore);
+    }
+
+    @Override
+    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+      if (clusteringService == null || Collections.disjoint(resourceTypes, CLUSTER_RESOURCES)) {
+        // A ClusteredStore requires a ClusteringService *and* ClusteredResourcePool instances
+        return 0;
+      }
+
+      // TODO: Add logic to ensure 'clusteringService' is configured for the desired resources
+
+      Set<ResourceType> nonClusterResourceTypes = new HashSet<ResourceType>(resourceTypes);
+      int clusterResourceCount = nonClusterResourceTypes.size();
+      nonClusterResourceTypes.removeAll(CLUSTER_RESOURCES);
+      clusterResourceCount -= nonClusterResourceTypes.size();
+
+      final Store.Provider candidateUnderlyingStoreProvider = selectProvider(nonClusterResourceTypes, serviceConfigs);
+      final int underlyingRank = candidateUnderlyingStoreProvider.rank(nonClusterResourceTypes, serviceConfigs);
+      return (underlyingRank == 0 ? 0 : 100 + clusterResourceCount + underlyingRank);
+    }
+
+    @Override
+    public void start(final ServiceProvider<Service> serviceProvider) {
+      this.serviceProvider = serviceProvider;
+      // TODO: Should this fail soft?
+      this.clusteringService = this.serviceProvider.getService(ClusteringService.class);
+    }
+
+    @Override
+    public void stop() {
+      this.serviceProvider = null;
+    }
+
+    private Store.Provider selectProvider(final Set<ResourceType> resourceTypes,
+                                          final Collection<ServiceConfiguration<?>> serviceConfigs) {
+
+      final Set<ResourceType> nonClusterResources = new HashSet<ResourceType>(resourceTypes);
+      nonClusterResources.removeAll(CLUSTER_RESOURCES);
+      if (nonClusterResources.isEmpty()) {
+        return new NonProvider();
+      }
+
+      return StoreSupport.selectStoreProvider(serviceProvider, nonClusterResources, serviceConfigs);
+    }
+  }
+
+  /**
+   * Nested {@link Store.Provider} implementation
+   * used when a {@link ClusteredStore} has no tiered co-stores.
+   */
+  private static final class NonProvider implements Store.Provider {
+
+    @Override
+    public <K, V> Store<K, V> createStore(final Configuration<K, V> storeConfig, final ServiceConfiguration<?>... serviceConfigs) {
+      return null;
+    }
+
+    @Override
+    public void releaseStore(final Store<?, ?> resource) {
+    }
+
+    @Override
+    public void initStore(final Store<?, ?> resource) {
+    }
+
+    @Override
+    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+      return 0;
+    }
+
+    @Override
+    public void start(final ServiceProvider<Service> serviceProvider) {
+    }
+
+    @Override
+    public void stop() {
+    }
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/internal/store/ClusteredStoreProviderFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/internal/store/ClusteredStoreProviderFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.internal.store;
+
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+/**
+ * Factory to create instances of {@link ClusteredStore.Provider}.
+ */
+public class ClusteredStoreProviderFactory implements ServiceFactory<ClusteredStore.Provider> {
+  @Override
+  public ClusteredStore.Provider create(final ServiceCreationConfiguration<ClusteredStore.Provider> configuration) {
+    return new ClusteredStore.Provider();
+  }
+
+  @Override
+  public Class<ClusteredStore.Provider> getServiceType() {
+    return ClusteredStore.Provider.class;
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/service/ClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/service/ClusteringService.java
@@ -16,12 +16,15 @@
 
 package org.ehcache.clustered.service;
 
+import org.ehcache.clustered.config.ClusteringServiceConfiguration;
 import org.ehcache.spi.service.PersistableResourceService;
 
 /**
  * @author Clifford W. Johnson
  */
 public interface ClusteringService extends PersistableResourceService {
+
+  ClusteringServiceConfiguration getConfiguration();
 
   void connect();
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/service/DefaultClusteringService.java
@@ -25,6 +25,7 @@ import org.ehcache.clustered.ServerSideConfiguration;
 import org.ehcache.clustered.client.EhcacheClientEntity;
 
 import org.ehcache.clustered.client.EhcacheClientEntityFactory;
+import org.ehcache.clustered.config.ClusteredResourceType;
 import org.ehcache.clustered.config.ClusteringServiceConfiguration;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
@@ -44,12 +45,13 @@ import org.terracotta.offheapstore.util.FindbugsSuppressWarnings;
 import static java.util.Collections.emptyList;
 
 /**
- * @author Clifford W. Johnson
+ * Provides support for accessing server-based cluster services.
  */
 public class DefaultClusteringService implements ClusteringService {
 
   private static final String AUTO_CREATE_QUERY = "auto-create";
 
+  private final ClusteringServiceConfiguration configuration;
   private final URI clusterUri;
   private final String entityIdentifier;
   private final boolean autoCreate;
@@ -61,6 +63,7 @@ public class DefaultClusteringService implements ClusteringService {
   private EhcacheClientEntity entity;
 
   public DefaultClusteringService(final ClusteringServiceConfiguration configuration) {
+    this.configuration = configuration;
     URI ehcacheUri = configuration.getClusterUri();
     this.clusterUri = extractClusterUri(ehcacheUri);
     this.entityIdentifier = clusterUri.relativize(ehcacheUri).getPath();
@@ -73,6 +76,11 @@ public class DefaultClusteringService implements ClusteringService {
     } catch (URISyntaxException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Override
+  public ClusteringServiceConfiguration getConfiguration() {
+    return this.configuration;
   }
 
   @Override
@@ -146,7 +154,7 @@ public class DefaultClusteringService implements ClusteringService {
 
   @Override
   public boolean handlesResourceType(ResourceType resourceType) {
-    return false;
+    return (ClusteredResourceType.class.isAssignableFrom(resourceType.getClass()));
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/service/DefaultClusteringService.java
@@ -153,7 +153,7 @@ public class DefaultClusteringService implements ClusteringService {
   }
 
   @Override
-  public boolean handlesResourceType(ResourceType resourceType) {
+  public boolean handlesResourceType(ResourceType<?> resourceType) {
     return (ClusteredResourceType.class.isAssignableFrom(resourceType.getClass()));
   }
 

--- a/clustered/client/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
+++ b/clustered/client/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
@@ -1,1 +1,2 @@
 org.ehcache.clustered.service.ClusteringServiceFactory
+org.ehcache.clustered.internal.store.ClusteredStoreProviderFactory

--- a/clustered/client/src/main/resources/META-INF/services/org.ehcache.xml.CacheResourceConfigurationParser
+++ b/clustered/client/src/main/resources/META-INF/services/org.ehcache.xml.CacheResourceConfigurationParser
@@ -1,0 +1,1 @@
+org.ehcache.clustered.config.xml.ClusteredResourceConfigurationParser

--- a/clustered/client/src/test/java/org/ehcache/clustered/BasicClusteredCacheTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/BasicClusteredCacheTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.Cache;
+import org.ehcache.PersistentCacheManager;
+import org.ehcache.clustered.client.UnitTestConnectionService;
+import org.ehcache.clustered.config.builders.ClusteredResourcePoolBuilder;
+import org.ehcache.clustered.config.builders.ClusteringServiceConfigurationBuilder;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Provides basic tests for creation of a cache using a {@link org.ehcache.clustered.internal.store.ClusteredStore ClusteredStore}.
+ */
+public class BasicClusteredCacheTest {
+
+  @Before
+  public void resetPassthroughServer() {
+    UnitTestConnectionService.reset();
+  }
+
+
+  @Test
+  public void underlyingHeap() throws Exception {
+
+    final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder =
+        CacheManagerBuilder.newCacheManagerBuilder()
+            .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/my-application?auto-create"))
+                .defaultServerResource("primary-server-resource")
+                .resourcePool("resource-pool-a", 128, MemoryUnit.GB)
+                .resourcePool("resource-pool-b", 128, MemoryUnit.GB, "secondary-server-resource"))
+            .withCache("clustered-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+                .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
+                    .heap(10, EntryUnit.ENTRIES)
+                    .with(ClusteredResourcePoolBuilder.fixed("resource-pool-a", 32, MemoryUnit.GB))));
+    final PersistentCacheManager cacheManager = clusteredCacheManagerBuilder.build(true);
+
+    final Cache<Long, String> cache = cacheManager.getCache("clustered-cache", Long.class, String.class);
+
+    cache.put(1L, "value");
+    assertThat(cache.containsKey(1L), is(true));
+    assertThat(cache.get(1L), is("value"));
+
+    cacheManager.close();
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/config/ClusteringServiceConfigurationTest.java
@@ -29,9 +29,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
-/**
- * @author Clifford W. Johnson
- */
 public class ClusteringServiceConfigurationTest {
 
   @Test(expected = NullPointerException.class)

--- a/clustered/client/src/test/java/org/ehcache/clustered/config/builders/ClusteredResourcePoolBuilderTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/config/builders/ClusteredResourcePoolBuilderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.config.builders;
+
+import org.ehcache.clustered.config.ClusteredResourceType;
+import org.ehcache.clustered.config.FixedClusteredResourcePool;
+import org.ehcache.clustered.config.SharedClusteredResourcePool;
+import org.ehcache.config.ResourcePool;
+import org.ehcache.config.ResourceType;
+import org.ehcache.config.units.MemoryUnit;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+public class ClusteredResourcePoolBuilderTest {
+
+  @Test
+  public void fixed2Arg() throws Exception {
+    ResourcePool pool = ClusteredResourcePoolBuilder.fixed(16, MemoryUnit.GB);
+    assertThat(pool, is(instanceOf(FixedClusteredResourcePool.class)));
+    assertThat(pool.getType(), Matchers.<ResourceType>is(ClusteredResourceType.Types.FIXED));
+    assertThat(pool.isPersistent(), is(true));
+    assertThat(((FixedClusteredResourcePool)pool).getSize(), is(16L));
+    assertThat(((FixedClusteredResourcePool)pool).getUnit(), is(MemoryUnit.GB));
+    assertThat(((FixedClusteredResourcePool)pool).getFromResource(), is(nullValue()));
+  }
+
+  @Test
+  public void fixed2ArgUnitNull() throws Exception {
+    try {
+      ClusteredResourcePoolBuilder.fixed(16, null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void fixed3Arg() throws Exception {
+    ResourcePool pool = ClusteredResourcePoolBuilder.fixed("resourceId", 16, MemoryUnit.GB);
+    assertThat(pool, is(instanceOf(FixedClusteredResourcePool.class)));
+    assertThat(pool.getType(), Matchers.<ResourceType>is(ClusteredResourceType.Types.FIXED));
+    assertThat(pool.isPersistent(), is(true));
+    assertThat(((FixedClusteredResourcePool)pool).getSize(), is(16L));
+    assertThat(((FixedClusteredResourcePool)pool).getUnit(), is(MemoryUnit.GB));
+    assertThat(((FixedClusteredResourcePool)pool).getFromResource(), is("resourceId"));
+  }
+
+  @Test
+  public void fixed3ArgFromNull() throws Exception {
+    ResourcePool pool = ClusteredResourcePoolBuilder.fixed(null, 16, MemoryUnit.GB);
+    assertThat(pool, is(instanceOf(FixedClusteredResourcePool.class)));
+    assertThat(pool.getType(), Matchers.<ResourceType>is(ClusteredResourceType.Types.FIXED));
+    assertThat(pool.isPersistent(), is(true));
+    assertThat(((FixedClusteredResourcePool)pool).getSize(), is(16L));
+    assertThat(((FixedClusteredResourcePool)pool).getUnit(), is(MemoryUnit.GB));
+    assertThat(((FixedClusteredResourcePool)pool).getFromResource(), is(nullValue()));
+  }
+
+  @Test
+  public void fixed3ArgUnitNull() throws Exception {
+    try {
+      ClusteredResourcePoolBuilder.fixed("resourceId", 16, null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void shared() throws Exception {
+    ResourcePool pool = ClusteredResourcePoolBuilder.shared("resourceId");
+    assertThat(pool, is(instanceOf(SharedClusteredResourcePool.class)));
+    assertThat(pool.getType(), Matchers.<ResourceType>is(ClusteredResourceType.Types.SHARED));
+    assertThat(pool.isPersistent(), is(true));
+    assertThat(((SharedClusteredResourcePool)pool).getSharedResource(), is("resourceId"));
+  }
+
+  @Test
+  public void sharedSharedResourceNull() throws Exception {
+    try {
+      ClusteredResourcePoolBuilder.shared(null);
+      fail();
+    } catch (NullPointerException e) {
+      // expected
+    }
+
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/docs/GettingStarted.java
@@ -18,23 +18,21 @@ package org.ehcache.clustered.docs;
 
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.clustered.client.UnitTestConnectionService;
-import org.ehcache.clustered.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.config.builders.ClusteredResourcePoolBuilder;
 import org.ehcache.clustered.config.builders.ClusteringServiceConfigurationBuilder;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
 import org.junit.Test;
 
 import java.net.URI;
 
 import org.junit.Before;
-import org.terracotta.offheapstore.util.MemoryUnit;
 
 /**
  * Samples demonstrating use of a clustered cache.
- *
- * @author Clifford W. Johnson
  *
  * @see org.ehcache.docs.GettingStarted
  */
@@ -65,13 +63,14 @@ public class GettingStarted {
     // tag::clusteredCacheManagerWithServerSideConfigExample
     final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder =
         CacheManagerBuilder.newCacheManagerBuilder()
-                .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/my-application?auto-create"))
-                        .defaultServerResource("primary-server-resource")
-                        .resourcePool("resource-pool-a", 128, MemoryUnit.GIGABYTES)
-                        .resourcePool("resource-pool-b", 128, MemoryUnit.GIGABYTES, "secondary-server-resource"))
-                .withCache("simple-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
+            .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("http://example.com:9540/my-application?auto-create"))
+                .defaultServerResource("primary-server-resource")
+                .resourcePool("resource-pool-a", 128, MemoryUnit.GB)
+                .resourcePool("resource-pool-b", 128, MemoryUnit.GB, "secondary-server-resource"))
+            .withCache("clustered-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class)
                 .withResourcePools(ResourcePoolsBuilder.newResourcePoolsBuilder()
-                    .heap(10, EntryUnit.ENTRIES)));
+                    .heap(10, EntryUnit.ENTRIES)
+                    .with(ClusteredResourcePoolBuilder.fixed("resource-pool-a", 32, MemoryUnit.GB))));
     final PersistentCacheManager cacheManager = clusteredCacheManagerBuilder.build(true);
 
     cacheManager.close();

--- a/clustered/client/src/test/java/org/ehcache/clustered/internal/store/ClusteredStoreProviderTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/internal/store/ClusteredStoreProviderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.internal.store;
+
+import org.ehcache.clustered.config.ClusteredResourceType;
+import org.ehcache.clustered.service.ClusteringService;
+import org.ehcache.config.ResourceType;
+import org.ehcache.core.internal.service.ServiceLocator;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.impl.internal.store.disk.OffHeapDiskStore;
+import org.ehcache.impl.internal.store.heap.OnHeapStore;
+import org.ehcache.impl.internal.store.offheap.OffHeapStore;
+import org.ehcache.impl.internal.store.tiering.CacheStore;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Provides basic tests for {@link org.ehcache.clustered.internal.store.ClusteredStore.Provider ClusteredStore.Provider}.
+ */
+public class ClusteredStoreProviderTest {
+
+  @Mock
+  private ClusteringService clusteringService;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testRank() throws Exception {
+    ClusteredStore.Provider provider = new ClusteredStore.Provider();
+    ServiceLocator serviceLocator = new ServiceLocator(
+        new CacheStore.Provider(),
+        new OnHeapStore.Provider(),
+        new OffHeapStore.Provider(),
+        new OffHeapDiskStore.Provider(),
+        mock(ClusteringService.class));
+    provider.start(serviceLocator);
+
+    assertRank(provider, 0, ResourceType.Core.DISK);
+    assertRank(provider, 0, ResourceType.Core.HEAP);
+    assertRank(provider, 0, ResourceType.Core.OFFHEAP);
+    assertRank(provider, 0, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP);
+    assertRank(provider, 0, ResourceType.Core.DISK, ResourceType.Core.HEAP);
+    assertRank(provider, 0, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+    assertRank(provider, 0, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+
+    assertRank(provider, 102, ClusteredResourceType.Types.FIXED, ResourceType.Core.DISK);
+    assertRank(provider, 102, ClusteredResourceType.Types.FIXED, ResourceType.Core.HEAP);
+    assertRank(provider, 102, ClusteredResourceType.Types.FIXED, ResourceType.Core.OFFHEAP);
+    assertRank(provider, -1, ClusteredResourceType.Types.FIXED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP);
+    assertRank(provider, 103, ClusteredResourceType.Types.FIXED, ResourceType.Core.DISK, ResourceType.Core.HEAP);
+    assertRank(provider, 103, ClusteredResourceType.Types.FIXED, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+    assertRank(provider, 104, ClusteredResourceType.Types.FIXED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+
+    assertRank(provider, 102, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK);
+    assertRank(provider, 102, ClusteredResourceType.Types.SHARED, ResourceType.Core.HEAP);
+    assertRank(provider, 102, ClusteredResourceType.Types.SHARED, ResourceType.Core.OFFHEAP);
+    assertRank(provider, -1, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP);
+    assertRank(provider, 103, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.HEAP);
+    assertRank(provider, 103, ClusteredResourceType.Types.SHARED, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+    assertRank(provider, 104, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+
+    assertRank(provider, 103, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK);
+    assertRank(provider, 103, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.HEAP);
+    assertRank(provider, 103, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.OFFHEAP);
+    assertRank(provider, -1, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP);
+    assertRank(provider, 104, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.HEAP);
+    assertRank(provider, 104, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+    assertRank(provider, 105, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+
+    final ResourceType unmatchedResourceType = new ResourceType() {
+      @Override
+      public boolean isPersistable() {
+        return true;
+      }
+
+      @Override
+      public boolean requiresSerialization() {
+        return true;
+      }
+    };
+    assertRank(provider, 0, unmatchedResourceType);
+    assertRank(provider, -1, ClusteredResourceType.Types.FIXED, unmatchedResourceType);
+  }
+
+  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType... resources) {
+
+    final List<ServiceConfiguration<?>> serviceConfigs = Collections.emptyList();
+    if (expectedRank == -1) {
+      try {
+        provider.rank(new HashSet<ResourceType>(Arrays.asList(resources)),
+            serviceConfigs);
+        fail();
+      } catch (IllegalStateException e) {
+        // Expected
+        assertThat(e.getMessage(), startsWith("No Store.Provider "));
+      }
+    } else {
+      assertThat(provider.rank(new HashSet<ResourceType>(Arrays.asList(resources)), serviceConfigs), is(expectedRank));
+    }
+  }
+
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/internal/store/ClusteredStoreProviderTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/internal/store/ClusteredStoreProviderTest.java
@@ -18,6 +18,7 @@ package org.ehcache.clustered.internal.store;
 
 import org.ehcache.clustered.config.ClusteredResourceType;
 import org.ehcache.clustered.service.ClusteringService;
+import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.service.ServiceLocator;
 import org.ehcache.core.spi.store.Store;
@@ -97,12 +98,15 @@ public class ClusteredStoreProviderTest {
     assertRank(provider, 104, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
     assertRank(provider, 105, ClusteredResourceType.Types.FIXED, ClusteredResourceType.Types.SHARED, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
 
-    final ResourceType unmatchedResourceType = new ResourceType() {
+    final ResourceType<ResourcePool> unmatchedResourceType = new ResourceType<ResourcePool>() {
+      @Override
+      public Class<ResourcePool> getResourcePoolClass() {
+        return ResourcePool.class;
+      }
       @Override
       public boolean isPersistable() {
         return true;
       }
-
       @Override
       public boolean requiresSerialization() {
         return true;
@@ -112,12 +116,12 @@ public class ClusteredStoreProviderTest {
     assertRank(provider, -1, ClusteredResourceType.Types.FIXED, unmatchedResourceType);
   }
 
-  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType... resources) {
+  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType<?>... resources) {
 
     final List<ServiceConfiguration<?>> serviceConfigs = Collections.emptyList();
     if (expectedRank == -1) {
       try {
-        provider.rank(new HashSet<ResourceType>(Arrays.asList(resources)),
+        provider.rank(new HashSet<ResourceType<?>>(Arrays.asList(resources)),
             serviceConfigs);
         fail();
       } catch (IllegalStateException e) {
@@ -125,7 +129,7 @@ public class ClusteredStoreProviderTest {
         assertThat(e.getMessage(), startsWith("No Store.Provider "));
       }
     } else {
-      assertThat(provider.rank(new HashSet<ResourceType>(Arrays.asList(resources)), serviceConfigs), is(expectedRank));
+      assertThat(provider.rank(new HashSet<ResourceType<?>>(Arrays.asList(resources)), serviceConfigs), is(expectedRank));
     }
   }
 

--- a/clustered/client/src/test/resources/configs/simple-cluster.xml
+++ b/clustered/client/src/test/resources/configs/simple-cluster.xml
@@ -11,7 +11,10 @@
   <ehcache:cache alias="simple-cache">
     <ehcache:key-type>java.lang.Long</ehcache:key-type>
     <ehcache:value-type>java.lang.String</ehcache:value-type>
-    <ehcache:heap unit="entries">10</ehcache:heap>
+    <ehcache:resources>
+      <ehcache:heap unit="entries">10</ehcache:heap>
+      <tc:cluster-fixed unit="GB">1</tc:cluster-fixed>
+    </ehcache:resources>
   </ehcache:cache>
 
 </ehcache:config>

--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -222,7 +222,7 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
    * @param ehcache the {@code InternalCache} instance for the cache to close
    */
   protected void closeEhcache(final String alias, final InternalCache<?, ?> ehcache) {
-    for (ResourceType resourceType : ehcache.getRuntimeConfiguration().getResourcePools().getResourceTypeSet()) {
+    for (ResourceType<?> resourceType : ehcache.getRuntimeConfiguration().getResourcePools().getResourceTypeSet()) {
       if (resourceType.isPersistable()) {
         ResourcePool resourcePool = ehcache.getRuntimeConfiguration()
             .getResourcePools()
@@ -422,8 +422,8 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
                                        final Collection<ServiceConfiguration<?>> serviceConfigs,
                                        final List<LifeCycled> lifeCycledList) {
 
-    final Set<ResourceType> resourceTypes = config.getResourcePools().getResourceTypeSet();
-    for (ResourceType resourceType : resourceTypes) {
+    final Set<ResourceType<?>> resourceTypes = config.getResourcePools().getResourceTypeSet();
+    for (ResourceType<?> resourceType : resourceTypes) {
       if (resourceType.isPersistable()) {
         PersistableResourceService persistableResourceService = getPersistableResourceService(resourceType);
 
@@ -454,7 +454,7 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
         });
         keySerializer = keySer;
       } catch (UnsupportedTypeException e) {
-        for (ResourceType resource : resourceTypes) {
+        for (ResourceType<?> resource : resourceTypes) {
           if (resource.requiresSerialization()) {
             throw new RuntimeException(e);
           }
@@ -471,7 +471,7 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
         });
         valueSerializer = valueSer;
       } catch (UnsupportedTypeException e) {
-        for (ResourceType resource : resourceTypes) {
+        for (ResourceType<?> resource : resourceTypes) {
           if (resource.requiresSerialization()) {
             throw new RuntimeException(e);
           }
@@ -508,7 +508,7 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
     return store;
   }
 
-  private PersistableResourceService getPersistableResourceService(ResourceType resourceType) {
+  private PersistableResourceService getPersistableResourceService(ResourceType<?> resourceType) {
     Collection<PersistableResourceService> services = serviceLocator.getServicesOfType(PersistableResourceService.class);
     for (PersistableResourceService service : services) {
       if (service.handlesResourceType(resourceType)) {

--- a/core/src/main/java/org/ehcache/core/config/AbstractResourcePool.java
+++ b/core/src/main/java/org/ehcache/core/config/AbstractResourcePool.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.core.config;
+
+import org.ehcache.config.ResourcePool;
+import org.ehcache.config.ResourceType;
+
+/**
+ * Foundation implementation for {@link ResourcePool} implementations.
+ */
+public abstract class AbstractResourcePool implements ResourcePool {
+  private final ResourceType type;
+  private final boolean persistent;
+
+  /**
+   * Creates a {@code AbstractResourcePool} instance.
+   *
+   * @param type the non-{@code null} {@code ResourceType}
+   * @param persistent whether or not this {@code ResourcePool} is persistent
+   */
+  public AbstractResourcePool(ResourceType type, boolean persistent) {
+    if (type == null) {
+      throw new NullPointerException("ResourceType may not be null");
+    }
+    this.type = type;
+    this.persistent = persistent;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ResourceType getType() {
+    return type;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isPersistent() {
+    return persistent;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException {@inheritDoc}
+   */
+  @Override
+  public void validateUpdate(ResourcePool newPool) {
+    // Replacement must be of the same ResourceType
+    if (!this.getType().equals(newPool.getType())) {
+      throw new IllegalArgumentException("ResourceType " + newPool.getType() + " can not replace " + this.getType());
+    }
+    // Replacement must have the same persistence
+    if (this.isPersistent() != newPool.isPersistent()) {
+      throw new IllegalArgumentException("ResourcePool for " + newPool.getType() + " with isPersistent="
+          + newPool.isPersistent() + " can not replace isPersistent=" + this.isPersistent());
+    }
+  }
+}

--- a/core/src/main/java/org/ehcache/core/config/AbstractResourcePool.java
+++ b/core/src/main/java/org/ehcache/core/config/AbstractResourcePool.java
@@ -21,9 +21,12 @@ import org.ehcache.config.ResourceType;
 
 /**
  * Foundation implementation for {@link ResourcePool} implementations.
+ *
+ * @param <P> the type of {@link ResourcePool} implemented by the subclass
+ * @param <T> the type of {@link ResourceType} related to the resource pool
  */
-public abstract class AbstractResourcePool implements ResourcePool {
-  private final ResourceType type;
+public abstract class AbstractResourcePool<P extends ResourcePool, T extends ResourceType<P>> implements ResourcePool {
+  private final T type;
   private final boolean persistent;
 
   /**
@@ -32,7 +35,7 @@ public abstract class AbstractResourcePool implements ResourcePool {
    * @param type the non-{@code null} {@code ResourceType}
    * @param persistent whether or not this {@code ResourcePool} is persistent
    */
-  public AbstractResourcePool(ResourceType type, boolean persistent) {
+  protected AbstractResourcePool(T type, boolean persistent) {
     if (type == null) {
       throw new NullPointerException("ResourceType may not be null");
     }
@@ -44,7 +47,7 @@ public abstract class AbstractResourcePool implements ResourcePool {
    * {@inheritDoc}
    */
   @Override
-  public ResourceType getType() {
+  public T getType() {
     return type;
   }
 

--- a/core/src/main/java/org/ehcache/core/config/ResourcePoolsImpl.java
+++ b/core/src/main/java/org/ehcache/core/config/ResourcePoolsImpl.java
@@ -67,12 +67,10 @@ public class ResourcePoolsImpl implements ResourcePools {
       throw new IllegalArgumentException("Pools to be updated cannot contain previously undefined resources pools");
     }
     // Can not update OFFHEAP
-    // TODO: Move to OFFHEAP ResourcePool
     if(toBeUpdated.getResourceTypeSet().contains(ResourceType.Core.OFFHEAP)) {
       throw new UnsupportedOperationException("Updating OFFHEAP resource is not supported");
     }
     // Can not update DISK
-    // TODO: Move to DISK ResourcePool
     if(toBeUpdated.getResourceTypeSet().contains(ResourceType.Core.DISK)) {
       throw new UnsupportedOperationException("Updating DISK resource is not supported");
     }
@@ -95,8 +93,6 @@ public class ResourcePoolsImpl implements ResourcePools {
    *
    * @param pools the resource pools to validate
    */
-  // TODO: Move to org.ehcache.impl.internal.store.tiering.CacheStore.Provider
-  // TODO: Generalize for all SizedResourcePool implementations (needs addition of defined ordering)
   public static void validateResourcePools(Collection<? extends ResourcePool> pools) {
     EnumMap<ResourceType.Core, SizedResourcePool> coreResources = new EnumMap<ResourceType.Core, SizedResourcePool>(ResourceType.Core.class);
     for (ResourcePool pool : pools) {

--- a/core/src/main/java/org/ehcache/core/config/ResourcePoolsImpl.java
+++ b/core/src/main/java/org/ehcache/core/config/ResourcePoolsImpl.java
@@ -34,9 +34,9 @@ import java.util.Set;
  */
 public class ResourcePoolsImpl implements ResourcePools {
 
-  private final Map<ResourceType, ResourcePool> pools;
+  private final Map<ResourceType<?>, ResourcePool> pools;
 
-  public ResourcePoolsImpl(Map<ResourceType, ResourcePool> pools) {
+  public ResourcePoolsImpl(Map<ResourceType<?>, ResourcePool> pools) {
     validateResourcePools(pools.values());
     this.pools = pools;
   }
@@ -45,15 +45,15 @@ public class ResourcePoolsImpl implements ResourcePools {
    * {@inheritDoc}
    */
   @Override
-  public ResourcePool getPoolForResource(ResourceType resourceType) {
-    return pools.get(resourceType);
+  public <P extends ResourcePool> P getPoolForResource(ResourceType<P> resourceType) {
+    return resourceType.getResourcePoolClass().cast(pools.get(resourceType));
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public Set<ResourceType> getResourceTypeSet() {
+  public Set<ResourceType<?>> getResourceTypeSet() {
     return pools.keySet();
   }
 
@@ -74,13 +74,13 @@ public class ResourcePoolsImpl implements ResourcePools {
     if(toBeUpdated.getResourceTypeSet().contains(ResourceType.Core.DISK)) {
       throw new UnsupportedOperationException("Updating DISK resource is not supported");
     }
-    for(ResourceType currentResourceType : toBeUpdated.getResourceTypeSet()) {
+    for(ResourceType<?> currentResourceType : toBeUpdated.getResourceTypeSet()) {
       getPoolForResource(currentResourceType).validateUpdate(toBeUpdated.getPoolForResource(currentResourceType));
     }
 
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
     poolsMap.putAll(pools);
-    for(ResourceType currentResourceType : toBeUpdated.getResourceTypeSet()) {
+    for(ResourceType<?> currentResourceType : toBeUpdated.getResourceTypeSet()) {
       ResourcePool poolForResource = toBeUpdated.getPoolForResource(currentResourceType);
       poolsMap.put(currentResourceType, poolForResource);
     }

--- a/core/src/main/java/org/ehcache/core/config/ResourcePoolsImpl.java
+++ b/core/src/main/java/org/ehcache/core/config/ResourcePoolsImpl.java
@@ -19,6 +19,7 @@ package org.ehcache.core.config;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
+import org.ehcache.config.SizedResourcePool;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,34 +62,29 @@ public class ResourcePoolsImpl implements ResourcePools {
    */
   @Override
   public ResourcePools validateAndMerge(ResourcePools toBeUpdated) {
+    // Ensure update pool types already exist in existing pools
     if(!getResourceTypeSet().containsAll(toBeUpdated.getResourceTypeSet())) {
       throw new IllegalArgumentException("Pools to be updated cannot contain previously undefined resources pools");
     }
+    // Can not update OFFHEAP
+    // TODO: Move to OFFHEAP ResourcePool
     if(toBeUpdated.getResourceTypeSet().contains(ResourceType.Core.OFFHEAP)) {
       throw new UnsupportedOperationException("Updating OFFHEAP resource is not supported");
     }
+    // Can not update DISK
+    // TODO: Move to DISK ResourcePool
     if(toBeUpdated.getResourceTypeSet().contains(ResourceType.Core.DISK)) {
       throw new UnsupportedOperationException("Updating DISK resource is not supported");
     }
     for(ResourceType currentResourceType : toBeUpdated.getResourceTypeSet()) {
-      if (toBeUpdated.getPoolForResource(currentResourceType).getSize() <= 0) {
-        throw new IllegalArgumentException("Unacceptable zero or negative size for resource pools provided");
-      }
-      if (toBeUpdated.getPoolForResource(currentResourceType).isPersistent() !=
-          getPoolForResource(currentResourceType).isPersistent()) {
-        throw new IllegalArgumentException("Persistence configuration cannot be updated");
-      }
-      if(!toBeUpdated.getPoolForResource(currentResourceType).getUnit().getClass()
-          .equals(getPoolForResource(currentResourceType).getUnit().getClass())) {
-        throw new UnsupportedOperationException("Modifying ResourceUnit type is not supported");
-      }
+      getPoolForResource(currentResourceType).validateUpdate(toBeUpdated.getPoolForResource(currentResourceType));
     }
 
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
     poolsMap.putAll(pools);
     for(ResourceType currentResourceType : toBeUpdated.getResourceTypeSet()) {
       ResourcePool poolForResource = toBeUpdated.getPoolForResource(currentResourceType);
-      poolsMap.put(currentResourceType, new ResourcePoolImpl(currentResourceType, poolForResource.getSize(), poolForResource.getUnit(), poolForResource.isPersistent()));
+      poolsMap.put(currentResourceType, poolForResource);
     }
 
     return new ResourcePoolsImpl(poolsMap);
@@ -99,19 +95,21 @@ public class ResourcePoolsImpl implements ResourcePools {
    *
    * @param pools the resource pools to validate
    */
+  // TODO: Move to org.ehcache.impl.internal.store.tiering.CacheStore.Provider
+  // TODO: Generalize for all SizedResourcePool implementations (needs addition of defined ordering)
   public static void validateResourcePools(Collection<? extends ResourcePool> pools) {
-    EnumMap<ResourceType.Core, ResourcePool> coreResources = new EnumMap<ResourceType.Core, ResourcePool>(ResourceType.Core.class);
+    EnumMap<ResourceType.Core, SizedResourcePool> coreResources = new EnumMap<ResourceType.Core, SizedResourcePool>(ResourceType.Core.class);
     for (ResourcePool pool : pools) {
       if (pool.getType() instanceof ResourceType.Core) {
-        coreResources.put((ResourceType.Core) pool.getType(), pool);
+        coreResources.put((ResourceType.Core)pool.getType(), (SizedResourcePool)pool);
       }
     }
 
-    List<ResourcePool> ordered = new ArrayList<ResourcePool>(coreResources.values());
+    List<SizedResourcePool> ordered = new ArrayList<SizedResourcePool>(coreResources.values());
     for (int i = 0; i < ordered.size(); i++) {
       for (int j = 0; j < i; j++) {
-        ResourcePool upper = ordered.get(j);
-        ResourcePool lower = ordered.get(i);
+        SizedResourcePool upper = ordered.get(j);
+        SizedResourcePool lower = ordered.get(i);
 
         boolean inversion;
         try {

--- a/core/src/main/java/org/ehcache/core/config/SizedResourcePoolImpl.java
+++ b/core/src/main/java/org/ehcache/core/config/SizedResourcePoolImpl.java
@@ -24,7 +24,8 @@ import org.ehcache.config.SizedResourcePool;
 /**
  * Implementation of the {@link SizedResourcePool} interface.
  */
-public class SizedResourcePoolImpl extends AbstractResourcePool implements SizedResourcePool {
+public class SizedResourcePoolImpl<P extends SizedResourcePool> extends AbstractResourcePool<P, ResourceType<P>>
+    implements SizedResourcePool {
 
   private final long size;
   private final ResourceUnit unit;
@@ -37,12 +38,11 @@ public class SizedResourcePoolImpl extends AbstractResourcePool implements Sized
    * @param unit the unit for the size
    * @param persistent whether the pool is to be persistent
    */
-  public SizedResourcePoolImpl(ResourceType type, long size, ResourceUnit unit, boolean persistent) {
+  public SizedResourcePoolImpl(ResourceType<P> type, long size, ResourceUnit unit, boolean persistent) {
     super(type, persistent);
     if (unit == null) {
       throw new NullPointerException("ResourceUnit can not be null");
     }
-    // TODO: Ensure 'type' can be sized?
     if (!type.isPersistable() && persistent) {
       throw new IllegalStateException("Non-persistable resource cannot be configured persistent");
     }

--- a/core/src/main/java/org/ehcache/core/config/SizedResourcePoolImpl.java
+++ b/core/src/main/java/org/ehcache/core/config/SizedResourcePoolImpl.java
@@ -19,16 +19,15 @@ package org.ehcache.core.config;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.ResourceUnit;
+import org.ehcache.config.SizedResourcePool;
 
 /**
- * Implementation of the {@link ResourcePool} interface.
+ * Implementation of the {@link SizedResourcePool} interface.
  */
-public class ResourcePoolImpl implements ResourcePool {
+public class SizedResourcePoolImpl extends AbstractResourcePool implements SizedResourcePool {
 
-  private final ResourceType type;
   private final long size;
   private final ResourceUnit unit;
-  private final boolean persistent;
 
   /**
    * Creates a new resource pool based on the provided parameters.
@@ -38,22 +37,17 @@ public class ResourcePoolImpl implements ResourcePool {
    * @param unit the unit for the size
    * @param persistent whether the pool is to be persistent
    */
-  public ResourcePoolImpl(ResourceType type, long size, ResourceUnit unit, boolean persistent) {
+  public SizedResourcePoolImpl(ResourceType type, long size, ResourceUnit unit, boolean persistent) {
+    super(type, persistent);
+    if (unit == null) {
+      throw new NullPointerException("ResourceUnit can not be null");
+    }
+    // TODO: Ensure 'type' can be sized?
     if (!type.isPersistable() && persistent) {
       throw new IllegalStateException("Non-persistable resource cannot be configured persistent");
     }
-    this.type = type;
     this.size = size;
     this.unit = unit;
-    this.persistent = persistent;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public ResourceType getType() {
-    return type;
   }
 
   /**
@@ -74,10 +68,25 @@ public class ResourcePoolImpl implements ResourcePool {
 
   /**
    * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException {@inheritDoc}
    */
   @Override
-  public boolean isPersistent() {
-    return persistent;
+  public void validateUpdate(final ResourcePool newPool) {
+    super.validateUpdate(newPool);
+
+    SizedResourcePool sizedPool = (SizedResourcePool)newPool;
+    // Ensure unit type has not changed
+    if (!this.getUnit().getClass().equals(sizedPool.getUnit().getClass())) {
+      throw new IllegalArgumentException("ResourcePool for " + sizedPool.getType() + " with ResourceUnit '"
+          + sizedPool.getUnit() + "' can not replace '" + this.getUnit() + "'");
+    }
+
+    // Ensure replacement has positive space
+    if (sizedPool.getSize() <= 0) {
+      throw new IllegalArgumentException("ResourcePool for " + sizedPool.getType()
+          + " must specify space greater than 0");
+    }
   }
 
   /**

--- a/core/src/main/java/org/ehcache/core/internal/service/ServiceLocator.java
+++ b/core/src/main/java/org/ehcache/core/internal/service/ServiceLocator.java
@@ -154,7 +154,6 @@ public final class ServiceLocator implements ServiceProvider<Service> {
        */
       for (Class<? extends Service> serviceClazz : serviceClazzes) {
         if (serviceClazz.isAnnotationPresent(PluralService.class)) {
-          //  TODO: Determine if thread-safety is a concern here ...
           // Permit multiple registrations
           Set<Service> registeredServices = services.get(serviceClazz);
           if (registeredServices == null) {
@@ -433,7 +432,6 @@ public final class ServiceLocator implements ServiceProvider<Service> {
       }
     }
 
-    // TODO: Since we examine ServiceDependencies on non-service concrete classes, why not interfaces?
     for (Class<?> interfaceClazz : clazz.getInterfaces()) {
       if (Service.class != interfaceClazz && Service.class.isAssignableFrom(interfaceClazz)) {
         identifyTransitiveDependenciesOf(interfaceClazz, dependencies);

--- a/core/src/main/java/org/ehcache/core/internal/store/StoreSupport.java
+++ b/core/src/main/java/org/ehcache/core/internal/store/StoreSupport.java
@@ -56,7 +56,7 @@ public final class StoreSupport {
    *        multiple {@code Store.Provider} implementations return the same top ranking
    */
   public static Store.Provider selectStoreProvider(
-      final ServiceProvider<Service> serviceProvider, final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+      final ServiceProvider<Service> serviceProvider, final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
 
     final Collection<Store.Provider> storeProviders = serviceProvider.getServicesOfType(Store.Provider.class);
     int highRank = 0;

--- a/core/src/main/java/org/ehcache/core/spi/store/Store.java
+++ b/core/src/main/java/org/ehcache/core/spi/store/Store.java
@@ -587,7 +587,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
      *      to handle the resource types specified by {@code resourceTypes}; a rank of 0 indicates the store
      *      can not handle all types specified in {@code resourceTypes}
      */
-    int rank(Set<ResourceType> resourceTypes, Collection<ServiceConfiguration<?>> serviceConfigs);
+    int rank(Set<ResourceType<?>> resourceTypes, Collection<ServiceConfiguration<?>> serviceConfigs);
   }
 
   /**

--- a/core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
@@ -582,7 +582,7 @@ public class EhcacheManagerTest {
     final CacheConfiguration<Object, Object> cacheConfiguration = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null, null, null, ResourcePoolsHelper.createHeapOnlyPools());
     final Store.Provider storeProvider = spy(new Store.Provider() {
       @Override
-      public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+      public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
         return 1;
       }
 

--- a/core/src/test/java/org/ehcache/core/config/ResourcePoolsHelper.java
+++ b/core/src/test/java/org/ehcache/core/config/ResourcePoolsHelper.java
@@ -36,39 +36,39 @@ public class ResourcePoolsHelper {
 
   public static ResourcePools createHeapOnlyPools(long heapSize) {
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new ResourcePoolImpl(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createHeapOnlyPools(long heapSize, ResourceUnit resourceUnit) {
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new ResourcePoolImpl(ResourceType.Core.HEAP, heapSize, resourceUnit, false));
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, resourceUnit, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createOffheapOnlyPools(long offheapSizeInMb) {
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.OFFHEAP, new ResourcePoolImpl(ResourceType.Core.OFFHEAP, offheapSizeInMb, MemoryUnit.MB, false));
+    poolsMap.put(ResourceType.Core.OFFHEAP, new SizedResourcePoolImpl(ResourceType.Core.OFFHEAP, offheapSizeInMb, MemoryUnit.MB, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createDiskOnlyPools(long diskSize, ResourceUnit resourceUnit) {
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.DISK, new ResourcePoolImpl(ResourceType.Core.DISK, diskSize, resourceUnit, false));
+    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, diskSize, resourceUnit, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createHeapDiskPools(long heapSize, long diskSizeInMb) {
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new ResourcePoolImpl(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
-    poolsMap.put(ResourceType.Core.DISK, new ResourcePoolImpl(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
+    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createHeapDiskPools(long heapSize, ResourceUnit heapResourceUnit, long diskSizeInMb) {
     Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new ResourcePoolImpl(ResourceType.Core.HEAP, heapSize, heapResourceUnit, false));
-    poolsMap.put(ResourceType.Core.DISK, new ResourcePoolImpl(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, heapResourceUnit, false));
+    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 

--- a/core/src/test/java/org/ehcache/core/config/ResourcePoolsHelper.java
+++ b/core/src/test/java/org/ehcache/core/config/ResourcePoolsHelper.java
@@ -19,6 +19,7 @@ import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.ResourceUnit;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 
@@ -35,40 +36,40 @@ public class ResourcePoolsHelper {
   }
 
   public static ResourcePools createHeapOnlyPools(long heapSize) {
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createHeapOnlyPools(long heapSize, ResourceUnit resourceUnit) {
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, resourceUnit, false));
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.HEAP, heapSize, resourceUnit, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createOffheapOnlyPools(long offheapSizeInMb) {
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.OFFHEAP, new SizedResourcePoolImpl(ResourceType.Core.OFFHEAP, offheapSizeInMb, MemoryUnit.MB, false));
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
+    poolsMap.put(ResourceType.Core.OFFHEAP, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.OFFHEAP, offheapSizeInMb, MemoryUnit.MB, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createDiskOnlyPools(long diskSize, ResourceUnit resourceUnit) {
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, diskSize, resourceUnit, false));
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
+    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.DISK, diskSize, resourceUnit, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createHeapDiskPools(long heapSize, long diskSizeInMb) {
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
-    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.HEAP, heapSize, EntryUnit.ENTRIES, false));
+    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 
   public static ResourcePools createHeapDiskPools(long heapSize, ResourceUnit heapResourceUnit, long diskSizeInMb) {
-    Map<ResourceType, ResourcePool> poolsMap = new HashMap<ResourceType, ResourcePool>();
-    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, heapSize, heapResourceUnit, false));
-    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
+    Map<ResourceType<?>, ResourcePool> poolsMap = new HashMap<ResourceType<?>, ResourcePool>();
+    poolsMap.put(ResourceType.Core.HEAP, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.HEAP, heapSize, heapResourceUnit, false));
+    poolsMap.put(ResourceType.Core.DISK, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.DISK, diskSizeInMb, MemoryUnit.MB, false));
     return new ResourcePoolsImpl(poolsMap);
   }
 

--- a/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
+++ b/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
@@ -47,33 +47,33 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMismatchedUnits() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, Integer.MAX_VALUE, ENTRIES, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, Integer.MAX_VALUE, ENTRIES, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, MB, false));
     validateResourcePools(pools);
   }
 
   @Test
   public void testMatchingEqualUnitsWellTiered() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 9, MB, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 9, MB, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, MB, false));
     validateResourcePools(pools);
   }
 
   @Test
   public void testMatchingUnequalUnitsWellTiered() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 9, MB, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10240, KB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 9, MB, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10240, KB, false));
     validateResourcePools(pools);
   }
 
   @Test
   public void testEntryResourceMatch() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 10, ENTRIES, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, ENTRIES, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 10, ENTRIES, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, ENTRIES, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -84,9 +84,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testEntryResourceInversion() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 11, ENTRIES, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, ENTRIES, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 11, ENTRIES, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, ENTRIES, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -97,9 +97,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceEqualUnitMatch() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 10, MB, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 10, MB, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -110,9 +110,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceEqualUnitInversion() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 11, MB, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 11, MB, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -123,9 +123,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceUnequalUnitMatch() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 10240, KB, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 10240, KB, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -136,9 +136,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceUnequalUnitInversion() {
-    Collection<SizedResourcePoolImpl> pools = asList(
-            new SizedResourcePoolImpl(HEAP, 10241, KB, false),
-            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl<SizedResourcePool>> pools = asList(
+            new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 10241, KB, false),
+            new SizedResourcePoolImpl<SizedResourcePool>(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -149,10 +149,10 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testAddingNewTierWhileUpdating() {
-    ResourcePools existing = new ResourcePoolsImpl(Collections.<ResourceType, ResourcePool>singletonMap(
-        ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, 10L, EntryUnit.ENTRIES, false)));
-    ResourcePools toBeUpdated = new ResourcePoolsImpl(Collections.<ResourceType, ResourcePool>singletonMap(
-        ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, 10L, MemoryUnit.MB, false)));
+    ResourcePools existing = new ResourcePoolsImpl(Collections.<ResourceType<?>, ResourcePool>singletonMap(
+        ResourceType.Core.HEAP, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.HEAP, 10L, EntryUnit.ENTRIES, false)));
+    ResourcePools toBeUpdated = new ResourcePoolsImpl(Collections.<ResourceType<?>, ResourcePool>singletonMap(
+        ResourceType.Core.DISK, new SizedResourcePoolImpl<SizedResourcePool>(ResourceType.Core.DISK, 10L, MemoryUnit.MB, false)));
     try {
       existing.validateAndMerge(toBeUpdated);
       fail();
@@ -191,8 +191,8 @@ public class ResourcePoolsImplTest {
     ResourcePools toBeUpdated = ResourcePoolsHelper.createHeapOnlyPools(2, MemoryUnit.GB);
 
     existing = existing.validateAndMerge(toBeUpdated);
-    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getSize(), Matchers.is(2L));
-    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.GB));
+    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getSize(), Matchers.is(2L));
+    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.GB));
   }
 
   @Test
@@ -206,8 +206,8 @@ public class ResourcePoolsImplTest {
     } catch (IllegalArgumentException uoe) {
       assertThat(uoe.getMessage(), Matchers.is("ResourcePool for heap with ResourceUnit 'entries' can not replace 'MB'"));
     }
-    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getSize(), Matchers.is(20L));
-    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
+    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getSize(), Matchers.is(20L));
+    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
   }
 
 }

--- a/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
+++ b/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
@@ -149,10 +149,10 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testAddingNewTierWhileUpdating() {
-    ResourcePools existing = new ResourcePoolsImpl(Collections.singletonMap((ResourceType) ResourceType.Core.HEAP,
-        (ResourcePool) new SizedResourcePoolImpl(ResourceType.Core.HEAP, 10L, EntryUnit.ENTRIES, false)));
-    ResourcePools toBeUpdated = new ResourcePoolsImpl(Collections.singletonMap((ResourceType) ResourceType.Core.DISK,
-        (ResourcePool) new SizedResourcePoolImpl(ResourceType.Core.DISK, 10L, MemoryUnit.MB, false)));
+    ResourcePools existing = new ResourcePoolsImpl(Collections.<ResourceType, ResourcePool>singletonMap(
+        ResourceType.Core.HEAP, new SizedResourcePoolImpl(ResourceType.Core.HEAP, 10L, EntryUnit.ENTRIES, false)));
+    ResourcePools toBeUpdated = new ResourcePoolsImpl(Collections.<ResourceType, ResourcePool>singletonMap(
+        ResourceType.Core.DISK, new SizedResourcePoolImpl(ResourceType.Core.DISK, 10L, MemoryUnit.MB, false)));
     try {
       existing.validateAndMerge(toBeUpdated);
       fail();

--- a/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
+++ b/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
@@ -19,6 +19,7 @@ import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.ResourceUnit;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.hamcrest.Matchers;
@@ -46,33 +47,33 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMismatchedUnits() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, Integer.MAX_VALUE, ENTRIES, false),
-            new ResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, Integer.MAX_VALUE, ENTRIES, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
     validateResourcePools(pools);
   }
 
   @Test
   public void testMatchingEqualUnitsWellTiered() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 9, MB, false),
-            new ResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 9, MB, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
     validateResourcePools(pools);
   }
 
   @Test
   public void testMatchingUnequalUnitsWellTiered() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 9, MB, false),
-            new ResourcePoolImpl(OFFHEAP, 10240, KB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 9, MB, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10240, KB, false));
     validateResourcePools(pools);
   }
 
   @Test
   public void testEntryResourceMatch() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 10, ENTRIES, false),
-            new ResourcePoolImpl(OFFHEAP, 10, ENTRIES, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 10, ENTRIES, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, ENTRIES, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -83,9 +84,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testEntryResourceInversion() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 11, ENTRIES, false),
-            new ResourcePoolImpl(OFFHEAP, 10, ENTRIES, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 11, ENTRIES, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, ENTRIES, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -96,9 +97,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceEqualUnitMatch() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 10, MB, false),
-            new ResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 10, MB, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -109,9 +110,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceEqualUnitInversion() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 11, MB, false),
-            new ResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 11, MB, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -122,9 +123,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceUnequalUnitMatch() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 10240, KB, false),
-            new ResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 10240, KB, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -135,9 +136,9 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testMemoryResourceUnequalUnitInversion() {
-    Collection<ResourcePoolImpl> pools = asList(
-            new ResourcePoolImpl(HEAP, 10241, KB, false),
-            new ResourcePoolImpl(OFFHEAP, 10, MB, false));
+    Collection<SizedResourcePoolImpl> pools = asList(
+            new SizedResourcePoolImpl(HEAP, 10241, KB, false),
+            new SizedResourcePoolImpl(OFFHEAP, 10, MB, false));
     try {
       validateResourcePools(pools);
       fail("Expected IllegalArgumentException");
@@ -148,8 +149,10 @@ public class ResourcePoolsImplTest {
 
   @Test
   public void testAddingNewTierWhileUpdating() {
-    ResourcePools existing = new ResourcePoolsImpl(Collections.singletonMap((ResourceType) ResourceType.Core.HEAP, (ResourcePool) new ResourcePoolImpl(ResourceType.Core.HEAP, 10L, EntryUnit.ENTRIES, false)));
-    ResourcePools toBeUpdated = new ResourcePoolsImpl(Collections.singletonMap((ResourceType) ResourceType.Core.DISK, (ResourcePool) new ResourcePoolImpl(ResourceType.Core.DISK, 10L, MemoryUnit.MB, false)));
+    ResourcePools existing = new ResourcePoolsImpl(Collections.singletonMap((ResourceType) ResourceType.Core.HEAP,
+        (ResourcePool) new SizedResourcePoolImpl(ResourceType.Core.HEAP, 10L, EntryUnit.ENTRIES, false)));
+    ResourcePools toBeUpdated = new ResourcePoolsImpl(Collections.singletonMap((ResourceType) ResourceType.Core.DISK,
+        (ResourcePool) new SizedResourcePoolImpl(ResourceType.Core.DISK, 10L, MemoryUnit.MB, false)));
     try {
       existing.validateAndMerge(toBeUpdated);
       fail();
@@ -188,8 +191,8 @@ public class ResourcePoolsImplTest {
     ResourcePools toBeUpdated = ResourcePoolsHelper.createHeapOnlyPools(2, MemoryUnit.GB);
 
     existing = existing.validateAndMerge(toBeUpdated);
-    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getSize(), Matchers.is(2L));
-    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.GB));
+    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getSize(), Matchers.is(2L));
+    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.GB));
   }
 
   @Test
@@ -200,11 +203,11 @@ public class ResourcePoolsImplTest {
     try {
       existing = existing.validateAndMerge(toBeUpdated);
       fail();
-    } catch (UnsupportedOperationException uoe) {
-      assertThat(uoe.getMessage(), Matchers.is("Modifying ResourceUnit type is not supported"));
+    } catch (IllegalArgumentException uoe) {
+      assertThat(uoe.getMessage(), Matchers.is("ResourcePool for heap with ResourceUnit 'entries' can not replace 'MB'"));
     }
-    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getSize(), Matchers.is(20L));
-    assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
+    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getSize(), Matchers.is(20L));
+    assertThat(((SizedResourcePool)existing.getPoolForResource(ResourceType.Core.HEAP)).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
   }
 
 }

--- a/core/src/test/java/org/ehcache/core/internal/store/StoreSupportTest.java
+++ b/core/src/test/java/org/ehcache/core/internal/store/StoreSupportTest.java
@@ -16,9 +16,9 @@
 
 package org.ehcache.core.internal.store;
 
+import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.service.ServiceLocator;
-import org.ehcache.core.internal.store.StoreSupport;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.spi.ServiceProvider;
 import org.ehcache.spi.service.Service;
@@ -42,7 +42,11 @@ import static org.junit.Assert.*;
  */
 public class StoreSupportTest {
 
-  private final ResourceType anyResourceType = new ResourceType() {
+  private final ResourceType<ResourcePool> anyResourceType = new ResourceType<ResourcePool>() {
+    @Override
+    public Class<ResourcePool> getResourcePoolClass() {
+      return ResourcePool.class;
+    }
     @Override
     public boolean isPersistable() {
       return false;
@@ -70,7 +74,7 @@ public class StoreSupportTest {
     final ServiceLocator serviceLocator = new ServiceLocator(storeProviders);
 
     final Store.Provider selectedProvider = StoreSupport.selectStoreProvider(serviceLocator,
-        Collections.singleton(anyResourceType),
+        Collections.<ResourceType<?>>singleton(anyResourceType),
         Collections.<ServiceConfiguration<?>>emptyList());
 
     assertThat(selectedProvider, is(Matchers.<Store.Provider>sameInstance(expectedProvider)));
@@ -96,7 +100,7 @@ public class StoreSupportTest {
 
     try {
       StoreSupport.selectStoreProvider(serviceLocator,
-          Collections.singleton(anyResourceType),
+          Collections.<ResourceType<?>>singleton(anyResourceType),
           Collections.<ServiceConfiguration<?>>emptyList());
       fail();
     } catch (IllegalStateException e) {
@@ -115,7 +119,7 @@ public class StoreSupportTest {
     final ServiceLocator serviceLocator = new ServiceLocator();
     try {
       StoreSupport.selectStoreProvider(serviceLocator,
-          Collections.singleton(anyResourceType),
+          Collections.<ResourceType<?>>singleton(anyResourceType),
           Collections.<ServiceConfiguration<?>>emptyList());
       fail();
     } catch (IllegalStateException e) {
@@ -127,7 +131,11 @@ public class StoreSupportTest {
   @Test
   public void testSelectStoreProviderNoHits() throws Exception {
 
-    final ResourceType otherResourceType = new ResourceType() {
+    final ResourceType<ResourcePool> otherResourceType = new ResourceType<ResourcePool>() {
+      @Override
+      public Class<ResourcePool> getResourcePoolClass() {
+        return ResourcePool.class;
+      }
       @Override
       public boolean isPersistable() {
         return true;
@@ -147,7 +155,7 @@ public class StoreSupportTest {
     final ServiceLocator serviceLocator = new ServiceLocator(storeProviders);
     try {
       StoreSupport.selectStoreProvider(serviceLocator,
-          Collections.singleton(otherResourceType),
+          Collections.<ResourceType<?>>singleton(otherResourceType),
           Collections.<ServiceConfiguration<?>>emptyList());
       fail();
     } catch (IllegalStateException e) {
@@ -214,7 +222,7 @@ public class StoreSupportTest {
     }
 
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       assertThat(resourceTypes, is(not(nullValue())));
       assertThat(serviceConfigs, is(not(nullValue())));
       rankAccessCount.incrementAndGet();

--- a/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
@@ -17,6 +17,7 @@
 package org.ehcache.config.builders;
 
 import org.ehcache.config.ResourcePool;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.core.config.SizedResourcePoolImpl;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.core.config.ResourcePoolsImpl;
@@ -40,13 +41,13 @@ import static org.ehcache.core.config.ResourcePoolsImpl.validateResourcePools;
  */
 public class ResourcePoolsBuilder implements Builder<ResourcePools> {
 
-  private final Map<ResourceType, ResourcePool> resourcePools;
+  private final Map<ResourceType<?>, ResourcePool> resourcePools;
 
   private ResourcePoolsBuilder() {
-    this(Collections.<ResourceType, ResourcePool>emptyMap());
+    this(Collections.<ResourceType<?>, ResourcePool>emptyMap());
   }
 
-  private ResourcePoolsBuilder(Map<ResourceType, ResourcePool> resourcePools) {
+  private ResourcePoolsBuilder(Map<ResourceType<?>, ResourcePool> resourcePools) {
     validateResourcePools(resourcePools.values());
     this.resourcePools = unmodifiableMap(resourcePools);
   }
@@ -68,7 +69,7 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    */
   public static ResourcePoolsBuilder newResourcePoolsBuilder(ResourcePools pools) {
     ResourcePoolsBuilder poolsBuilder = new ResourcePoolsBuilder();
-    for (ResourceType currentResourceType : pools.getResourceTypeSet()) {
+    for (ResourceType<?> currentResourceType : pools.getResourceTypeSet()) {
       poolsBuilder = poolsBuilder.with(pools.getPoolForResource(currentResourceType));
     }
     return poolsBuilder;
@@ -83,12 +84,12 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
   public ResourcePoolsBuilder with(ResourcePool resourcePool) {
-    final ResourceType type = resourcePool.getType();
+    final ResourceType<?> type = resourcePool.getType();
     final ResourcePool existingPool = resourcePools.get(type);
     if (existingPool != null) {
       throw new IllegalArgumentException("Can not add '" + resourcePool + "'; configuration already contains '" + existingPool + "'");
     }
-    Map<ResourceType, ResourcePool> newPools = new HashMap<ResourceType, ResourcePool>(resourcePools);
+    Map<ResourceType<?>, ResourcePool> newPools = new HashMap<ResourceType<?>, ResourcePool>(resourcePools);
     newPools.put(type, resourcePool);
     return new ResourcePoolsBuilder(newPools);
   }
@@ -100,7 +101,7 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @return a new builder with the added pool
    */
   public ResourcePoolsBuilder withReplacing(ResourcePool resourcePool) {
-    Map<ResourceType, ResourcePool> newPools = new HashMap<ResourceType, ResourcePool>(resourcePools);
+    Map<ResourceType<?>, ResourcePool> newPools = new HashMap<ResourceType<?>, ResourcePool>(resourcePools);
     newPools.put(resourcePool.getType(), resourcePool);
     return new ResourcePoolsBuilder(newPools);
   }
@@ -116,8 +117,8 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    *
    * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
-  public ResourcePoolsBuilder with(ResourceType type, long size, ResourceUnit unit, boolean persistent) {
-    return with(new SizedResourcePoolImpl(type, size, unit, persistent));
+  public ResourcePoolsBuilder with(ResourceType<SizedResourcePool> type, long size, ResourceUnit unit, boolean persistent) {
+    return with(new SizedResourcePoolImpl<SizedResourcePool>(type, size, unit, persistent));
   }
 
   /**

--- a/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
@@ -99,7 +99,6 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param resourcePool the non-{@code null} resource pool to add/replace
    * @return a new builder with the added pool
    */
-  // TODO: Determine the use case for this method
   public ResourcePoolsBuilder withReplacing(ResourcePool resourcePool) {
     Map<ResourceType, ResourcePool> newPools = new HashMap<ResourceType, ResourcePool>(resourcePools);
     newPools.put(resourcePool.getType(), resourcePool);
@@ -128,7 +127,7 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param unit the pool size unit
    * @return a new builder with the added pool
    *
-   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
+   * @throws IllegalArgumentException if the set of resource pools already contains a heap resource
    */
   public ResourcePoolsBuilder heap(long size, ResourceUnit unit) {
     return with(ResourceType.Core.HEAP, size, unit, false);
@@ -141,7 +140,7 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param unit the pool size unit
    * @return a new builder with the added pool
    *
-   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
+   * @throws IllegalArgumentException if the set of resource pools already contains an offheap resource
    */
   public ResourcePoolsBuilder offheap(long size, MemoryUnit unit) {
     return with(ResourceType.Core.OFFHEAP, size, unit, false);
@@ -154,7 +153,7 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param unit the pool size unit
    * @return a new builder with the added pool
    *
-   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
+   * @throws IllegalArgumentException if the set of resource pools already contains a disk resource
    */
   public ResourcePoolsBuilder disk(long size, MemoryUnit unit) {
     return disk(size, unit, false);
@@ -168,7 +167,7 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param persistent if the pool is persistent or not
    * @return a new builder with the added pool
    *
-   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
+   * @throws IllegalArgumentException if the set of resource pools already contains a disk resource
    */
   public ResourcePoolsBuilder disk(long size, MemoryUnit unit, boolean persistent) {
     return with(ResourceType.Core.DISK, size, unit, persistent);

--- a/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
@@ -17,7 +17,7 @@
 package org.ehcache.config.builders;
 
 import org.ehcache.config.ResourcePool;
-import org.ehcache.core.config.ResourcePoolImpl;
+import org.ehcache.core.config.SizedResourcePoolImpl;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.core.config.ResourcePoolsImpl;
 import org.ehcache.config.ResourceType;
@@ -69,25 +69,56 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
   public static ResourcePoolsBuilder newResourcePoolsBuilder(ResourcePools pools) {
     ResourcePoolsBuilder poolsBuilder = new ResourcePoolsBuilder();
     for (ResourceType currentResourceType : pools.getResourceTypeSet()) {
-      poolsBuilder = poolsBuilder.with(currentResourceType, pools.getPoolForResource(currentResourceType).getSize(),
-          pools.getPoolForResource(currentResourceType).getUnit(), pools.getPoolForResource(currentResourceType).isPersistent());
+      poolsBuilder = poolsBuilder.with(pools.getPoolForResource(currentResourceType));
     }
     return poolsBuilder;
   }
 
   /**
-   * Adds or replace the {@link ResourcePool} of {@link ResourceType} in the returned builder.
+   * Add the {@link ResourcePool} of {@link ResourceType} in the returned builder.
+   *
+   * @param resourcePool the non-{@code null} resource pool to add
+   * @return a new builder with the added pool
+   *
+   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
+   */
+  public ResourcePoolsBuilder with(ResourcePool resourcePool) {
+    final ResourceType type = resourcePool.getType();
+    final ResourcePool existingPool = resourcePools.get(type);
+    if (existingPool != null) {
+      throw new IllegalArgumentException("Can not add '" + resourcePool + "'; configuration already contains '" + existingPool + "'");
+    }
+    Map<ResourceType, ResourcePool> newPools = new HashMap<ResourceType, ResourcePool>(resourcePools);
+    newPools.put(type, resourcePool);
+    return new ResourcePoolsBuilder(newPools);
+  }
+
+  /**
+   * Add or replace the {@link ResourcePool} of {@link ResourceType} in the returned builder.
+   *
+   * @param resourcePool the non-{@code null} resource pool to add/replace
+   * @return a new builder with the added pool
+   */
+  // TODO: Determine the use case for this method
+  public ResourcePoolsBuilder withReplacing(ResourcePool resourcePool) {
+    Map<ResourceType, ResourcePool> newPools = new HashMap<ResourceType, ResourcePool>(resourcePools);
+    newPools.put(resourcePool.getType(), resourcePool);
+    return new ResourcePoolsBuilder(newPools);
+  }
+
+  /**
+   * Add the {@link ResourcePool} of {@link ResourceType} in the returned builder.
    *
    * @param type the resource type
    * @param size the pool size
    * @param unit the pool size unit
    * @param persistent if the pool is to be persistent
    * @return a new builder with the added pool
+   *
+   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
   public ResourcePoolsBuilder with(ResourceType type, long size, ResourceUnit unit, boolean persistent) {
-    Map<ResourceType, ResourcePool> newPools = new HashMap<ResourceType, ResourcePool>(resourcePools);
-    newPools.put(type, new ResourcePoolImpl(type, size, unit, persistent));
-    return new ResourcePoolsBuilder(newPools);
+    return with(new SizedResourcePoolImpl(type, size, unit, persistent));
   }
 
   /**
@@ -96,6 +127,8 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param size the pool size
    * @param unit the pool size unit
    * @return a new builder with the added pool
+   *
+   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
   public ResourcePoolsBuilder heap(long size, ResourceUnit unit) {
     return with(ResourceType.Core.HEAP, size, unit, false);
@@ -107,6 +140,8 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param size the pool size
    * @param unit the pool size unit
    * @return a new builder with the added pool
+   *
+   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
   public ResourcePoolsBuilder offheap(long size, MemoryUnit unit) {
     return with(ResourceType.Core.OFFHEAP, size, unit, false);
@@ -118,6 +153,8 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param size the pool size
    * @param unit the pool size unit
    * @return a new builder with the added pool
+   *
+   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
   public ResourcePoolsBuilder disk(long size, MemoryUnit unit) {
     return disk(size, unit, false);
@@ -130,6 +167,8 @@ public class ResourcePoolsBuilder implements Builder<ResourcePools> {
    * @param unit the pool size unit
    * @param persistent if the pool is persistent or not
    * @return a new builder with the added pool
+   *
+   * @throws IllegalArgumentException if the set of resource pools already contains a pool for {@code type}
    */
   public ResourcePoolsBuilder disk(long size, MemoryUnit unit, boolean persistent) {
     return with(ResourceType.Core.DISK, size, unit, persistent);

--- a/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -197,7 +197,7 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> imp
       serviceConfigsList.add(new DefaultCopierConfiguration<K>((Class) SerializingCopier.class, DefaultCopierConfiguration.Type.VALUE));
     }
 
-    Set<ResourceType> resources = resourcePools.getResourceTypeSet();
+    Set<ResourceType<?>> resources = resourcePools.getResourceTypeSet();
     boolean persistent = resources.contains(DISK);
     if (persistent) {
       if (id == null) {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -251,7 +251,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
     }
 
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       return resourceTypes.equals(Collections.singleton(ResourceType.Core.DISK)) ? 1 : 0;
     }
 
@@ -267,7 +267,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
       TimeSource timeSource = serviceProvider.getService(TimeSourceService.class).getTimeSource();
       ExecutionService executionService = serviceProvider.getService(ExecutionService.class);
 
-      SizedResourcePool diskPool = (SizedResourcePool)storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
+      SizedResourcePool diskPool = storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
       if (!(diskPool.getUnit() instanceof MemoryUnit)) {
         throw new IllegalArgumentException("OffHeapDiskStore only supports resources configuration expressed in \"memory\" unit");
       }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -16,11 +16,11 @@
 
 package org.ehcache.impl.internal.store.disk;
 
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.core.CacheConfigurationChangeListener;
 import org.ehcache.Status;
 import org.ehcache.config.Eviction;
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration;
 import org.ehcache.config.units.MemoryUnit;
@@ -267,7 +267,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
       TimeSource timeSource = serviceProvider.getService(TimeSourceService.class).getTimeSource();
       ExecutionService executionService = serviceProvider.getService(ExecutionService.class);
 
-      ResourcePool diskPool = storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
+      SizedResourcePool diskPool = (SizedResourcePool)storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
       if (!(diskPool.getUnit() instanceof MemoryUnit)) {
         throw new IllegalArgumentException("OffHeapDiskStore only supports resources configuration expressed in \"memory\" unit");
       }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -163,10 +163,10 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       if(event.getProperty().equals(CacheConfigurationProperty.UPDATE_SIZE)) {
         ResourcePools updatedPools = (ResourcePools)event.getNewValue();
         ResourcePools configuredPools = (ResourcePools)event.getOldValue();
-        if(((SizedResourcePool)updatedPools.getPoolForResource(ResourceType.Core.HEAP)).getSize() !=
-            ((SizedResourcePool)configuredPools.getPoolForResource(ResourceType.Core.HEAP)).getSize()) {
-          LOG.info("Setting size: " + ((SizedResourcePool)updatedPools.getPoolForResource(ResourceType.Core.HEAP)).getSize());
-          SizedResourcePool pool = (SizedResourcePool)updatedPools.getPoolForResource(ResourceType.Core.HEAP);
+        if(updatedPools.getPoolForResource(ResourceType.Core.HEAP).getSize() !=
+            configuredPools.getPoolForResource(ResourceType.Core.HEAP).getSize()) {
+          LOG.info("Setting size: " + updatedPools.getPoolForResource(ResourceType.Core.HEAP).getSize());
+          SizedResourcePool pool = updatedPools.getPoolForResource(ResourceType.Core.HEAP);
           if (pool.getUnit() instanceof MemoryUnit) {
             capacity = ((MemoryUnit)pool.getUnit()).toBytes(pool.getSize());
           } else {
@@ -209,7 +209,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
     if (valueCopier == null) {
       throw new NullPointerException("valueCopier must not be null");
     }
-    SizedResourcePool heapPool = (SizedResourcePool)config.getResourcePools().getPoolForResource(ResourceType.Core.HEAP);
+    SizedResourcePool heapPool = config.getResourcePools().getPoolForResource(ResourceType.Core.HEAP);
     if (heapPool == null) {
       throw new IllegalArgumentException("OnHeap store must be configured with a resource of type 'heap'");
     }
@@ -1553,7 +1553,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
     private final Set<Store<?, ?>> createdStores = Collections.newSetFromMap(new ConcurrentWeakIdentityHashMap<Store<?, ?>, Boolean>());
 
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       return resourceTypes.equals(Collections.singleton(ResourceType.Core.HEAP)) ? 1 : 0;
     }
 
@@ -1571,7 +1571,7 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
 
       SizeOfEngineProvider sizeOfEngineProvider = serviceProvider.getService(SizeOfEngineProvider.class);
       SizeOfEngine sizeOfEngine = sizeOfEngineProvider.createSizeOfEngine(
-          ((SizedResourcePool)storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP)).getUnit(), serviceConfigs);
+          storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getUnit(), serviceConfigs);
       OnHeapStore<K, V> onHeapStore = new OnHeapStore<K, V>(storeConfig, timeSource, keyCopier, valueCopier, sizeOfEngine, eventDispatcher);
       createdStores.add(onHeapStore);
       return onHeapStore;

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
@@ -16,10 +16,10 @@
 
 package org.ehcache.impl.internal.store.offheap;
 
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.core.CacheConfigurationChangeListener;
 import org.ehcache.config.Eviction;
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.core.events.StoreEventDispatcher;
@@ -135,7 +135,7 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
       }
       TimeSource timeSource = serviceProvider.getService(TimeSourceService.class).getTimeSource();
 
-      ResourcePool offHeapPool = storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP);
+      SizedResourcePool offHeapPool = (SizedResourcePool)storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP);
       if (!(offHeapPool.getUnit() instanceof MemoryUnit)) {
         throw new IllegalArgumentException("OffHeapStore only supports resources with memory unit");
       }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
@@ -120,7 +120,7 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
     private final Set<Store<?, ?>> createdStores = Collections.newSetFromMap(new ConcurrentWeakIdentityHashMap<Store<?, ?>, Boolean>());
 
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       return resourceTypes.equals(Collections.singleton(ResourceType.Core.OFFHEAP)) ? 1 : 0;
     }
 
@@ -135,7 +135,7 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
       }
       TimeSource timeSource = serviceProvider.getService(TimeSourceService.class).getTimeSource();
 
-      SizedResourcePool offHeapPool = (SizedResourcePool)storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP);
+      SizedResourcePool offHeapPool = storeConfig.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP);
       if (!(offHeapPool.getUnit() instanceof MemoryUnit)) {
         throw new IllegalArgumentException("OffHeapStore only supports resources with memory unit");
       }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/tiering/CacheStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/tiering/CacheStore.java
@@ -347,7 +347,7 @@ public class CacheStore<K, V> implements Store<K, V> {
     private final ConcurrentMap<Store<?, ?>, Map.Entry<CachingTier.Provider, AuthoritativeTier.Provider>> providersMap = new ConcurrentWeakIdentityHashMap<Store<?, ?>, Map.Entry<CachingTier.Provider, AuthoritativeTier.Provider>>();
 
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       if (SUPPORTED_RESOURCE_COMBINATIONS.contains(resourceTypes)) {
         return resourceTypes.size();
       } else {

--- a/impl/src/main/java/org/ehcache/impl/persistence/DefaultLocalPersistenceService.java
+++ b/impl/src/main/java/org/ehcache/impl/persistence/DefaultLocalPersistenceService.java
@@ -171,7 +171,7 @@ public class DefaultLocalPersistenceService implements LocalPersistenceService {
    * {@inheritDoc}
    */
   @Override
-  public boolean handlesResourceType(ResourceType resourceType) {
+  public boolean handlesResourceType(ResourceType<?> resourceType) {
     return ResourceType.Core.DISK.equals(resourceType);
   }
 

--- a/impl/src/test/java/org/ehcache/EhcacheRuntimeConfigurationTest.java
+++ b/impl/src/test/java/org/ehcache/EhcacheRuntimeConfigurationTest.java
@@ -17,6 +17,7 @@
 package org.ehcache;
 
 import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
@@ -53,12 +54,12 @@ public class EhcacheRuntimeConfigurationTest {
     poolsBuilder = poolsBuilder.heap(20L, EntryUnit.ENTRIES);
     ResourcePools pools = poolsBuilder.build();
     cache.getRuntimeConfiguration().updateResourcePools(pools);
-    assertThat(cache.getRuntimeConfiguration().getResourcePools()
-        .getPoolForResource(ResourceType.Core.HEAP).getSize(), is(20L));
+    assertThat(((SizedResourcePool)cache.getRuntimeConfiguration().getResourcePools()
+        .getPoolForResource(ResourceType.Core.HEAP)).getSize(), is(20L));
     pools = poolsBuilder.build();
     cache.getRuntimeConfiguration().updateResourcePools(pools);
-    assertThat(cache.getRuntimeConfiguration().getResourcePools()
-        .getPoolForResource(ResourceType.Core.HEAP).getSize(), is(20L));
+    assertThat(((SizedResourcePool)cache.getRuntimeConfiguration().getResourcePools()
+        .getPoolForResource(ResourceType.Core.HEAP)).getSize(), is(20L));
     cacheManager.close();
   }
 
@@ -82,8 +83,8 @@ public class EhcacheRuntimeConfigurationTest {
 //      expected
       assertThat(iae.getMessage(), is("Pools to be updated cannot contain previously undefined resources pools"));
     }
-    assertThat(cache.getRuntimeConfiguration().getResourcePools()
-        .getPoolForResource(ResourceType.Core.HEAP).getSize(), is(10L));
+    assertThat(((SizedResourcePool)cache.getRuntimeConfiguration().getResourcePools()
+        .getPoolForResource(ResourceType.Core.HEAP)).getSize(), is(10L));
     cacheManager.close();
   }
 }

--- a/impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
@@ -20,6 +20,7 @@ import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.ResourceUnit;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.exceptions.BulkCacheWritingException;
@@ -255,7 +256,7 @@ public class CacheConfigurationBuilderTest {
         .withExpiry(expiry)
         .build();
     assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getType(), Matchers.<ResourceType>is(ResourceType.Core.OFFHEAP));
-    assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
+    assertThat(((SizedResourcePool)config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP)).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
@@ -20,7 +20,6 @@ import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.ResourceUnit;
-import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.exceptions.BulkCacheWritingException;
@@ -256,7 +255,7 @@ public class CacheConfigurationBuilderTest {
         .withExpiry(expiry)
         .build();
     assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getType(), Matchers.<ResourceType>is(ResourceType.Core.OFFHEAP));
-    assertThat(((SizedResourcePool)config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP)).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
+    assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/config/builders/ResourcePoolsBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/ResourcePoolsBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.config.builders;
+
+import org.ehcache.config.SizedResourcePool;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.config.SizedResourcePoolImpl;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.ehcache.config.ResourceType.Core.HEAP;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class ResourcePoolsBuilderTest {
+
+  @Test
+  public void testPreExistingWith() throws Exception {
+    ResourcePoolsBuilder builder = ResourcePoolsBuilder.newResourcePoolsBuilder();
+    builder = builder.heap(8, MemoryUnit.MB);
+
+    try {
+      builder.with(new SizedResourcePoolImpl(HEAP, 16, MemoryUnit.MB, false));
+      fail("Expecting IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(),
+          Matchers.containsString("Can not add 'Pool {16 MB heap}'; configuration already contains 'Pool {8 MB heap}'"));
+    }
+  }
+
+  @Test
+  public void testWithReplacing() throws Exception {
+    ResourcePoolsBuilder builder = ResourcePoolsBuilder.newResourcePoolsBuilder();
+    builder = builder.heap(8, MemoryUnit.MB);
+
+    SizedResourcePool newPool = new SizedResourcePoolImpl(HEAP, 16, MemoryUnit.MB, false);
+
+    builder = builder.withReplacing(newPool);
+
+    final SizedResourcePool heapPool = ((SizedResourcePool)builder.build().getPoolForResource(HEAP)) ;
+    assertThat(heapPool.isPersistent(), is(equalTo(newPool.isPersistent())));
+    assertThat(heapPool.getSize(), is(equalTo(newPool.getSize())));
+    assertThat(heapPool.getUnit(), is(equalTo(newPool.getUnit())));
+  }
+}

--- a/impl/src/test/java/org/ehcache/config/builders/ResourcePoolsBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/ResourcePoolsBuilderTest.java
@@ -35,7 +35,7 @@ public class ResourcePoolsBuilderTest {
     builder = builder.heap(8, MemoryUnit.MB);
 
     try {
-      builder.with(new SizedResourcePoolImpl(HEAP, 16, MemoryUnit.MB, false));
+      builder.with(new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 16, MemoryUnit.MB, false));
       fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage(),
@@ -48,11 +48,11 @@ public class ResourcePoolsBuilderTest {
     ResourcePoolsBuilder builder = ResourcePoolsBuilder.newResourcePoolsBuilder();
     builder = builder.heap(8, MemoryUnit.MB);
 
-    SizedResourcePool newPool = new SizedResourcePoolImpl(HEAP, 16, MemoryUnit.MB, false);
+    SizedResourcePool newPool = new SizedResourcePoolImpl<SizedResourcePool>(HEAP, 16, MemoryUnit.MB, false);
 
     builder = builder.withReplacing(newPool);
 
-    final SizedResourcePool heapPool = ((SizedResourcePool)builder.build().getPoolForResource(HEAP)) ;
+    final SizedResourcePool heapPool = builder.build().getPoolForResource(HEAP);
     assertThat(heapPool.isPersistent(), is(equalTo(newPool.isPersistent())));
     assertThat(heapPool.getSize(), is(equalTo(newPool.getSize())));
     assertThat(heapPool.getUnit(), is(equalTo(newPool.getUnit())));

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -22,12 +22,12 @@ import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.builders.WriteBehindConfigurationBuilder;
 import org.ehcache.config.builders.CacheEventListenerConfigurationBuilder;
-import org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.docs.plugs.CharSequenceSerializer;
@@ -313,8 +313,8 @@ public class GettingStarted {
     // tag::updateResourcesAtRuntime[]
     ResourcePools pools = ResourcePoolsBuilder.newResourcePoolsBuilder().heap(20L, EntryUnit.ENTRIES).build(); // <1>
     cache.getRuntimeConfiguration().updateResourcePools(pools); // <2>
-    assertThat(cache.getRuntimeConfiguration().getResourcePools()
-        .getPoolForResource(ResourceType.Core.HEAP).getSize(), is(20L));
+    assertThat(((SizedResourcePool)cache.getRuntimeConfiguration().getResourcePools()
+        .getPoolForResource(ResourceType.Core.HEAP)).getSize(), is(20L));
     // end::updateResourcesAtRuntime[]
 
     for(long i = 0; i < 20; i++ ){

--- a/impl/src/test/java/org/ehcache/impl/internal/persistence/TestLocalPersistenceService.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/persistence/TestLocalPersistenceService.java
@@ -71,7 +71,7 @@ public class TestLocalPersistenceService extends ExternalResource implements Loc
   }
 
   @Override
-  public boolean handlesResourceType(ResourceType resourceType) {
+  public boolean handlesResourceType(ResourceType<?> resourceType) {
     return persistenceService.handlesResourceType(resourceType);
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreSPITest.java
@@ -17,9 +17,9 @@
 package org.ehcache.impl.internal.store.disk;
 
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.exceptions.CachePersistenceException;
@@ -104,7 +104,7 @@ public class OffHeapDiskStoreSPITest extends AuthoritativeTierSPITest<String, St
           String spaceName = "OffheapDiskStore-" + index.getAndIncrement();
           PersistenceSpaceIdentifier space = persistenceService.getOrCreatePersistenceSpace(spaceName);
           ResourcePools resourcePools = getDiskResourcePool(capacity);
-          ResourcePool diskPool = resourcePools.getPoolForResource(DISK);
+          SizedResourcePool diskPool = (SizedResourcePool)resourcePools.getPoolForResource(DISK);
           MemoryUnit unit = (MemoryUnit)diskPool.getUnit();
 
           Store.Configuration<String, String> config = new StoreConfigurationImpl<String, String>(getKeyType(), getValueType(),

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
@@ -17,6 +17,7 @@
 package org.ehcache.impl.internal.store.disk;
 
 import org.ehcache.config.EvictionVeto;
+import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
@@ -167,12 +168,15 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     assertRank(provider, 0, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
     assertRank(provider, 0, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
 
-    final ResourceType unmatchedResourceType = new ResourceType() {
+    final ResourceType<ResourcePool> unmatchedResourceType = new ResourceType<ResourcePool>() {
+      @Override
+      public Class<ResourcePool> getResourcePoolClass() {
+        return ResourcePool.class;
+      }
       @Override
       public boolean isPersistable() {
         return true;
       }
-
       @Override
       public boolean requiresSerialization() {
         return true;
@@ -182,9 +186,9 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     assertRank(provider, 0, ResourceType.Core.DISK, unmatchedResourceType);
   }
 
-  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType... resources) {
+  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType<?>... resources) {
     assertThat(provider.rank(
-        new HashSet<ResourceType>(Arrays.asList(resources)),
+        new HashSet<ResourceType<?>>(Arrays.asList(resources)),
         Collections.<ServiceConfiguration<?>>emptyList()),
         is(expectedRank));
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreProviderTest.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.impl.internal.store.heap;
 
+import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -45,12 +46,15 @@ public class OnHeapStoreProviderTest {
     assertRank(provider, 0, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
     assertRank(provider, 0, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
 
-    final ResourceType unmatchedResourceType = new ResourceType() {
+    final ResourceType<ResourcePool> unmatchedResourceType = new ResourceType<ResourcePool>() {
+      @Override
+      public Class<ResourcePool> getResourcePoolClass() {
+        return ResourcePool.class;
+      }
       @Override
       public boolean isPersistable() {
         return true;
       }
-
       @Override
       public boolean requiresSerialization() {
         return true;
@@ -61,9 +65,9 @@ public class OnHeapStoreProviderTest {
     assertRank(provider, 0, ResourceType.Core.HEAP, unmatchedResourceType);
   }
 
-  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType... resources) {
+  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType<?>... resources) {
     assertThat(provider.rank(
-        new HashSet<ResourceType>(Arrays.asList(resources)),
+        new HashSet<ResourceType<?>>(Arrays.asList(resources)),
         Collections.<ServiceConfiguration<?>>emptyList()),
         is(expectedRank));
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreSPITest.java
@@ -17,9 +17,9 @@
 package org.ehcache.impl.internal.store.offheap;
 
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.expiry.Expirations;
@@ -78,7 +78,7 @@ public class OffHeapStoreSPITest extends AuthoritativeTierSPITest<String, String
         Serializer<String> valueSerializer = new JavaSerializer<String>(getClass().getClassLoader());
 
         ResourcePools resourcePools = getOffHeapResourcePool(capacity);
-        ResourcePool offheapPool = resourcePools.getPoolForResource(OFFHEAP);
+        SizedResourcePool offheapPool = (SizedResourcePool)resourcePools.getPoolForResource(OFFHEAP);
         MemoryUnit unit = (MemoryUnit)offheapPool.getUnit();
 
         Store.Configuration<String, String> config = new StoreConfigurationImpl<String, String>(getKeyType(), getValueType(),

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreTest.java
@@ -17,6 +17,7 @@
 package org.ehcache.impl.internal.store.offheap;
 
 import org.ehcache.config.EvictionVeto;
+import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
 import org.ehcache.config.units.MemoryUnit;
@@ -89,12 +90,15 @@ public class OffHeapStoreTest extends AbstractOffHeapStoreTest {
     assertRank(provider, 0, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
     assertRank(provider, 0, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
 
-    final ResourceType unmatchedResourceType = new ResourceType() {
+    final ResourceType<ResourcePool> unmatchedResourceType = new ResourceType<ResourcePool>() {
+      @Override
+      public Class<ResourcePool> getResourcePoolClass() {
+        return ResourcePool.class;
+      }
       @Override
       public boolean isPersistable() {
         return true;
       }
-
       @Override
       public boolean requiresSerialization() {
         return true;
@@ -105,9 +109,9 @@ public class OffHeapStoreTest extends AbstractOffHeapStoreTest {
     assertRank(provider, 0, ResourceType.Core.OFFHEAP, unmatchedResourceType);
   }
 
-  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType... resources) {
+  private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType<?>... resources) {
     assertThat(provider.rank(
-        new HashSet<ResourceType>(Arrays.asList(resources)),
+        new HashSet<ResourceType<?>>(Arrays.asList(resources)),
         Collections.<ServiceConfiguration<?>>emptyList()),
         is(expectedRank));
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/CacheStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/CacheStoreSPITest.java
@@ -17,10 +17,10 @@
 package org.ehcache.impl.internal.store.tiering;
 
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
@@ -128,7 +128,7 @@ public class CacheStoreSPITest extends StoreSPITest<String, String> {
           LocalPersistenceService.PersistenceSpaceIdentifier space = persistenceService.getOrCreatePersistenceSpace(spaceName);
           FileBasedPersistenceContext persistenceContext = persistenceService.createPersistenceContextWithin(space, "store");
 
-          ResourcePool diskPool = config.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
+          SizedResourcePool diskPool = (SizedResourcePool)config.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
           MemoryUnit unit = (MemoryUnit) diskPool.getUnit();
 
           long sizeInBytes = unit.toBytes(diskPool.getSize());

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/CacheStoreWith3TiersSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/CacheStoreWith3TiersSPITest.java
@@ -17,10 +17,10 @@
 package org.ehcache.impl.internal.store.tiering;
 
 import org.ehcache.config.EvictionVeto;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
@@ -127,7 +127,7 @@ public class CacheStoreWith3TiersSPITest extends StoreSPITest<String, String> {
         StoreEventDispatcher<String, String> noOpEventDispatcher = NullStoreEventDispatcher.<String, String>nullStoreEventDispatcher();
         final OnHeapStore<String, String> onHeapStore = new OnHeapStore<String, String>(config, timeSource, defaultCopier, defaultCopier, new NoopSizeOfEngine(), noOpEventDispatcher);
 
-        ResourcePool offheapPool = config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP);
+        SizedResourcePool offheapPool = (SizedResourcePool)config.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP);
         long offheapSize = ((MemoryUnit) offheapPool.getUnit()).toBytes(offheapPool.getSize());
 
         final OffHeapStore<String, String> offHeapStore = new OffHeapStore<String, String>(config, timeSource, noOpEventDispatcher, offheapSize);
@@ -137,7 +137,7 @@ public class CacheStoreWith3TiersSPITest extends StoreSPITest<String, String> {
           LocalPersistenceService.PersistenceSpaceIdentifier space = persistenceService.getOrCreatePersistenceSpace(spaceName);
           FileBasedPersistenceContext persistenceContext = persistenceService.createPersistenceContextWithin(space, "store");
 
-          ResourcePool diskPool = config.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
+          SizedResourcePool diskPool = (SizedResourcePool)config.getResourcePools().getPoolForResource(ResourceType.Core.DISK);
           long diskSize = ((MemoryUnit) diskPool.getUnit()).toBytes(diskPool.getSize());
 
           OffHeapDiskStore<String, String> diskStore = new OffHeapDiskStore<String, String>(

--- a/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
@@ -506,7 +506,7 @@ public class EhcacheBulkMethodsITest {
    */
   private static class CustomStoreProvider implements Store.Provider {
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       return Integer.MAX_VALUE;     // Ensure this Store.Provider is ranked highest
     }
 

--- a/integration-test/src/test/java/org/ehcache/integration/UserManagedCacheEvictionTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/UserManagedCacheEvictionTest.java
@@ -17,6 +17,7 @@ package org.ehcache.integration;
 
 import org.ehcache.UserManagedCache;
 import org.ehcache.config.ResourceType;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.UserManagedCacheBuilder;
 import org.ehcache.config.units.EntryUnit;
 import org.junit.Test;
@@ -37,7 +38,8 @@ public class UserManagedCacheEvictionTest {
     UserManagedCache<Number, String> cache = UserManagedCacheBuilder.newUserManagedCacheBuilder(Number.class, String.class)
         .withResourcePools(newResourcePoolsBuilder().heap(1, EntryUnit.ENTRIES))
         .build(true);
-    assertThat(cache.getRuntimeConfiguration().getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(),
+    assertThat(((SizedResourcePool)cache.getRuntimeConfiguration()
+            .getResourcePools().getPoolForResource(ResourceType.Core.HEAP)).getSize(),
         equalTo(1L));
 
     // we put 3 elements, but there's only capacity for 1

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
@@ -745,7 +745,7 @@ public class XAStore<K, V> implements Store<K, V> {
       }
 
       final Store.Provider candidateUnderlyingProvider = selectProvider(resourceTypes, serviceConfigs, xaServiceConfiguration);
-      return 10 + candidateUnderlyingProvider.rank(resourceTypes, serviceConfigs);
+      return 1000 + candidateUnderlyingProvider.rank(resourceTypes, serviceConfigs);
     }
 
     @Override

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
@@ -737,7 +737,7 @@ public class XAStore<K, V> implements Store<K, V> {
     private final Map<Store<?, ?>, CreatedStoreRef> createdStores = new ConcurrentWeakIdentityHashMap<Store<?, ?>, CreatedStoreRef>();
 
     @Override
-    public int rank(final Set<ResourceType> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
+    public int rank(final Set<ResourceType<?>> resourceTypes, final Collection<ServiceConfiguration<?>> serviceConfigs) {
       final XAStoreConfiguration xaServiceConfiguration = findSingletonAmongst(XAStoreConfiguration.class, serviceConfigs);
       if (xaServiceConfiguration == null) {
         // An XAStore must be configured for use
@@ -968,7 +968,7 @@ public class XAStore<K, V> implements Store<K, V> {
       this.serviceProvider = null;
     }
 
-    private Store.Provider selectProvider(final Set<ResourceType> resourceTypes,
+    private Store.Provider selectProvider(final Set<ResourceType<?>> resourceTypes,
                                           final Collection<ServiceConfiguration<?>> serviceConfigs,
                                           final XAStoreConfiguration xaConfig) {
       List<ServiceConfiguration<?>> configsWithoutXA = new ArrayList<ServiceConfiguration<?>>(serviceConfigs);

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
@@ -18,6 +18,7 @@ package org.ehcache.transactions.xa.internal;
 
 import org.ehcache.Cache;
 import org.ehcache.ValueSupplier;
+import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.EntryUnit;
@@ -1479,12 +1480,15 @@ public class XAStoreTest {
     final Set<ServiceConfiguration<?>> emptyConfigs = Collections.emptySet();
     assertRank(provider, 0, emptyConfigs, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
 
-    final ResourceType unmatchedResourceType = new ResourceType() {
+    final ResourceType<ResourcePool> unmatchedResourceType = new ResourceType<ResourcePool>() {
+      @Override
+      public Class<ResourcePool> getResourcePoolClass() {
+        return ResourcePool.class;
+      }
       @Override
       public boolean isPersistable() {
         return true;
       }
-
       @Override
       public boolean requiresSerialization() {
         return true;
@@ -1496,17 +1500,17 @@ public class XAStoreTest {
   }
 
   private void assertRank(final Store.Provider provider, final int expectedRank,
-                          final Collection<ServiceConfiguration<?>> serviceConfigs, final ResourceType... resources) {
+                          final Collection<ServiceConfiguration<?>> serviceConfigs, final ResourceType<?>... resources) {
     if (expectedRank == -1) {
       try {
-        provider.rank(new HashSet<ResourceType>(Arrays.asList(resources)), serviceConfigs);
+        provider.rank(new HashSet<ResourceType<?>>(Arrays.asList(resources)), serviceConfigs);
         fail();
       } catch (IllegalStateException e) {
         // Expected
         assertThat(e.getMessage(), startsWith("No Store.Provider "));
       }
     } else {
-      assertThat(provider.rank(new HashSet<ResourceType>(Arrays.asList(resources)), serviceConfigs), is(expectedRank));
+      assertThat(provider.rank(new HashSet<ResourceType<?>>(Arrays.asList(resources)), serviceConfigs), is(expectedRank));
     }
   }
 

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
@@ -1468,13 +1468,13 @@ public class XAStoreTest {
     provider.start(serviceLocator);
 
     final Set<ServiceConfiguration<?>> xaStoreConfigs = Collections.<ServiceConfiguration<?>>singleton(configuration);
-    assertRank(provider, 11, xaStoreConfigs, ResourceType.Core.HEAP);
-    assertRank(provider, 11, xaStoreConfigs, ResourceType.Core.OFFHEAP);
-    assertRank(provider, 11, xaStoreConfigs, ResourceType.Core.DISK);
-    assertRank(provider, 12, xaStoreConfigs, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+    assertRank(provider, 1001, xaStoreConfigs, ResourceType.Core.HEAP);
+    assertRank(provider, 1001, xaStoreConfigs, ResourceType.Core.OFFHEAP);
+    assertRank(provider, 1001, xaStoreConfigs, ResourceType.Core.DISK);
+    assertRank(provider, 1002, xaStoreConfigs, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
     assertRank(provider, -1, xaStoreConfigs, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP);
-    assertRank(provider, 12, xaStoreConfigs, ResourceType.Core.DISK, ResourceType.Core.HEAP);
-    assertRank(provider, 13, xaStoreConfigs, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
+    assertRank(provider, 1002, xaStoreConfigs, ResourceType.Core.DISK, ResourceType.Core.HEAP);
+    assertRank(provider, 1003, xaStoreConfigs, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);
 
     final Set<ServiceConfiguration<?>> emptyConfigs = Collections.emptySet();
     assertRank(provider, 0, emptyConfigs, ResourceType.Core.DISK, ResourceType.Core.OFFHEAP, ResourceType.Core.HEAP);

--- a/xml/src/main/java/org/ehcache/xml/CacheResourceConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/CacheResourceConfigurationParser.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.xml;
+
+import org.ehcache.config.ResourcePool;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.xml.transform.Source;
+
+/**
+ * Defines a handler for processing {@code /config/cache/resources} extension elements.
+ *
+ * @author Clifford W. Johnson
+ */
+public interface CacheResourceConfigurationParser {
+
+  Source getXmlSchema() throws IOException;
+
+  URI getNamespace();
+
+  ResourcePool parseResourceConfiguration(Element fragment);
+}

--- a/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
@@ -18,6 +18,7 @@ package org.ehcache.xml;
 
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceUnit;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.core.config.SizedResourcePoolImpl;
@@ -526,7 +527,7 @@ class ConfigurationParser {
 
   private ResourcePool parseResource(Heap resource) {
     ResourceType heapResource = resource.getValue();
-    return new SizedResourcePoolImpl(org.ehcache.config.ResourceType.Core.HEAP,
+    return new SizedResourcePoolImpl<SizedResourcePool>(org.ehcache.config.ResourceType.Core.HEAP,
             heapResource.getValue().longValue(), parseUnit(heapResource), false);
   }
 
@@ -538,15 +539,15 @@ class ConfigurationParser {
       Object resource = unmarshaller.unmarshal(element);
       if (resource instanceof Heap) {
         ResourceType heapResource = ((Heap) resource).getValue();
-        return new SizedResourcePoolImpl(org.ehcache.config.ResourceType.Core.HEAP,
+        return new SizedResourcePoolImpl<SizedResourcePool>(org.ehcache.config.ResourceType.Core.HEAP,
                 heapResource.getValue().longValue(), parseUnit(heapResource), false);
       } else if (resource instanceof Offheap) {
         MemoryType offheapResource = ((Offheap) resource).getValue();
-        return new SizedResourcePoolImpl(org.ehcache.config.ResourceType.Core.OFFHEAP,
+        return new SizedResourcePoolImpl<SizedResourcePool>(org.ehcache.config.ResourceType.Core.OFFHEAP,
                 offheapResource.getValue().longValue(), parseMemory(offheapResource), false);
       } else if (resource instanceof Disk) {
         PersistableMemoryType diskResource = ((Disk) resource).getValue();
-        return new SizedResourcePoolImpl(org.ehcache.config.ResourceType.Core.DISK,
+        return new SizedResourcePoolImpl<SizedResourcePool>(org.ehcache.config.ResourceType.Core.DISK,
                 diskResource.getValue().longValue(), parseMemory(diskResource), diskResource.isPersistent());
       } else {
         // Someone updated the core resources without updating *this* code ...

--- a/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
@@ -85,7 +85,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
 /**
- * @author Alex Snaps
+ * Provides support for parsing a cache configuration expressed in XML.
  */
 class ConfigurationParser {
 
@@ -94,7 +94,7 @@ class ConfigurationParser {
   private static final URL CORE_SCHEMA_URL = XmlConfiguration.class.getResource("/ehcache-core.xsd");
   private static final String CORE_SCHEMA_NAMESPACE = "http://www.ehcache.org/v3";
   private static final String CORE_SCHEMA_ROOT_ELEMENT = "config";
-  private static final String CORE_SCHEMA_JAXB_MODEL_PACKAGE = "org.ehcache.xml.model";
+  private static final String CORE_SCHEMA_JAXB_MODEL_PACKAGE = ConfigType.class.getPackage().getName();
 
   private final Map<URI, CacheManagerServiceConfigurationParser<?>> xmlParsers = new HashMap<URI, CacheManagerServiceConfigurationParser<?>>();
   private final Map<URI, CacheServiceConfigurationParser<?>> cacheXmlParsers = new HashMap<URI, CacheServiceConfigurationParser<?>>();

--- a/xml/src/main/java/org/ehcache/xml/exceptions/XmlConfigurationException.java
+++ b/xml/src/main/java/org/ehcache/xml/exceptions/XmlConfigurationException.java
@@ -18,8 +18,6 @@ package org.ehcache.xml.exceptions;
 
 /**
  * Thrown to reflect an error in an XML configuration.
- *
- * @author Clifford W. Johnson
  */
 public class XmlConfigurationException extends RuntimeException {
   private static final long serialVersionUID = 4797841652996371653L;
@@ -30,5 +28,9 @@ public class XmlConfigurationException extends RuntimeException {
 
   public XmlConfigurationException(final String message, final Throwable cause) {
     super(message, cause);
+  }
+
+  public XmlConfigurationException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -459,7 +459,7 @@
   <xs:complexType name="memory-type">
     <xs:simpleContent>
       <xs:extension base="xs:positiveInteger">
-        <xs:attribute name="unit" type="ehcache:memory-unit" default="b" use="optional">
+        <xs:attribute name="unit" type="ehcache:memory-unit" default="B" use="optional">
           <xs:annotation>
             <xs:documentation xml:lang="en">
               The memory unit (see org.ehcache.config.units.MemoryUnit) this value is expressed in.
@@ -546,24 +546,24 @@
   </xs:simpleType>
   <xs:simpleType name="memory-unit">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="b"/>
-      <xs:enumeration value="kb"/>
-      <xs:enumeration value="mb"/>
-      <xs:enumeration value="gb"/>
-      <xs:enumeration value="tb"/>
-      <xs:enumeration value="pb"/>
+      <xs:enumeration value="B"/>
+      <xs:enumeration value="kB"/>
+      <xs:enumeration value="MB"/>
+      <xs:enumeration value="GB"/>
+      <xs:enumeration value="TB"/>
+      <xs:enumeration value="PB"/>
     </xs:restriction>
   </xs:simpleType>
   <!-- Keeping the below explicit instead of union with the above to ease auto complete -->
   <xs:simpleType name="resource-unit">
     <xs:restriction base="xs:string">
       <xs:enumeration value="entries"/>
-      <xs:enumeration value="b"/>
-      <xs:enumeration value="kb"/>
-      <xs:enumeration value="mb"/>
-      <xs:enumeration value="gb"/>
-      <xs:enumeration value="tb"/>
-      <xs:enumeration value="pb"/>
+      <xs:enumeration value="B"/>
+      <xs:enumeration value="kB"/>
+      <xs:enumeration value="MB"/>
+      <xs:enumeration value="GB"/>
+      <xs:enumeration value="TB"/>
+      <xs:enumeration value="PB"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="event-firing-type">

--- a/xml/src/test/java/org/ehcache/xml/IntegrationConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/IntegrationConfigurationTest.java
@@ -279,16 +279,16 @@ public class IntegrationConfigurationTest {
         usesDefaultSizeOfEngine.getRuntimeConfiguration().updateResourcePools(pools);
         fail();
       } catch (Exception ex) {
-        assertThat(ex, instanceOf(UnsupportedOperationException.class));
-        assertThat(ex.getMessage(), equalTo("Modifying ResourceUnit type is not supported"));
+        assertThat(ex, instanceOf(IllegalArgumentException.class));
+        assertThat(ex.getMessage(), equalTo("ResourcePool for heap with ResourceUnit 'entries' can not replace 'kB'"));
       }
 
       try {
         usesConfiguredInCache.getRuntimeConfiguration().updateResourcePools(pools);
         fail();
       } catch (Exception ex) {
-        assertThat(ex, instanceOf(UnsupportedOperationException.class));
-        assertThat(ex.getMessage(), equalTo("Modifying ResourceUnit type is not supported"));
+        assertThat(ex, instanceOf(IllegalArgumentException.class));
+        assertThat(ex.getMessage(), equalTo("ResourcePool for heap with ResourceUnit 'entries' can not replace 'kB'"));
       }
 
     } finally {

--- a/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
@@ -329,12 +329,12 @@ public class XmlConfigurationTest {
     assertThat(implicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
   }
 
-  private <K, V> long getResourceSize(final CacheConfiguration<K, V> config, final ResourceType type) {
-    return ((SizedResourcePool)config.getResourcePools().getPoolForResource(type)).getSize();
+  private <K, V> long getResourceSize(final CacheConfiguration<K, V> config, final ResourceType<SizedResourcePool> type) {
+    return config.getResourcePools().getPoolForResource(type).getSize();
   }
 
-  private <K, V> ResourceUnit getResourceUnit(final CacheConfiguration<K, V> config, final ResourceType type) {
-    return ((SizedResourcePool)config.getResourcePools().getPoolForResource(type)).getUnit();
+  private <K, V> ResourceUnit getResourceUnit(final CacheConfiguration<K, V> config, final ResourceType<SizedResourcePool> type) {
+    return config.getResourcePools().getPoolForResource(type).getUnit();
   }
 
   @Test

--- a/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
@@ -20,6 +20,7 @@ import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.Configuration;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.ResourceUnit;
+import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 import org.ehcache.impl.config.copy.DefaultCopyProviderConfiguration;
@@ -264,26 +265,26 @@ public class XmlConfigurationTest {
     XmlConfiguration xmlConfig = new XmlConfiguration(resource);
 
     CacheConfiguration<?, ?> tieredCacheConfig = xmlConfig.getCacheConfigurations().get("tiered");
-    assertThat(tieredCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(10L));
-    assertThat(tieredCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK).getSize(), equalTo(100L));
+    assertThat(getResourceSize(tieredCacheConfig, ResourceType.Core.HEAP), equalTo(10L));
+    assertThat(getResourceSize(tieredCacheConfig, ResourceType.Core.DISK), equalTo(100L));
     assertThat(tieredCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK).isPersistent(), is(false));
 
     CacheConfiguration<?, ?> tieredPersistentCacheConfig = xmlConfig.getCacheConfigurations().get("tieredPersistent");
-    assertThat(tieredPersistentCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(10L));
-    assertThat(tieredPersistentCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK).getSize(), equalTo(100L));
+    assertThat(getResourceSize(tieredPersistentCacheConfig, ResourceType.Core.HEAP), equalTo(10L));
+    assertThat(getResourceSize(tieredPersistentCacheConfig, ResourceType.Core.DISK), equalTo(100L));
     assertThat(tieredPersistentCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK).isPersistent(), is(true));
 
     CacheConfiguration<?, ?> tieredOffHeapCacheConfig = xmlConfig.getCacheConfigurations().get("tieredOffHeap");
-    assertThat(tieredOffHeapCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(10L));
-    assertThat(tieredOffHeapCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getSize(), equalTo(10L));
-    assertThat(tieredOffHeapCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getUnit(), equalTo((ResourceUnit) MemoryUnit.MB));
+    assertThat(getResourceSize(tieredOffHeapCacheConfig, ResourceType.Core.HEAP), equalTo(10L));
+    assertThat(getResourceSize(tieredOffHeapCacheConfig, ResourceType.Core.OFFHEAP), equalTo(10L));
+    assertThat(getResourceUnit(tieredOffHeapCacheConfig, ResourceType.Core.OFFHEAP), equalTo((ResourceUnit) MemoryUnit.MB));
 
     CacheConfiguration<?, ?> explicitHeapOnlyCacheConfig = xmlConfig.getCacheConfigurations().get("explicitHeapOnly");
-    assertThat(explicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(15L));
+    assertThat(getResourceSize(explicitHeapOnlyCacheConfig, ResourceType.Core.HEAP), equalTo(15L));
     assertThat(explicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
 
     CacheConfiguration<?, ?> implicitHeapOnlyCacheConfig = xmlConfig.getCacheConfigurations().get("directHeapOnly");
-    assertThat(implicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(25L));
+    assertThat(getResourceSize(implicitHeapOnlyCacheConfig, ResourceType.Core.HEAP), equalTo(25L));
     assertThat(implicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
   }
 
@@ -293,22 +294,22 @@ public class XmlConfigurationTest {
     XmlConfiguration xmlConfig = new XmlConfiguration(resource);
 
     CacheConfigurationBuilder<Object, Object> tieredResourceTemplate = xmlConfig.newCacheConfigurationBuilderFromTemplate("tieredResourceTemplate");
-    assertThat(tieredResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(5L));
-    assertThat(tieredResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.DISK).getSize(), equalTo(50L));
+    assertThat(getResourceSize(tieredResourceTemplate.build(), ResourceType.Core.HEAP), equalTo(5L));
+    assertThat(getResourceSize(tieredResourceTemplate.build(), ResourceType.Core.DISK), equalTo(50L));
     assertThat(tieredResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.DISK).isPersistent(), is(false));
 
     CacheConfigurationBuilder<Object, Object> persistentTieredResourceTemplate = xmlConfig.newCacheConfigurationBuilderFromTemplate("persistentTieredResourceTemplate");
-    assertThat(persistentTieredResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(5L));
-    assertThat(persistentTieredResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.DISK).getSize(), equalTo(50L));
+    assertThat(getResourceSize(persistentTieredResourceTemplate.build(), ResourceType.Core.HEAP), equalTo(5L));
+    assertThat(getResourceSize(persistentTieredResourceTemplate.build(), ResourceType.Core.DISK), equalTo(50L));
     assertThat(persistentTieredResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.DISK).isPersistent(), is(true));
 
     CacheConfigurationBuilder<Object, Object> tieredOffHeapResourceTemplate = xmlConfig.newCacheConfigurationBuilderFromTemplate("tieredOffHeapResourceTemplate");
-    assertThat(tieredOffHeapResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(5L));
-    assertThat(tieredOffHeapResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getSize(), equalTo(50L));
-    assertThat(tieredOffHeapResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.OFFHEAP).getUnit(), equalTo((ResourceUnit)MemoryUnit.MB));
+    assertThat(getResourceSize(tieredOffHeapResourceTemplate.build(), ResourceType.Core.HEAP), equalTo(5L));
+    assertThat(getResourceSize(tieredOffHeapResourceTemplate.build(), ResourceType.Core.OFFHEAP), equalTo(50L));
+    assertThat(getResourceUnit(tieredOffHeapResourceTemplate.build(), ResourceType.Core.OFFHEAP), equalTo((ResourceUnit)MemoryUnit.MB));
 
     CacheConfigurationBuilder<Object, Object> explicitHeapResourceTemplate = xmlConfig.newCacheConfigurationBuilderFromTemplate("explicitHeapResourceTemplate");
-    assertThat(explicitHeapResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(15L));
+    assertThat(getResourceSize(explicitHeapResourceTemplate.build(), ResourceType.Core.HEAP), equalTo(15L));
     assertThat(explicitHeapResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
 
     CacheConfigurationBuilder<Object, Object> implicitHeapResourceTemplate = xmlConfig.newCacheConfigurationBuilderFromTemplate("implicitHeapResourceTemplate");
@@ -316,16 +317,24 @@ public class XmlConfigurationTest {
     assertThat(implicitHeapResourceTemplate.build().getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
 
     CacheConfiguration<?, ?> tieredCacheConfig = xmlConfig.getCacheConfigurations().get("templatedTieredResource");
-    assertThat(tieredCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(5L));
-    assertThat(tieredCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK).getSize(), equalTo(50L));
+    assertThat(getResourceSize(tieredCacheConfig, ResourceType.Core.HEAP), equalTo(5L));
+    assertThat(getResourceSize(tieredCacheConfig, ResourceType.Core.DISK), equalTo(50L));
 
     CacheConfiguration<?, ?> explicitHeapOnlyCacheConfig = xmlConfig.getCacheConfigurations().get("templatedExplicitHeapResource");
-    assertThat(explicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), equalTo(15L));
+    assertThat(getResourceSize(explicitHeapOnlyCacheConfig, ResourceType.Core.HEAP), equalTo(15L));
     assertThat(explicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
 
     CacheConfiguration<?, ?> implicitHeapOnlyCacheConfig = xmlConfig.getCacheConfigurations().get("templatedImplicitHeapResource");
     assertThat(implicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP), is(nullValue()));
     assertThat(implicitHeapOnlyCacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.DISK), is(nullValue()));
+  }
+
+  private <K, V> long getResourceSize(final CacheConfiguration<K, V> config, final ResourceType type) {
+    return ((SizedResourcePool)config.getResourcePools().getPoolForResource(type)).getSize();
+  }
+
+  private <K, V> ResourceUnit getResourceUnit(final CacheConfiguration<K, V> config, final ResourceType type) {
+    return ((SizedResourcePool)config.getResourcePools().getPoolForResource(type)).getUnit();
   }
 
   @Test
@@ -646,8 +655,7 @@ public class XmlConfigurationTest {
     try {
       new XmlConfiguration(XmlConfigurationTest.class.getResource("/configs/custom-resource.xml"));
     } catch (XmlConfigurationException xce) {
-      IllegalArgumentException e = (IllegalArgumentException) xce.getCause();
-      assertThat(e.getMessage(), containsString("Can't find parser for resource: [fancy:fancy: null]"));
+      assertThat(xce.getMessage(), containsString("Can't find parser for namespace: http://www.example.com/fancy"));
     }
   }
 

--- a/xml/src/test/resources/configs/default-serializer.xml
+++ b/xml/src/test/resources/configs/default-serializer.xml
@@ -38,7 +38,7 @@
     </ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap unit="entries">10</ehcache:heap>
-      <ehcache:offheap unit="mb">1</ehcache:offheap>
+      <ehcache:offheap unit="MB">1</ehcache:offheap>
     </ehcache:resources>
   </ehcache:cache>
 
@@ -51,7 +51,7 @@
                 </ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap unit="entries">10</ehcache:heap>
-      <ehcache:offheap unit="mb">1</ehcache:offheap>
+      <ehcache:offheap unit="MB">1</ehcache:offheap>
     </ehcache:resources>
   </ehcache:cache>
 </ehcache:config>

--- a/xml/src/test/resources/configs/docs/getting-started.xml
+++ b/xml/src/test/resources/configs/docs/getting-started.xml
@@ -24,7 +24,7 @@
     <key-type>java.lang.String</key-type> <!--2-->
     <resources>
       <heap unit="entries">2000</heap> <!--3-->
-      <offheap unit="mb">500</offheap> <!--4-->
+      <offheap unit="MB">500</offheap> <!--4-->
     </resources>
   </cache>
 

--- a/xml/src/test/resources/configs/docs/thread-pools.xml
+++ b/xml/src/test/resources/configs/docs/thread-pools.xml
@@ -36,7 +36,7 @@
 
     <resources>
       <heap unit="entries">10</heap>
-      <disk unit="mb">10</disk>
+      <disk unit="MB">10</disk>
     </resources>
   </cache>
 
@@ -55,7 +55,7 @@
     <listeners thread-pool="cache2Pool"/> <!--6-->
     <resources>
       <heap unit="entries">10</heap>
-      <disk unit="mb">10</disk>
+      <disk unit="MB">10</disk>
     </resources>
     <disk-store-settings thread-pool="cache2Pool" writer-threads="2"/> <!--7-->
   </cache>

--- a/xml/src/test/resources/configs/ehcache-complete.xml
+++ b/xml/src/test/resources/configs/ehcache-complete.xml
@@ -36,7 +36,7 @@
   <ehcache:write-behind thread-pool="wb"/>
   <ehcache:heap-store>
     <ehcache:max-object-graph-size>1000</ehcache:max-object-graph-size>
-    <ehcache:max-object-size unit="mb">100</ehcache:max-object-size>
+    <ehcache:max-object-size unit="MB">100</ehcache:max-object-size>
   </ehcache:heap-store>
   <ehcache:disk-store thread-pool="pool-disk"/>
 
@@ -65,12 +65,12 @@
       </ehcache:listener>
     </ehcache:listeners>
     <ehcache:resources>
-      <ehcache:heap unit="mb">100</ehcache:heap>
-      <ehcache:disk unit="gb" persistent="true">100</ehcache:disk>
+      <ehcache:heap unit="MB">100</ehcache:heap>
+      <ehcache:disk unit="GB" persistent="true">100</ehcache:disk>
     </ehcache:resources>
     <ehcache:heap-store-settings>
       <ehcache:max-object-graph-size>10</ehcache:max-object-graph-size>
-      <ehcache:max-object-size unit="mb">100</ehcache:max-object-size>
+      <ehcache:max-object-size unit="MB">100</ehcache:max-object-size>
     </ehcache:heap-store-settings>
     <ehcache:disk-store-settings thread-pool="pool-disk" writer-threads="10"/>
     <foo:foo/>

--- a/xml/src/test/resources/configs/resources-caches.xml
+++ b/xml/src/test/resources/configs/resources-caches.xml
@@ -24,7 +24,7 @@
     <ehcache:value-type>java.lang.String</ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap unit="entries">10</ehcache:heap>
-      <ehcache:disk unit="mb">100</ehcache:disk>
+      <ehcache:disk unit="MB">100</ehcache:disk>
     </ehcache:resources>
     <ehcache:disk-store-settings writer-threads="2" thread-pool="some-pool"/>
   </ehcache:cache>
@@ -34,7 +34,7 @@
     <ehcache:value-type>java.lang.String</ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap unit="entries">10</ehcache:heap>
-      <ehcache:disk unit="mb" persistent="true">100</ehcache:disk>
+      <ehcache:disk unit="MB" persistent="true">100</ehcache:disk>
     </ehcache:resources>
   </ehcache:cache>
 
@@ -43,7 +43,7 @@
     <ehcache:value-type>java.lang.String</ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap unit="entries">10</ehcache:heap>
-      <ehcache:offheap unit="mb">10</ehcache:offheap>
+      <ehcache:offheap unit="MB">10</ehcache:offheap>
     </ehcache:resources>
   </ehcache:cache>
 

--- a/xml/src/test/resources/configs/resources-templates.xml
+++ b/xml/src/test/resources/configs/resources-templates.xml
@@ -24,7 +24,7 @@
     <ehcache:value-type>java.lang.String</ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap>5</ehcache:heap>
-      <ehcache:disk unit="mb">50</ehcache:disk>
+      <ehcache:disk unit="MB">50</ehcache:disk>
     </ehcache:resources>
   </ehcache:cache-template>
 
@@ -36,7 +36,7 @@
     <ehcache:value-type>java.lang.String</ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap>5</ehcache:heap>
-      <ehcache:disk unit="mb" persistent="true">50</ehcache:disk>
+      <ehcache:disk unit="MB" persistent="true">50</ehcache:disk>
     </ehcache:resources>
   </ehcache:cache-template>
 
@@ -48,7 +48,7 @@
     <ehcache:value-type>java.lang.String</ehcache:value-type>
     <ehcache:resources>
       <ehcache:heap>5</ehcache:heap>
-      <ehcache:offheap unit="mb">50</ehcache:offheap>
+      <ehcache:offheap unit="MB">50</ehcache:offheap>
     </ehcache:resources>
   </ehcache:cache-template>
 

--- a/xml/src/test/resources/configs/sizeof-engine.xml
+++ b/xml/src/test/resources/configs/sizeof-engine.xml
@@ -20,7 +20,7 @@
 
   <ehcache:heap-store>
     <ehcache:max-object-graph-size>200</ehcache:max-object-graph-size>
-    <ehcache:max-object-size unit="b">100000</ehcache:max-object-size>
+    <ehcache:max-object-size unit="B">100000</ehcache:max-object-size>
   </ehcache:heap-store>
 
   <ehcache:cache alias="usesDefaultSizeOfEngine">
@@ -31,8 +31,8 @@
     java.lang.String           
     </ehcache:value-type>
     <ehcache:resources>
-      <ehcache:heap unit="kb">10</ehcache:heap>
-      <ehcache:offheap unit="mb">1</ehcache:offheap>
+      <ehcache:heap unit="kB">10</ehcache:heap>
+      <ehcache:offheap unit="MB">1</ehcache:offheap>
     </ehcache:resources>
   </ehcache:cache>
 
@@ -44,8 +44,8 @@
      java.lang.String        
     </ehcache:value-type>
     <ehcache:resources>
-      <ehcache:heap unit="kb">10</ehcache:heap>
-      <ehcache:offheap unit="mb">1</ehcache:offheap>
+      <ehcache:heap unit="kB">10</ehcache:heap>
+      <ehcache:offheap unit="MB">1</ehcache:offheap>
     </ehcache:resources>
     <ehcache:heap-store-settings>
       <ehcache:max-object-graph-size>500</ehcache:max-object-graph-size>


### PR DESCRIPTION
This commit addresses Issues #833 and #834 and partially addresses
Issue #760.

This commit lays the foundation for a ClusteredStore along with many
underlying support constructs.

* The byte-count 'memory-unit' and 'resource-unit' enumeration values
  in ehcache-core.xsd are changed to upper-case (with the exception of
  'kB').
* ResourcePool is split into ResourcePool and SizedResourcePool along
  with associated implementations.
* The XAStore.provider 'rank' method is changed to use 1000 as its base
  value.  This makes room for other 'grouping' providers.
* MaintainableService and PersistableResourceService are marked as
  plural services.
* Use of org.terracotta.offheapstore.util.MemoryUnit in the clustering
  code is changed to org.ehcache.config.units.MemoryUnit.
* A 'with(ResourcePool)' method is added to ResourcePoolsBuilder to
  accept non-core resources.
* The behavior of the ResourcePoolsBuilder 'with', 'heap', 'offheap',
  and 'disk' methods are changed to throw an IllegalArgumentException
  when a resource pool of a type already existing in the pool collection
  instead of silently replacing the existing pool.  The
  'withReplacing(ResourcePool)' method is added for preserve the old
  add/replace behavior.
* Removes the private ConfigurationParser.ResourcePoolImpl class in
  deference to the "regular" implementation.

ClusteredStore support specifics include:

* Introduction of the CacheResourceConfigurationParser and
  ClusteredResourceConfigurationParser to handle parsing of the
  <cluster-fixed> and <cluster-shared> cache resource elements.
  ConfigurationParser is updated to handle parsing resource extension
  elements.
* ClusteredResourceType, ClusteredResourcePool, and
  ClusteredResourcePoolBuilder are introduced to represent clustered
  cache resources.

-----

The `ClusteredStore` implementation in this commit is a rudimentary shell -- it relies on having a heap (or other store) configured to be functional.  This commit also lacks code which links clustered resources to the `ClusteringService` configuration.