### PR TITLE
Issue #961 Move Builder type to API

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107Configuration.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107Configuration.java
@@ -15,6 +15,7 @@
  */
 package org.ehcache.jsr107;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 
@@ -47,6 +48,20 @@ public abstract class Eh107Configuration<K, V> implements Configuration<K, V> {
    */
   public static <K, V> Configuration<K, V> fromEhcacheCacheConfiguration(CacheConfiguration<K, V> ehcacheConfig) {
     return new Eh107ConfigurationWrapper<K, V> (ehcacheConfig);
+  }
+
+  /**
+   * Creates a new JSR-107 {@link Configuration} from the provided {@link CacheConfiguration} obtained through a
+   * {@link Builder}.
+   *
+   * @param ehcacheConfigBuilder the native Ehcache configuration through a builder
+   * @param <K> the key type
+   * @param <V> the value type
+   *
+   * @return a JSR-107 configuration
+   */
+  public static <K, V> Configuration<K, V> fromEhcacheCacheConfiguration(Builder<? extends CacheConfiguration<K, V>> ehcacheConfigBuilder) {
+    return new Eh107ConfigurationWrapper<K, V>(ehcacheConfigBuilder.build());
   }
 
   /**

--- a/api/src/main/java/org/ehcache/CacheManager.java
+++ b/api/src/main/java/org/ehcache/CacheManager.java
@@ -16,6 +16,7 @@
 
 package org.ehcache;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.RuntimeConfiguration;
 
@@ -39,6 +40,21 @@ public interface CacheManager {
    * @throws java.lang.IllegalStateException If the cache creation fails
    */
   <K, V> Cache<K, V> createCache(String alias, CacheConfiguration<K, V> config);
+
+  /**
+   * Creates a {@link Cache} in this {@code CacheManager} according to the specified {@link CacheConfiguration} provided
+   * through a {@link Builder}.
+   *
+   * @param alias the alias under which the cache will be created
+   * @param configBuilder the builder for the configuration of the cache to create
+   * @param <K> the type of the keys used to access data within this cache
+   * @param <V> the type of the values held within this cache
+   * @return the created and initialized {@link Cache}
+   *
+   * @throws java.lang.IllegalArgumentException If there is already a cache registered with the given alias.
+   * @throws java.lang.IllegalStateException If the cache creation fails
+   */
+  <K, V> Cache<K, V> createCache(String alias, Builder<? extends CacheConfiguration<K, V>> configBuilder);
 
   /**
    * Retrieves the {@link Cache} associated with the given alias, if one is known.

--- a/api/src/main/java/org/ehcache/config/Builder.java
+++ b/api/src/main/java/org/ehcache/config/Builder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.ehcache.config.builders;
+package org.ehcache.config;
 
 /**
  * Abstraction of something that can build a {@code T}

--- a/api/src/main/java/org/ehcache/config/CacheRuntimeConfiguration.java
+++ b/api/src/main/java/org/ehcache/config/CacheRuntimeConfiguration.java
@@ -29,13 +29,12 @@ import java.util.Set;
  *
  * @param <K> the type of the keys used to access data within the cache
  * @param <V> the type of the values held within the cache
- *
- * @author Alex Snaps
  */
 public interface CacheRuntimeConfiguration<K, V> extends CacheConfiguration<K, V> {
 
   /**
-   * Allows for registering {@link org.ehcache.event.CacheEventListener} on the cache
+   * Allows for registering a {@link CacheEventListener} on the cache configured according to the provided
+   * {@link EventOrdering}, {@link EventFiring} and {@link EventType} set.
    *
    * @param listener the listener instance to register
    * @param ordering the {@link org.ehcache.event.EventOrdering ordering} required by this listener
@@ -48,7 +47,8 @@ public interface CacheRuntimeConfiguration<K, V> extends CacheConfiguration<K, V
                                   EventOrdering ordering, EventFiring firing, Set<EventType> forEventTypes);
 
   /**
-   * Allows for registering {@link org.ehcache.event.CacheEventListener} on the cache
+   * Allows for registering a {@link CacheEventListener} on the cache configured according to the provided
+   * {@link EventOrdering}, {@link EventFiring} and {@link EventType}s.
    *
    * @param listener the listener instance to register
    * @param ordering the {@link org.ehcache.event.EventOrdering ordering} required by this listener

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/builders/ClusteringServiceConfigurationBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/builders/ClusteringServiceConfigurationBuilder.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.ehcache.clustered.client.config.ClusteringServiceConfiguration;
 import org.ehcache.clustered.client.config.ClusteringServiceConfiguration.PoolDefinition;
-import org.ehcache.config.builders.Builder;
+import org.ehcache.config.Builder;
 import org.ehcache.config.units.MemoryUnit;
 
 import static java.util.Collections.emptyMap;

--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -40,7 +40,7 @@ import org.ehcache.core.internal.store.StoreSupport;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
 import org.ehcache.core.internal.util.ClassLoading;
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
+import org.ehcache.core.events.CacheEventListenerConfiguration;
 import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.exceptions.CachePersistenceException;
 import org.ehcache.spi.LifeCycled;

--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -19,6 +19,7 @@ package org.ehcache.core;
 import org.ehcache.Cache;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.Status;
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.Configuration;
 import org.ehcache.config.ResourcePool;
@@ -236,6 +237,11 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
         }
       }
     }
+  }
+
+  @Override
+  public <K, V> Cache<K, V> createCache(String alias, Builder<? extends CacheConfiguration<K, V>> configBuilder) {
+    return createCache(alias, configBuilder.build());
   }
 
   @Override

--- a/core/src/main/java/org/ehcache/core/EhcacheRuntimeConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheRuntimeConfiguration.java
@@ -16,14 +16,12 @@
 
 package org.ehcache.core;
 
-import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.core.internal.events.EventListenerWrapper;
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
 import org.ehcache.event.EventType;

--- a/core/src/main/java/org/ehcache/core/EhcacheRuntimeConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheRuntimeConfiguration.java
@@ -16,12 +16,14 @@
 
 package org.ehcache.core;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.core.internal.events.EventListenerWrapper;
 import org.ehcache.event.CacheEventListener;
+import org.ehcache.event.CacheEventListenerConfiguration;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
 import org.ehcache.event.EventType;

--- a/core/src/main/java/org/ehcache/core/events/CacheEventListenerConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/events/CacheEventListenerConfiguration.java
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package org.ehcache.event;
+package org.ehcache.core.events;
 
+import org.ehcache.event.CacheEventListenerProvider;
+import org.ehcache.event.EventFiring;
+import org.ehcache.event.EventOrdering;
+import org.ehcache.event.EventType;
 import org.ehcache.spi.service.ServiceConfiguration;
 
 import java.util.EnumSet;
 
 /**
  * Configuration contract for setting up {@link org.ehcache.event.CacheEvent} system in a cache.
- *
- * @author Alex Snaps
  */
 public interface CacheEventListenerConfiguration extends ServiceConfiguration<CacheEventListenerProvider> {
 

--- a/core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
@@ -308,7 +308,7 @@ public class EhcacheManagerTest {
       assertThat(e.getMessage().contains(Status.UNINITIALIZED.name()), is(true));
     }
     try {
-      cacheManager.createCache("foo", null);
+      cacheManager.createCache("foo", (CacheConfiguration) null);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e.getMessage().contains(Status.UNINITIALIZED.name()), is(true));

--- a/impl/src/main/java/org/ehcache/config/builders/CacheConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/CacheConfigurationBuilder.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.config.builders;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePools;

--- a/impl/src/main/java/org/ehcache/config/builders/CacheEventListenerConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/CacheEventListenerConfigurationBuilder.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.config.builders;
 
+import org.ehcache.config.Builder;
 import org.ehcache.impl.config.event.DefaultCacheEventListenerConfiguration;
 import org.ehcache.event.CacheEventListener;
 import org.ehcache.event.CacheEventListenerConfiguration;

--- a/impl/src/main/java/org/ehcache/config/builders/CacheEventListenerConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/CacheEventListenerConfigurationBuilder.java
@@ -19,7 +19,7 @@ package org.ehcache.config.builders;
 import org.ehcache.config.Builder;
 import org.ehcache.impl.config.event.DefaultCacheEventListenerConfiguration;
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
+import org.ehcache.core.events.CacheEventListenerConfiguration;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
 import org.ehcache.event.EventType;

--- a/impl/src/main/java/org/ehcache/config/builders/CacheManagerBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/CacheManagerBuilder.java
@@ -18,6 +18,7 @@ package org.ehcache.config.builders;
 
 import org.ehcache.CacheManager;
 import org.ehcache.PersistentCacheManager;
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.Configuration;
 import org.ehcache.config.units.MemoryUnit;

--- a/impl/src/main/java/org/ehcache/config/builders/ConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/ConfigurationBuilder.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.config.builders;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.Configuration;
 import org.ehcache.core.config.DefaultConfiguration;

--- a/impl/src/main/java/org/ehcache/config/builders/PooledExecutionServiceConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/PooledExecutionServiceConfigurationBuilder.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.config.builders;
 
+import org.ehcache.config.Builder;
 import org.ehcache.impl.config.executor.PooledExecutionServiceConfiguration;
 
 import java.util.HashSet;

--- a/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/ResourcePoolsBuilder.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.config.builders;
 
+import org.ehcache.config.Builder;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.units.EntryUnit;

--- a/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -17,6 +17,7 @@
 package org.ehcache.config.builders;
 
 import org.ehcache.Cache;
+import org.ehcache.config.Builder;
 import org.ehcache.core.Ehcache;
 import org.ehcache.core.EhcacheWithLoaderWriter;
 import org.ehcache.core.InternalCache;

--- a/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -33,7 +33,7 @@ import org.ehcache.core.spi.store.heap.SizeOfEngine;
 import org.ehcache.impl.events.CacheEventDispatcherImpl;
 import org.ehcache.core.internal.store.StoreSupport;
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
+import org.ehcache.core.events.CacheEventListenerConfiguration;
 import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 import org.ehcache.impl.config.serializer.DefaultSerializerConfiguration;

--- a/impl/src/main/java/org/ehcache/config/builders/WriteBehindConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/WriteBehindConfigurationBuilder.java
@@ -18,6 +18,7 @@ package org.ehcache.config.builders;
 
 import java.util.concurrent.TimeUnit;
 
+import org.ehcache.config.Builder;
 import org.ehcache.impl.config.loaderwriter.writebehind.DefaultBatchingConfiguration;
 import org.ehcache.impl.config.loaderwriter.writebehind.DefaultWriteBehindConfiguration;
 import org.ehcache.spi.loaderwriter.WriteBehindConfiguration;
@@ -30,7 +31,7 @@ import org.ehcache.spi.loaderwriter.WriteBehindConfiguration.BatchingConfigurati
  * instance without modifying the one on which the method was called.
  * This enables the sharing of builder instances without any risk of seeing them modified by code elsewhere.
  */
-public abstract class WriteBehindConfigurationBuilder implements Builder<WriteBehindConfiguration>  {
+public abstract class WriteBehindConfigurationBuilder implements Builder<WriteBehindConfiguration> {
 
   protected int concurrency = 1;
   protected int queueSize = Integer.MAX_VALUE;

--- a/impl/src/main/java/org/ehcache/impl/config/event/DefaultCacheEventListenerConfiguration.java
+++ b/impl/src/main/java/org/ehcache/impl/config/event/DefaultCacheEventListenerConfiguration.java
@@ -17,7 +17,7 @@
 package org.ehcache.impl.config.event;
 
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
+import org.ehcache.core.events.CacheEventListenerConfiguration;
 import org.ehcache.event.CacheEventListenerProvider;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;

--- a/impl/src/test/java/org/ehcache/impl/internal/spi/event/DefaultCacheEventListenerProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/spi/event/DefaultCacheEventListenerProviderTest.java
@@ -24,7 +24,7 @@ import org.ehcache.config.builders.CacheEventListenerConfigurationBuilder;
 import org.ehcache.impl.config.event.DefaultCacheEventListenerConfiguration;
 import org.ehcache.event.CacheEvent;
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.CacheEventListenerConfiguration;
+import org.ehcache.core.events.CacheEventListenerConfiguration;
 import org.ehcache.event.EventType;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.hamcrest.core.IsCollectionContaining;

--- a/integration-test/src/test/java/org/ehcache/integration/SimpleEhcacheTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/SimpleEhcacheTest.java
@@ -58,7 +58,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimplePut() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
     assertThat(testCache.get(1), Matchers.<CharSequence>equalTo("one"));
@@ -66,7 +66,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimplePutIfAbsent() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     CharSequence one = testCache.putIfAbsent(1, "one");
     assertThat(one, is(nullValue()));
@@ -77,7 +77,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimplePutAll() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     Map<Integer, String> values = new HashMap<Integer, String>();
     values.put(1, "one");
@@ -93,7 +93,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleGetAll() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -107,7 +107,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleContainsKey() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
 
@@ -117,7 +117,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testClear() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -130,7 +130,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleRemove() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -143,7 +143,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleRemoveAll() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
     testCache.put(2, "two");
@@ -158,7 +158,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleRemove2Args() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
 
@@ -170,7 +170,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleReplace() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
 
@@ -181,7 +181,7 @@ public class SimpleEhcacheTest {
 
   @Test
   public void testSimpleReplace3Args() throws Exception {
-    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)).build());
+    Cache<Number, CharSequence> testCache = cacheManager.createCache("testCache", newCacheConfigurationBuilder(Number.class, CharSequence.class, heap(10)));
 
     testCache.put(1, "one");
 

--- a/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
@@ -21,7 +21,7 @@ import org.ehcache.config.Configuration;
 import org.ehcache.config.EvictionVeto;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourcePools;
-import org.ehcache.config.builders.Builder;
+import org.ehcache.config.Builder;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheEventListenerConfigurationBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;


### PR DESCRIPTION
* Enables CacheManager.createCache to be seeded with a Builder of
CacheConfiguration
* Took the opportunity to add some more overloaded methods taking
builders when there was a version taking a configuration