### PR TITLE
Issue #975 Fix inter document links

### DIFF
--- a/docs/src/docs/asciidoc/user/107.adoc
+++ b/docs/src/docs/asciidoc/user/107.adoc
@@ -61,7 +61,7 @@ include::{sourcedir}/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationI
 === Getting JSR-107 caches configured through Ehcache XML
 
 Another way to have the full Ehcache configuration options on your caches while having no code dependency on the provider is
-to use XML based configuration. See link:xml{outfilesuffix}[the XML documentation] for more details on configuring `Cache`s in XML.
+to use XML based configuration. See <<xml.adoc#,the XML documentation>> for more details on configuring `Cache`s in XML.
 
 Find below the XML configuration followed by the code to use it from JSR-107:
 
@@ -85,10 +85,11 @@ NOTE: You can also use the `CachingProvider.getCacheManager()` method that takes
       vendor specific values returned by `CachingProvider.getDefaultURI` and `.getDefaultClassLoader` respectively.
       Be aware that these are not entirely specified for Ehcache 3.0 and may change in future releases!
 
+[[supplement-jsr-107-configurations]]
 === Supplement JSR-107's configurations
 
 As of Ehcache 3.0, you can also create `cache-templates`.  See the
-link:xml{outfilesuffix}#code-cache-template-code-elements[Cache Templates] section of the XML Documentation for more details. The Ehcache 3.0
+<<xml.adoc#cache-template-elements,Cache Templates>> section of the XML Documentation for more details. The Ehcache 3.0
 JSR-107 Caching Provider comes with an extension to the regular XML configuration so you can:
 
  . Configure a default template from which all programmatically created `Cache` instances inherit, and
@@ -111,7 +112,7 @@ include::{sourcedir}/107/src/test/resources/org/ehcache/docs/ehcache-jsr107-temp
     creating the `Cache` named `foos` at runtime, Ehcache will enhance its config, giving it a capacity of 2000 entries,
     as well as insuring both key and value types are `String`.
 
-NOTE: See link:xsds{outfilesuffix}#jsr-107-extension[this xsd] for complete definition
+NOTE: See <<xsds.adoc#jsr-107-extension,this xsd>> for complete definition
 
 Using the above configuration, you can not only supplement but also override the configuration of JSR-107 created caches
 without modifying the application code.

--- a/docs/src/docs/asciidoc/user/examples.adoc
+++ b/docs/src/docs/asciidoc/user/examples.adoc
@@ -100,7 +100,7 @@ While running, lines like the following are displayed to the console:
 ----
 Note the presence of the +Filling cache with peeps+, +Clearing peeps cache+, and +Getting peeps from cache+ lines indicating cache interactions.
 
-
+[[xml-with-107-extension]]
 == XML with 107 extension
 
 [source,xml,indent=0]

--- a/docs/src/docs/asciidoc/user/getting-started.adoc
+++ b/docs/src/docs/asciidoc/user/getting-started.adoc
@@ -15,11 +15,12 @@ We feel that the Ehcache 3.0 API is a great improvement over the Ehcache 2.x API
 millions of developers.   We hope you enjoy this new generation of Ehcache!
 
 NOTE: If you are looking to use the JSR-107, aka `javax.cache` API, you should start by reading
-      link:107{outfilesuffix}[the Ehcache 3.x JSR-107 Provider page]
+      <<107.adoc#,the Ehcache 3.x JSR-107 Provider page>>.
 
 In order to start using Ehcache, you will need to configure your first `CacheManager` and `Cache`.
 This can be achieved through <<configuring-with-java,programmatic configuration>> or <<configuring-with-xml,XML>>.
 
+[[configuring-with-java]]
 == Configuring with Java
 
 Java configuration is most easily achieved through the use of builders that offer a fluent API.
