### PR TITLE
Issue 870: fix BulkCacheWritingException under load

### DIFF
--- a/api/src/main/java/org/ehcache/spi/loaderwriter/BulkCacheWritingException.java
+++ b/api/src/main/java/org/ehcache/spi/loaderwriter/BulkCacheWritingException.java
@@ -66,4 +66,15 @@ public class BulkCacheWritingException extends CacheWritingException {
   public Set<?> getSuccesses() {
     return successes;
   }
+
+  @Override
+  public String getMessage() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Failed keys :");
+    for (Map.Entry<?, Exception> entry : failures.entrySet()) {
+      sb.append("\n ").append(entry.getKey()).append(" : ").append(entry.getValue());
+    }
+    return sb.toString();
+  }
+
 }

--- a/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
@@ -628,10 +628,15 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     }
   }
 
-  private void cacheLoaderWriterWriteAllCall(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, Map<K, V> entriesToRemap, Set<K> successes, Map<K, Exception> failures) {
+  private void cacheLoaderWriterWriteAllCall(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, Map<K, V> entriesToRemap, Set<K> successes, Map<K, Exception> failures) throws IllegalStateException {
     Map<K, V> toWrite = new HashMap<K, V>();
     for (Map.Entry<? extends K, ? extends V> entry: entries) {
-      toWrite.put(entry.getKey(), entriesToRemap.get(entry.getKey()));
+      V value = entriesToRemap.get(entry.getKey());
+      if (value == null) {
+        continue;
+      }
+
+      toWrite.put(entry.getKey(), value);
     }
     try {
       if (! toWrite.isEmpty()) {
@@ -688,7 +693,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
       new Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>>() {
         @Override
         public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries) {
-          Set<K> unknowns = cacheLoaderWriterDeleteAllCall(entries, successes, failures);
+          Set<K> unknowns = cacheLoaderWriterDeleteAllCall(entries, entriesToRemove, successes, failures);
 
           Map<K, V> results = new LinkedHashMap<K, V>();
 
@@ -728,7 +733,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
       try {
         // just in case not all writes happened:
         if (!entriesToRemove.isEmpty()) {
-          cacheLoaderWriterDeleteAllCall(entriesToRemove.entrySet(), successes, failures);
+          cacheLoaderWriterDeleteAllCall(entriesToRemove.entrySet(), entriesToRemove, successes, failures);
         }
         if (failures.isEmpty()) {
           resilienceStrategy.removeAllFailure(keys, e);
@@ -741,11 +746,14 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     }
   }
 
-  private Set<K> cacheLoaderWriterDeleteAllCall(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, Set<K> successes, Map<K, Exception> failures) {
+  private Set<K> cacheLoaderWriterDeleteAllCall(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, Map<K, ? extends V> entriesToRemove, Set<K> successes, Map<K, Exception> failures) {
     final Set<K> unknowns = new HashSet<K>();
     Set<K> toDelete = new HashSet<K>();
     for (Map.Entry<? extends K, ? extends V> entry : entries) {
-      toDelete.add(entry.getKey());
+      K key = entry.getKey();
+      if (entriesToRemove.containsKey(key)) {
+        toDelete.add(key);
+      }
     }
 
     try {

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
@@ -24,6 +24,8 @@ import org.ehcache.core.spi.function.Function;
 import org.ehcache.core.spi.function.NullaryFunction;
 import org.ehcache.core.statistics.BulkOps;
 import org.ehcache.spi.loaderwriter.BulkCacheWritingException;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,13 +33,18 @@ import org.junit.rules.TestName;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Formatter;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +56,8 @@ import static org.ehcache.core.EhcacheBasicBulkUtil.KEY_SET_C;
 import static org.ehcache.core.EhcacheBasicBulkUtil.copyWithout;
 import static org.ehcache.core.EhcacheBasicBulkUtil.fanIn;
 import static org.ehcache.core.EhcacheBasicBulkUtil.getEntryMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
@@ -56,14 +65,18 @@ import static org.hamcrest.Matchers.isIn;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Provides testing of basic REMOVE_ALL operations on an {@code Ehcache}.
@@ -245,6 +258,48 @@ public class EhcacheBasicRemoveAllTest extends EhcacheBasicCrudBase {
     assertThat(ehcache.getBulkMethodEntries().get(BulkOps.REMOVE_ALL).intValue(), is(0));
   }
 
+  @Test
+  public void removeAllStoreCallsMethodTwice() throws Exception {
+    this.store = mock(Store.class);
+    CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
+    final List<String> removed = new ArrayList<String>();
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        Iterable<String> i = (Iterable) invocation.getArguments()[0];
+        for (String key : i) {
+          removed.add(key);
+        }
+        return null;
+      }
+    }).when(cacheLoaderWriter).deleteAll(any(Iterable.class));
+    final EhcacheWithLoaderWriter<String, String> ehcache = this.getEhcacheWithLoaderWriter(cacheLoaderWriter);
+
+    final ArgumentCaptor<Function> functionArgumentCaptor = ArgumentCaptor.forClass(Function.class);
+
+    when(store.bulkCompute(anySet(), functionArgumentCaptor.capture())).then(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        Function function = functionArgumentCaptor.getValue();
+        Iterable arg = new HashMap((Map) function.getClass().getDeclaredField("val$entriesToRemove").get(function)).entrySet();
+        function.apply(arg);
+        function.apply(arg);
+        return null;
+      }
+    });
+
+    Set<String> keys = new HashSet<String>() {{
+      add("1");
+      add("2");
+    }};
+
+    ehcache.removeAll(keys);
+
+    assertThat(removed.size(), is(2));
+    assertThat(removed.contains("1"), is(true));
+    assertThat(removed.contains("2"), is(true));
+  }
+
   /**
    * Gets an initialized {@link Ehcache Ehcache} instance
    *
@@ -252,6 +307,14 @@ public class EhcacheBasicRemoveAllTest extends EhcacheBasicCrudBase {
    */
   private Ehcache<String, String> getEhcache() {
     final Ehcache<String, String> ehcache = new Ehcache<String, String>(CACHE_CONFIGURATION, this.store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicRemoveAllTest"));
+    ehcache.init();
+    assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
+    this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);
+    return ehcache;
+  }
+
+  private EhcacheWithLoaderWriter<String, String> getEhcacheWithLoaderWriter(CacheLoaderWriter<? super String, String> cacheLoaderWriter) {
+    final EhcacheWithLoaderWriter<String, String> ehcache = new EhcacheWithLoaderWriter<String, String>(CACHE_CONFIGURATION, this.store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheBasicPutAllTest"));
     ehcache.init();
     assertThat("cache not initialized", ehcache.getStatus(), Matchers.is(Status.AVAILABLE));
     this.spiedResilienceStrategy = this.setResilienceStrategySpy(ehcache);


### PR DESCRIPTION
The EhcacheWithLoaderWriter removeAll() and putAll() implementations now have the logic to deal with Store.bulkCompute() calling the function with the same arguments many times.

I've also modified the BulkCacheWritingException class to report a more useful error message.