### PR TITLE
:bug: #992 Replace Boolean with enum for 3 states

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/ConfigurationMerger.java
+++ b/107/src/main/java/org/ehcache/jsr107/ConfigurationMerger.java
@@ -25,6 +25,7 @@ import org.ehcache.impl.config.copy.DefaultCopyProviderConfiguration;
 import org.ehcache.impl.config.loaderwriter.DefaultCacheLoaderWriterConfiguration;
 import org.ehcache.impl.internal.classes.ClassInstanceConfiguration;
 import org.ehcache.impl.copy.SerializingCopier;
+import org.ehcache.jsr107.config.ConfigurationElementState;
 import org.ehcache.jsr107.config.Jsr107CacheConfiguration;
 import org.ehcache.jsr107.config.Jsr107Service;
 import org.ehcache.spi.copy.Copier;
@@ -265,23 +266,23 @@ class ConfigurationMerger {
   }
 
   private void setupManagementAndStatsInternal(Eh107Configuration<?, ?> configuration, Jsr107CacheConfiguration cacheConfiguration) {
-    Boolean enableManagement = jsr107Service.isManagementEnabledOnAllCaches();
-    Boolean enableStatistics = jsr107Service.isStatisticsEnabledOnAllCaches();
+    ConfigurationElementState enableManagement = jsr107Service.isManagementEnabledOnAllCaches();
+    ConfigurationElementState enableStatistics = jsr107Service.isStatisticsEnabledOnAllCaches();
     if (cacheConfiguration != null) {
-      Boolean managementEnabled = cacheConfiguration.isManagementEnabled();
-      if (managementEnabled != null) {
+      ConfigurationElementState managementEnabled = cacheConfiguration.isManagementEnabled();
+      if (managementEnabled != null && managementEnabled != ConfigurationElementState.UNSPECIFIED) {
         enableManagement = managementEnabled;
       }
-      Boolean statisticsEnabled = cacheConfiguration.isStatisticsEnabled();
-      if (statisticsEnabled != null) {
+      ConfigurationElementState statisticsEnabled = cacheConfiguration.isStatisticsEnabled();
+      if (statisticsEnabled != null && statisticsEnabled != ConfigurationElementState.UNSPECIFIED) {
         enableStatistics = statisticsEnabled;
       }
     }
-    if (enableManagement != null) {
-      configuration.setManagementEnabled(enableManagement);
+    if (enableManagement != null && enableManagement != ConfigurationElementState.UNSPECIFIED) {
+      configuration.setManagementEnabled(enableManagement.asBoolean());
     }
-    if (enableStatistics != null) {
-      configuration.setStatisticsEnabled(enableStatistics);
+    if (enableStatistics != null && enableStatistics != ConfigurationElementState.UNSPECIFIED) {
+      configuration.setStatisticsEnabled(enableStatistics.asBoolean());
     }
   }
 

--- a/107/src/main/java/org/ehcache/jsr107/config/ConfigurationElementState.java
+++ b/107/src/main/java/org/ehcache/jsr107/config/ConfigurationElementState.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.jsr107.config;
+
+/**
+ * ConfigurationElementState
+ */
+public enum ConfigurationElementState {
+
+  /**
+   * Indicates the configuration did not specify a value
+   */
+  UNSPECIFIED {
+    @Override
+    public boolean asBoolean() {
+      throw new IllegalStateException("Cannot be converted to boolean");
+    }
+  },
+
+  /**
+   * Indicates the configuration disabled the option
+   */
+  DISABLED {
+    @Override
+    public boolean asBoolean() {
+      return false;
+    }
+  },
+
+  /**
+   * Indicates the configuration enabled the option
+   */
+  ENABLED {
+    @Override
+    public boolean asBoolean() {
+      return true;
+    }
+  };
+
+  public abstract boolean asBoolean();
+}

--- a/107/src/main/java/org/ehcache/jsr107/config/Jsr107CacheConfiguration.java
+++ b/107/src/main/java/org/ehcache/jsr107/config/Jsr107CacheConfiguration.java
@@ -23,10 +23,10 @@ import org.ehcache.spi.service.ServiceConfiguration;
  */
 public class Jsr107CacheConfiguration implements ServiceConfiguration<Jsr107Service> {
 
-  private final Boolean statisticsEnabled;
-  private final Boolean managementEnabled;
+  private final ConfigurationElementState statisticsEnabled;
+  private final ConfigurationElementState managementEnabled;
 
-  public Jsr107CacheConfiguration(Boolean statisticsEnabled, Boolean managementEnabled) {
+  public Jsr107CacheConfiguration(ConfigurationElementState statisticsEnabled, ConfigurationElementState managementEnabled) {
     this.statisticsEnabled = statisticsEnabled;
     this.managementEnabled = managementEnabled;
   }
@@ -44,7 +44,7 @@ public class Jsr107CacheConfiguration implements ServiceConfiguration<Jsr107Serv
    *
    * @return {@code true} if management is enabled, {@code false} if disabled, {@code null} to keep cache manager level
    */
-  public Boolean isManagementEnabled() {
+  public ConfigurationElementState isManagementEnabled() {
     return managementEnabled;
   }
 
@@ -56,7 +56,7 @@ public class Jsr107CacheConfiguration implements ServiceConfiguration<Jsr107Serv
    *
    * @return {@code true} if statistics are enabled, {@code false} if disabled, {@code null} to keep cache manager level
    */
-  public Boolean isStatisticsEnabled() {
+  public ConfigurationElementState isStatisticsEnabled() {
     return statisticsEnabled;
   }
 }

--- a/107/src/main/java/org/ehcache/jsr107/config/Jsr107Configuration.java
+++ b/107/src/main/java/org/ehcache/jsr107/config/Jsr107Configuration.java
@@ -28,8 +28,8 @@ public class Jsr107Configuration implements ServiceCreationConfiguration<Jsr107S
 
   private final String defaultTemplate;
   private final boolean jsr107CompliantAtomics;
-  private final Boolean enableManagementAll;
-  private final Boolean enableStatisticsAll;
+  private final ConfigurationElementState enableManagementAll;
+  private final ConfigurationElementState enableStatisticsAll;
   private final Map<String, String> templates;
 
   /**
@@ -41,7 +41,7 @@ public class Jsr107Configuration implements ServiceCreationConfiguration<Jsr107S
    * @param enableStatisticsAll
    */
   public Jsr107Configuration(final String defaultTemplate, final Map<String, String> templates,
-                             boolean jsr107CompliantAtomics, Boolean enableManagementAll, Boolean enableStatisticsAll) {
+                             boolean jsr107CompliantAtomics, ConfigurationElementState enableManagementAll, ConfigurationElementState enableStatisticsAll) {
     this.defaultTemplate = defaultTemplate;
     this.jsr107CompliantAtomics = jsr107CompliantAtomics;
     this.enableManagementAll = enableManagementAll;
@@ -92,7 +92,7 @@ public class Jsr107Configuration implements ServiceCreationConfiguration<Jsr107S
    *
    * @return {@code true} to enable management on all caches, {@code false} otherwise
    */
-  public Boolean isEnableManagementAll() {
+  public ConfigurationElementState isEnableManagementAll() {
     return enableManagementAll;
   }
 
@@ -101,7 +101,7 @@ public class Jsr107Configuration implements ServiceCreationConfiguration<Jsr107S
    *
    * @return {@code true} to enable management on all caches, {@code false} otherwise
    */
-  public Boolean isEnableStatisticsAll() {
+  public ConfigurationElementState isEnableStatisticsAll() {
     return enableStatisticsAll;
   }
 }

--- a/107/src/main/java/org/ehcache/jsr107/config/Jsr107Service.java
+++ b/107/src/main/java/org/ehcache/jsr107/config/Jsr107Service.java
@@ -46,13 +46,13 @@ public interface Jsr107Service extends Service {
    *
    * @return {@code true} to enable management on all caches, {@code false} otherwise
    */
-  Boolean isManagementEnabledOnAllCaches();
+  ConfigurationElementState isManagementEnabledOnAllCaches();
 
   /**
    * Indicates if all created caches should have statistics enabled.
    *
    * @return {@code true} to enable management on all caches, {@code false} otherwise
    */
-  Boolean isStatisticsEnabledOnAllCaches();
+  ConfigurationElementState isStatisticsEnabledOnAllCaches();
 
 }

--- a/107/src/main/java/org/ehcache/jsr107/internal/DefaultJsr107Service.java
+++ b/107/src/main/java/org/ehcache/jsr107/internal/DefaultJsr107Service.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.jsr107.internal;
 
+import org.ehcache.jsr107.config.ConfigurationElementState;
 import org.ehcache.jsr107.config.Jsr107Configuration;
 import org.ehcache.jsr107.config.Jsr107Service;
 import org.ehcache.spi.service.ServiceProvider;
@@ -62,7 +63,7 @@ public class DefaultJsr107Service implements Jsr107Service {
   }
 
   @Override
-  public Boolean isManagementEnabledOnAllCaches() {
+  public ConfigurationElementState isManagementEnabledOnAllCaches() {
     if (configuration == null) {
       return null;
     } else {
@@ -71,7 +72,7 @@ public class DefaultJsr107Service implements Jsr107Service {
   }
 
   @Override
-  public Boolean isStatisticsEnabledOnAllCaches() {
+  public ConfigurationElementState isStatisticsEnabledOnAllCaches() {
     if (configuration == null) {
       return null;
     } else {

--- a/107/src/main/java/org/ehcache/jsr107/internal/Jsr107CacheConfigurationParser.java
+++ b/107/src/main/java/org/ehcache/jsr107/internal/Jsr107CacheConfigurationParser.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.jsr107.internal;
 
+import org.ehcache.jsr107.config.ConfigurationElementState;
 import org.ehcache.jsr107.config.Jsr107CacheConfiguration;
 import org.ehcache.jsr107.config.Jsr107Service;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -54,13 +55,13 @@ public class Jsr107CacheConfigurationParser implements CacheServiceConfiguration
   public ServiceConfiguration<Jsr107Service> parseServiceConfiguration(Element fragment) {
     String localName = fragment.getLocalName();
     if ("mbeans".equals(localName)) {
-      Boolean managementEnabled = null;
-      Boolean statisticsEnabled = null;
+      ConfigurationElementState managementEnabled = ConfigurationElementState.UNSPECIFIED;
+      ConfigurationElementState statisticsEnabled = ConfigurationElementState.UNSPECIFIED;
       if (fragment.hasAttribute(MANAGEMENT_ENABLED_ATTRIBUTE)) {
-        managementEnabled = Boolean.parseBoolean(fragment.getAttribute(MANAGEMENT_ENABLED_ATTRIBUTE));
+        managementEnabled = Boolean.parseBoolean(fragment.getAttribute(MANAGEMENT_ENABLED_ATTRIBUTE)) ? ConfigurationElementState.ENABLED : ConfigurationElementState.DISABLED;
       }
       if (fragment.hasAttribute(STATISTICS_ENABLED_ATTRIBUTE)) {
-        statisticsEnabled = Boolean.parseBoolean(fragment.getAttribute(STATISTICS_ENABLED_ATTRIBUTE));
+        statisticsEnabled = Boolean.parseBoolean(fragment.getAttribute(STATISTICS_ENABLED_ATTRIBUTE)) ? ConfigurationElementState.ENABLED : ConfigurationElementState.DISABLED;
       }
       return new Jsr107CacheConfiguration(statisticsEnabled, managementEnabled);
     } else {

--- a/107/src/main/java/org/ehcache/jsr107/internal/Jsr107ServiceConfigurationParser.java
+++ b/107/src/main/java/org/ehcache/jsr107/internal/Jsr107ServiceConfigurationParser.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.jsr107.internal;
 
+import org.ehcache.jsr107.config.ConfigurationElementState;
 import org.ehcache.jsr107.config.Jsr107Configuration;
 import org.ehcache.xml.CacheManagerServiceConfigurationParser;
 import org.ehcache.jsr107.config.Jsr107Service;
@@ -61,16 +62,16 @@ public class Jsr107ServiceConfigurationParser implements CacheManagerServiceConf
   @Override
   public ServiceCreationConfiguration<Jsr107Service> parseServiceCreationConfiguration(final Element fragment) {
     boolean jsr107CompliantAtomics = true;
-    Boolean enableManagementAll = null;
-    Boolean enableStatisticsAll = null;
+    ConfigurationElementState enableManagementAll = ConfigurationElementState.UNSPECIFIED;
+    ConfigurationElementState enableStatisticsAll = ConfigurationElementState.UNSPECIFIED;
     if (fragment.hasAttribute(JSR_107_COMPLIANT_ATOMICS_ATTRIBUTE)) {
       jsr107CompliantAtomics = parseBoolean(fragment.getAttribute(JSR_107_COMPLIANT_ATOMICS_ATTRIBUTE));
     }
     if (fragment.hasAttribute(ENABLE_MANAGEMENT_ALL_ATTRIBUTE)) {
-      enableManagementAll = parseBoolean(fragment.getAttribute(ENABLE_MANAGEMENT_ALL_ATTRIBUTE));
+      enableManagementAll = parseBoolean(fragment.getAttribute(ENABLE_MANAGEMENT_ALL_ATTRIBUTE)) ? ConfigurationElementState.ENABLED : ConfigurationElementState.DISABLED;
     }
     if (fragment.hasAttribute(ENABLE_STATISTICS_ALL_ATTRIBUTE)) {
-      enableStatisticsAll = parseBoolean(fragment.getAttribute(ENABLE_STATISTICS_ALL_ATTRIBUTE));
+      enableStatisticsAll = parseBoolean(fragment.getAttribute(ENABLE_STATISTICS_ALL_ATTRIBUTE)) ? ConfigurationElementState.ENABLED : ConfigurationElementState.DISABLED;
     }
     final String defaultTemplate = fragment.getAttribute(DEFAULT_TEMPLATE_ATTRIBUTE);
     final HashMap<String, String> templates = new HashMap<String, String>();

--- a/107/src/test/java/org/ehcache/jsr107/ConfigStatsManagementActivationTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/ConfigStatsManagementActivationTest.java
@@ -17,6 +17,7 @@
 package org.ehcache.jsr107;
 
 import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.jsr107.config.ConfigurationElementState;
 import org.ehcache.jsr107.config.Jsr107CacheConfiguration;
 import org.junit.After;
 import org.junit.Before;
@@ -103,7 +104,7 @@ public class ConfigStatsManagementActivationTest {
     CacheManager cacheManager = provider.getCacheManager();
 
     CacheConfigurationBuilder<Long, String> configurationBuilder = newCacheConfigurationBuilder(Long.class, String.class, heap(10))
-        .add(new Jsr107CacheConfiguration(true, true));
+        .add(new Jsr107CacheConfiguration(ConfigurationElementState.ENABLED, ConfigurationElementState.ENABLED));
     Cache<Long, String> cache = cacheManager.createCache("test", Eh107Configuration.fromEhcacheCacheConfiguration(configurationBuilder));
 
     Eh107Configuration<Long, String> configuration = cache.getConfiguration(Eh107Configuration.class);


### PR DESCRIPTION
Instead of using Boolean, enum with unspecified, disabled and enabled
 is used to extract configuration information for MBeans in 107.