@@ -71,7 +72,7 @@ include::{sourcedir}/impl/src/test/java/org/ehcache/docs/UserManagedCaches.java[
 <4> In the same vein, a `UserManagedCache` requires you to `UserManagedCache.close()` it explicitly. If you would also use
     managed caches simultaneously, the `CacheManager.close()` operation would not impact the user managed cache(s).
 
-NOTE: See link:usermanaged{outfilesuffix}[the user managed cache documentation] for more information on this feature.
+NOTE: See <<usermanaged.adoc#,the user managed cache documentation>> for more information on this feature.
 
 == Storage Tiers
 
@@ -165,7 +166,7 @@ include::{sourcedir}/impl/src/test/java/org/ehcache/docs/GettingStarted.java[tag
 <2> To update capacity of `ResourcePools`, `updateResourcePools(ResourcePools)` method in `RuntimeConfiguration` can be of help.
     `ResourcePools` object created earlier can then be passed to this method so as to trigger the update.
 
-
+[[configuring-with-xml]]
 == Configuring With XML
 
 ...It wouldn't be Java without _some_ XML
@@ -185,7 +186,7 @@ include::{sourcedir}/xml/src/test/resources/configs/docs/getting-started.xml[tag
 <6> `bar` is such a `Cache`.   `bar` uses the `<cache-template>` named `myDefaults` and overrides its `key-type` to a wider type.
 <7> `simpleCache` is another such a `Cache`.  It uses `myDefaults` configuration for its sole `CacheConfiguration`.
 
-Refer to the link:xml{outfilesuffix}[XML documentation] for more details on the XML format.
+Refer to the <<xml.adoc#,XML documentation>> for more details on the XML format.
 
 In order to parse an XML configuration, you can use the `XmlConfiguration` type:
 

--- a/docs/src/docs/asciidoc/user/serializers-copiers.adoc
+++ b/docs/src/docs/asciidoc/user/serializers-copiers.adoc
@@ -117,6 +117,7 @@ Ehcache instantiated the serializer itself.
 When Ehcache instantiates a serializer itself, it will pass it a `ClassLoader` via the constructor. Such class loader must be used to access the classes
 of the serialized types as they might not be available in the current class loader
 
+[[persistent-vs-transient-caches]]
 ==== Persistent vs. transient caches
 
 When configured on a persistent cache, serializers may need to persist and restore their state across restarts, so you have to implement a

--- a/docs/src/docs/asciidoc/user/xml.adoc
+++ b/docs/src/docs/asciidoc/user/xml.adoc
@@ -13,7 +13,7 @@ endif::notBuildingForSite[]
 == Introduction
 
 Using an XML file you can configure a `CacheManager` at creation time, according to
-link:xsds{outfilesuffix}#core[this schema definition].
+<<xsds.adoc#core,this schema definition>>.
 
 === `<config>` root element
 
@@ -35,7 +35,7 @@ is called during `CacheManager.init` processing and the `Service.stop` method is
 These `Service` instances can then be used by `Cache` instances managed by the `CacheManager`.
 
 JSR-107 uses this extension point of the XML configuration (and Ehcache 3's modular architecture), as explained in the
-link:107{outfilesuffix}#supplement-jsr-107-s-configurations[JSR-107 configuration section].
+<<107.adoc#supplement-jsr-107-configurations,JSR-107 configuration section>>.
 
 === `<default-serializers>` element
 
@@ -57,7 +57,7 @@ It requires the `directory` location where data needs be stored on disk.
 A `<cache>` element represent a `Cache` instance that will be created and managed by the `CacheManager`.
 Each `<cache>` requires the `alias` attribute, used at runtime to retrieve the corresponding `Cache<K, V>` instance using
 the `org.ehcache.CacheManager.getCache(String, Class<K>, Class<V>)` method. The optional `uses-template` attribute, lets you reference
-a `<cache-template>` element's `name` attribute. See the <<code-cache-template-code-elements,cache-template section>>
+a `<cache-template>` element's `name` attribute. See the <<cache-template-elements,cache-template section>>
 for further details on using them.
 
 Supported nested elements are optional:
@@ -69,6 +69,7 @@ Supported nested elements are optional:
  . `<integration>`: configure a `CacheLoaderWriter` for a _cache-through_ pattern
  . `<resources>`: configure the tiers and their capacity. When using on-heap only, you can replace this element by the `<heap>` one.
 
+[[cache-template-elements]]
 === `<cache-template>` elements
 
 `<cache-template>` elements represent a uniquely named (specified using the mandatory `name` attribute) template for
@@ -78,7 +79,7 @@ can override these properties as it needs.
 
 A `<cache-template>` element may contain all the same child elements as a `<cache>` element.
 
-NOTE: We've setup a complete configuration link:examples{outfilesuffix}#xml-with-107-extension[example] to inspire you.
+NOTE: We've setup a complete configuration <<examples.adoc#xml-with-107-extension,example>> to inspire you.
 
 == XML programmatic parsing
 

--- a/docs/src/docs/asciidoc/user/xsds.adoc
+++ b/docs/src/docs/asciidoc/user/xsds.adoc
@@ -10,6 +10,7 @@ ifdef::notBuildingForSite[]
 include::menu.adoc[]
 endif::notBuildingForSite[]
 
+[[core]]
 == Core
 
 [source,xsd,indent=0]
@@ -17,6 +18,7 @@ endif::notBuildingForSite[]
 include::{sourcedir}/xml/src/main/resources/ehcache-core.xsd[lines=18..-1]
 ----
 
+[[jsr-107-extension]]
 == JSR-107 extension
 
 [source,xsd,indent=0]


### PR DESCRIPTION
* Use proper asciidoc syntax
* Specify explicit section IDs when referenced