### PR TITLE
Adding Default Copiers for better perf in jsr #806

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107IdentityCopier.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107IdentityCopier.java
@@ -14,33 +14,22 @@
  * limitations under the License.
  */
 
-package com.pany.domain;
+package org.ehcache.jsr107;
 
-import java.io.Serializable;
+import org.ehcache.impl.copy.ReadWriteCopier;
 
 /**
- * Client
+ * Default copier for JSR caches to be used for immutable types
+ * even for store by value cases.
  */
-public class Client implements Serializable {
+class Eh107IdentityCopier<T> extends ReadWriteCopier<T> {
 
-  private final String name;
-  private final long creditLine;
+  public Eh107IdentityCopier() {
 
-  public Client(String name, long creditLine) {
-    this.name = name;
-    this.creditLine = creditLine;
   }
 
-  public Client(Client toCopy) {
-    this.name = toCopy.getName();
-    this.creditLine = toCopy.getCreditLine();
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public long getCreditLine() {
-    return creditLine;
+  @Override
+  public T copy(T obj) {
+    return obj;
   }
 }

--- a/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
+++ b/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.pany.domain.Client;
 import com.pany.domain.Product;
 
 import java.util.Random;
@@ -151,26 +152,27 @@ public class EhCache107ConfigurationIntegrationDocTest {
         getClass().getClassLoader());
 
     // tag::jsr107SupplementWithTemplatesExample[]
-    MutableConfiguration<Long, String> mutableConfiguration = new MutableConfiguration<Long, String>();
-    mutableConfiguration.setTypes(Long.class, String.class); // <1>
+    MutableConfiguration<Long, Client> mutableConfiguration = new MutableConfiguration<Long, Client>();
+    mutableConfiguration.setTypes(Long.class, Client.class); // <1>
 
-    Cache<Long, String> anyCache = manager.createCache("anyCache", mutableConfiguration); // <2>
+    Cache<Long, Client> anyCache = manager.createCache("anyCache", mutableConfiguration); // <2>
 
-    CacheRuntimeConfiguration<Long, String> ehcacheConfig = (CacheRuntimeConfiguration<Long, String>)anyCache.getConfiguration(
+    CacheRuntimeConfiguration<Long, Client> ehcacheConfig = (CacheRuntimeConfiguration<Long, Client>)anyCache.getConfiguration(
         Eh107Configuration.class).unwrap(CacheRuntimeConfiguration.class); // <3>
     ehcacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(); // <4>
 
-    Cache<Long, String> anotherCache = manager.createCache("byRefCache", mutableConfiguration);
+    Cache<Long, Client> anotherCache = manager.createCache("byRefCache", mutableConfiguration);
     assertFalse(anotherCache.getConfiguration(Configuration.class).isStoreByValue()); // <5>
 
-    MutableConfiguration<String, String> otherConfiguration = new MutableConfiguration<String, String>();
-    otherConfiguration.setTypes(String.class, String.class);
+    MutableConfiguration<String, Client> otherConfiguration = new MutableConfiguration<String, Client>();
+    otherConfiguration.setTypes(String.class, Client.class);
     otherConfiguration.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(Duration.ONE_MINUTE)); // <6>
 
-    Cache<String, String> foosCache = manager.createCache("foos", otherConfiguration);// <7>
-    CacheRuntimeConfiguration<Long, String> foosEhcacheConfig = (CacheRuntimeConfiguration<Long, String>)foosCache.getConfiguration(
+    Cache<String, Client> foosCache = manager.createCache("foos", otherConfiguration);// <7>
+    CacheRuntimeConfiguration<Long, Client> foosEhcacheConfig = (CacheRuntimeConfiguration<Long, Client>)foosCache.getConfiguration(
         Eh107Configuration.class).unwrap(CacheRuntimeConfiguration.class);
-    foosEhcacheConfig.getExpiry().getExpiryForCreation(42L, "Answer!").getAmount(); // <8>
+    Client client1 = new Client("client1", 1);
+    foosEhcacheConfig.getExpiry().getExpiryForCreation(42L, client1).getAmount(); // <8>
 
     CompleteConfiguration<String, String> foosConfig = foosCache.getConfiguration(CompleteConfiguration.class);
 
@@ -183,7 +185,7 @@ public class EhCache107ConfigurationIntegrationDocTest {
     }
     // end::jsr107SupplementWithTemplatesExample[]
     assertThat(ehcacheConfig.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize(), is(20L));
-    assertThat(foosEhcacheConfig.getExpiry().getExpiryForCreation(42L, "Answer!"),
+    assertThat(foosEhcacheConfig.getExpiry().getExpiryForCreation(42L, client1),
         is(new org.ehcache.expiry.Duration(2, TimeUnit.MINUTES)));
   }
 
@@ -193,28 +195,30 @@ public class EhCache107ConfigurationIntegrationDocTest {
         getClass().getResource("/org/ehcache/docs/ehcache-jsr107-template-override.xml").toURI(),
         getClass().getClassLoader());
 
-    MutableConfiguration<Long, String> mutableConfiguration = new MutableConfiguration<Long, String>();
-    mutableConfiguration.setTypes(Long.class, String.class);
+    MutableConfiguration<Long, Client> mutableConfiguration = new MutableConfiguration<Long, Client>();
+    mutableConfiguration.setTypes(Long.class, Client.class);
 
-    Cache<Long, String> myCache = null;
+    Client client1 = new Client("client1", 1);
+
+    Cache<Long, Client> myCache = null;
     myCache = cacheManager.createCache("anyCache", mutableConfiguration);
-    myCache.put(1L, "foo");
-    assertNotSame("foo", myCache.get(1L));
+    myCache.put(1L, client1);
+    assertNotSame(client1, myCache.get(1L));
     assertTrue(myCache.getConfiguration(Configuration.class).isStoreByValue());
 
     myCache = cacheManager.createCache("byRefCache", mutableConfiguration);
-    myCache.put(1L, "foo");
-    assertSame("foo", myCache.get(1L));
+    myCache.put(1L, client1);
+    assertSame(client1, myCache.get(1L));
     assertFalse(myCache.getConfiguration(Configuration.class).isStoreByValue());
 
     myCache = cacheManager.createCache("weirdCache1", mutableConfiguration);
-    myCache.put(1L, "foo");
-    assertNotSame("foo", myCache.get(1L));
+    myCache.put(1L, client1);
+    assertNotSame(client1, myCache.get(1L));
     assertTrue(myCache.getConfiguration(Configuration.class).isStoreByValue());
 
     myCache = cacheManager.createCache("weirdCache2", mutableConfiguration);
-    myCache.put(1L, "foo");
-    assertSame("foo", myCache.get(1L));
+    myCache.put(1L, client1);
+    assertSame(client1, myCache.get(1L));
     assertFalse(myCache.getConfiguration(Configuration.class).isStoreByValue());
   }
 
@@ -224,17 +228,18 @@ public class EhCache107ConfigurationIntegrationDocTest {
         getClass().getResource("/org/ehcache/docs/ehcache-jsr107-template-override.xml").toURI(),
         getClass().getClassLoader());
 
-    MutableConfiguration<Long, String> mutableConfiguration = new MutableConfiguration<Long, String>();
-    mutableConfiguration.setTypes(Long.class, String.class).setStoreByValue(false);
+    MutableConfiguration<Long, Client> mutableConfiguration = new MutableConfiguration<Long, Client>();
+    mutableConfiguration.setTypes(Long.class, Client.class).setStoreByValue(false);
 
-    Cache<Long, String> myCache = null;
+    Cache<Long, Client> myCache = null;
+    Client client1 = new Client("client1", 1);
 
     myCache = cacheManager.createCache("anotherCache", mutableConfiguration);
-    myCache.put(1L, "foo");
-    assertSame("foo", myCache.get(1L));
+    myCache.put(1L, client1);
+    assertSame(client1, myCache.get(1L));
 
     myCache = cacheManager.createCache("byValCache", mutableConfiguration);
-    myCache.put(1L, "foo");
-    assertNotSame("foo", myCache.get(1L));
+    myCache.put(1L, client1);
+    assertNotSame(client1, myCache.get(1L));
   }
 }

--- a/107/src/test/resources/ehcache-107-copiers-immutable-types.xml
+++ b/107/src/test/resources/ehcache-107-copiers-immutable-types.xml
@@ -1,0 +1,57 @@
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ehcache:config
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns:ehcache='http://www.ehcache.org/v3'
+    xmlns:jsr107='http://www.ehcache.org/v3/jsr107'>
+
+  <ehcache:service>
+    <jsr107:defaults>
+      <jsr107:cache name="stringCache" template="stringtemplate"/>
+      <jsr107:cache name="floatCache" template="floattemplate"/>
+      <jsr107:cache name="doubleCache" template="doubletemplate"/>
+      <jsr107:cache name="charCache" template="chartemplate"/>
+      <jsr107:cache name="integerCache" template="integertemplate"/>
+    </jsr107:defaults>
+    </ehcache:service>
+
+  <ehcache:cache-template name="stringtemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.String</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="chartemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Character</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="floattemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Float</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="doubletemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Double</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="integertemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Integer</ehcache:value-type>
+  </ehcache:cache-template>
+
+</ehcache:config>

--- a/107/src/test/resources/ehcache-107-default-copiers.xml
+++ b/107/src/test/resources/ehcache-107-default-copiers.xml
@@ -20,10 +20,10 @@
     xmlns:jsr107='http://www.ehcache.org/v3/jsr107'>
 
   <ehcache:service>
-      <jsr107:defaults>
-        <jsr107:cache name="bar" template="bartemplate"/>
-      </jsr107:defaults>
-    </ehcache:service>
+    <jsr107:defaults>
+      <jsr107:cache name="bar" template="bartemplate"/>
+    </jsr107:defaults>
+  </ehcache:service>
 
   <ehcache:default-copiers>
     <ehcache:copier type="com.pany.domain.Client">com.pany.ehcache.ClientCopier</ehcache:copier>

--- a/107/src/test/resources/ehcache-107-immutable-types-cm-level-copiers.xml
+++ b/107/src/test/resources/ehcache-107-immutable-types-cm-level-copiers.xml
@@ -1,0 +1,61 @@
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ehcache:config
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns:ehcache='http://www.ehcache.org/v3'
+    xmlns:jsr107='http://www.ehcache.org/v3/jsr107'>
+
+  <ehcache:service>
+    <jsr107:defaults>
+      <jsr107:cache name="stringCache" template="stringtemplate"/>
+      <jsr107:cache name="floatCache" template="floattemplate"/>
+      <jsr107:cache name="doubleCache" template="doubletemplate"/>
+      <jsr107:cache name="charCache" template="chartemplate"/>
+      <jsr107:cache name="integerCache" template="integertemplate"/>
+    </jsr107:defaults>
+  </ehcache:service>
+
+  <ehcache:default-copiers>
+    <ehcache:copier type="java.lang.Long">org.ehcache.impl.copy.IdentityCopier</ehcache:copier>
+  </ehcache:default-copiers>
+
+  <ehcache:cache-template name="stringtemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.String</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="chartemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Character</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="floattemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Float</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="doubletemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Double</ehcache:value-type>
+  </ehcache:cache-template>
+
+  <ehcache:cache-template name="integertemplate">
+    <ehcache:key-type>java.lang.Long</ehcache:key-type>
+    <ehcache:value-type>java.lang.Integer</ehcache:value-type>
+  </ehcache:cache-template>
+
+</ehcache:config>

--- a/107/src/test/resources/org/ehcache/docs/ehcache-jsr107-template-override.xml
+++ b/107/src/test/resources/org/ehcache/docs/ehcache-jsr107-template-override.xml
@@ -5,7 +5,7 @@
 
   <service> <!--2-->
     <jsr107:defaults default-template="tinyCache"> <!--3-->
-      <jsr107:cache name="foos" template="stringCache"/> <!--4-->
+      <jsr107:cache name="foos" template="clientCache"/> <!--4-->
       <jsr107:cache name="byRefCache" template="byRefTemplate"/>
       <jsr107:cache name="byValCache" template="byValueTemplate"/>
       <jsr107:cache name="weirdCache1" template="mixedTemplate1"/>
@@ -13,9 +13,9 @@
     </jsr107:defaults>
   </service>
 
-  <cache-template name="stringCache">
+  <cache-template name="clientCache">
     <key-type>java.lang.String</key-type>
-    <value-type>java.lang.String</value-type>
+    <value-type>com.pany.domain.Client</value-type>
     <expiry>
       <ttl unit="minutes">2</ttl>
     </expiry>
@@ -28,25 +28,25 @@
 
   <cache-template name="byRefTemplate">
     <key-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.Long</key-type>
-    <value-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.String</value-type>
+    <value-type copier="org.ehcache.impl.copy.IdentityCopier">com.pany.domain.Client</value-type>
     <heap unit="entries">10</heap>
   </cache-template>
 
   <cache-template name="byValueTemplate">
     <key-type copier="org.ehcache.impl.copy.SerializingCopier">java.lang.Long</key-type>
-    <value-type copier="org.ehcache.impl.copy.SerializingCopier">java.lang.String</value-type>
+    <value-type copier="org.ehcache.impl.copy.SerializingCopier">com.pany.domain.Client</value-type>
     <heap unit="entries">10</heap>
   </cache-template>
 
   <cache-template name="mixedTemplate1">
     <key-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.Long</key-type>
-    <value-type copier="org.ehcache.impl.copy.SerializingCopier">java.lang.String</value-type>
+    <value-type copier="org.ehcache.impl.copy.SerializingCopier">com.pany.domain.Client</value-type>
     <heap unit="entries">10</heap>
   </cache-template>
 
   <cache-template name="mixedTemplate2">
     <key-type copier="org.ehcache.impl.copy.SerializingCopier">java.lang.Long</key-type>
-    <value-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.String</value-type>
+    <value-type copier="org.ehcache.impl.copy.IdentityCopier">com.pany.domain.Client</value-type>
     <heap unit="entries">10</heap>
   </cache-template>
 </config>


### PR DESCRIPTION
* Creating a copy of IdentityCopier in JSR i.e. 'Eh107IdentityCopier' since thye logic of deciding whether as cache is storebyval or not depends on the kind of Copier configured for val type(in case of template overriding).