### PR TITLE
Remove mavenLocal() from repo list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ subprojects {
   repositories {
     mavenCentral()
     maven { url "http://repo.terracotta.org/maven2" }
-    mavenLocal()
   }
 
   sourceSets {


### PR DESCRIPTION
Its presence causes more grief than anything. Developers needing to
pull locally built artifacts can add it temporarily.