### PR TITLE
#836: fix ordered event handling when OversizeMappingException happens

### DIFF
--- a/core/src/main/java/org/ehcache/core/events/StoreEventDispatcher.java
+++ b/core/src/main/java/org/ehcache/core/events/StoreEventDispatcher.java
@@ -52,4 +52,11 @@ public interface StoreEventDispatcher<K, V> extends StoreEventSource<K, V> {
    * @param throwable the exception
    */
   void releaseEventSinkAfterFailure(StoreEventSink<K, V> eventSink, Throwable throwable);
+
+  /**
+   * Reset an event sink by dropping all queued events.
+   *
+   * @param eventSink the event sink to reset
+   */
+  void reset(StoreEventSink<K, V> eventSink);
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/events/AbstractStoreEventDispatcher.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/AbstractStoreEventDispatcher.java
@@ -44,6 +44,11 @@ abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDispatche
     }
 
     @Override
+    public void reset() {
+      // Do nothing
+    }
+
+    @Override
     public void removed(Object key, ValueSupplier value) {
       // Do nothing
     }
@@ -129,5 +134,10 @@ abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDispatche
   @Override
   public void releaseEventSinkAfterFailure(StoreEventSink<K, V> eventSink, Throwable throwable) {
     ((CloseableStoreEventSink) eventSink).closeOnFailure();
+  }
+
+  @Override
+  public void reset(StoreEventSink<K, V> eventSink) {
+    ((CloseableStoreEventSink) eventSink).reset();
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/events/CloseableStoreEventSink.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/CloseableStoreEventSink.java
@@ -25,4 +25,6 @@ interface CloseableStoreEventSink<K, V> extends StoreEventSink<K, V> {
   void close();
 
   void closeOnFailure();
+
+  void reset();
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/events/FireableStoreEventHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/FireableStoreEventHolder.java
@@ -100,4 +100,9 @@ class FireableStoreEventHolder<K, V> {
   StoreEvent<K, V> getEvent() {
     return event;
   }
+
+  @Override
+  public String toString() {
+    return "FireableStoreEventHolder in state " + status.get() + " of " + event + (failed ? " (failed)":" (not failed)");
+  }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/events/NullStoreEventDispatcher.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/NullStoreEventDispatcher.java
@@ -74,6 +74,11 @@ public class NullStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
   }
 
   @Override
+  public void reset(StoreEventSink<K, V> eventSink) {
+    // Do nothing
+  }
+
+  @Override
   public void addEventListener(StoreEventListener<K, V> eventListener) {
     // Do nothing
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.events;
+
+import org.ehcache.core.spi.store.events.StoreEventFilter;
+import org.ehcache.core.spi.store.events.StoreEventListener;
+import org.ehcache.event.EventType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.HashSet;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
+import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * InvocationScopedEventSinkTest
+ */
+public class InvocationScopedEventSinkTest {
+
+  private StoreEventListener listener;
+  private InvocationScopedEventSink<String, String> eventSink;
+
+  @Before
+  public void setUp() {
+    HashSet<StoreEventListener<String, String>> storeEventListeners = new HashSet<StoreEventListener<String, String>>();
+    listener = mock(StoreEventListener.class);
+    storeEventListeners.add(listener);
+    eventSink = new InvocationScopedEventSink<String, String>(new HashSet<StoreEventFilter<String, String>>(),
+        false, new BlockingQueue[] { new ArrayBlockingQueue<FireableStoreEventHolder<String, String>>(10) }, storeEventListeners);
+
+  }
+
+  @Test
+  public void testReset() {
+    eventSink.created("k1", "v1");
+    eventSink.evicted("k1", supplierOf("v2"));
+    eventSink.reset();
+    eventSink.created("k1", "v1");
+    eventSink.updated("k1", supplierOf("v1"), "v2");
+    eventSink.evicted("k1", supplierOf("v2"));
+    eventSink.close();
+
+    InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
+    inOrder.verify(listener).onEvent(argThat(eventType(EventType.UPDATED)));
+    inOrder.verify(listener).onEvent(argThat(eventType(EventType.EVICTED)));
+    verifyNoMoreInteractions(listener);
+  }
+
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/events/TestStoreEventDispatcher.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/TestStoreEventDispatcher.java
@@ -61,6 +61,11 @@ public class TestStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
   }
 
   @Override
+  public void reset(StoreEventSink<K, V> eventSink) {
+    // No-op
+  }
+
+  @Override
   public void addEventListener(StoreEventListener<K, V> eventListener) {
     listeners.add(eventListener);
   }


### PR DESCRIPTION
`compute()` (and friends) might be called many times in case a OversizeMappingException happens. In that case, all pre-recorded events should be dropped as the repeated call recreates those events.