### PR TITLE
Issue #1005 Add PUT operation and the codec for the same

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/BaseOperation.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/BaseOperation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations;
+
+/**
+ * Base class that represents a {@link org.ehcache.Cache} operation
+ *
+ * @param <K> key type
+ */
+public abstract class BaseOperation<K> {
+
+  protected final K key;
+
+  public BaseOperation(final K key) {
+    this.key = key;
+  }
+
+  public abstract OperationCode getOpCode();
+
+  public K getKey() {
+    return key;
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/OperationCode.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/OperationCode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations;
+
+import org.ehcache.clustered.client.internal.store.operations.codecs.OperationCodecFactory;
+
+import static org.ehcache.clustered.client.internal.store.operations.codecs.OperationCodecFactory.PutOperationCodecFactory;
+
+public enum OperationCode {
+
+  PUT((byte)1, new PutOperationCodecFactory());
+
+  private byte value;
+  private OperationCodecFactory codecFactory;
+
+  OperationCode(byte value, OperationCodecFactory codecFactory) {
+    this.value = value;
+    this.codecFactory = codecFactory;
+  }
+
+  public byte getValue() {
+    return value;
+  }
+
+  public OperationCodecFactory getCodecFactory() {
+    return codecFactory;
+  }
+
+  public static OperationCode valueOf(byte value) {
+    switch (value) {
+      case 1:
+        return PUT;
+      default:
+        throw new IllegalArgumentException("Operation undefined for the value " + value);
+    }
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/PutOperation.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/PutOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations;
+
+/**
+ * Represents the PUT operation on a {@link org.ehcache.Cache}
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class PutOperation<K, V> extends BaseOperation<K> {
+
+  public PutOperation(final K key, final V value) {
+    super(key);
+    this.value = value;
+  }
+
+  private final V value;
+
+  public V getValue() {
+    return value;
+  }
+
+  @Override
+  public OperationCode getOpCode() {
+    return OperationCode.PUT;
+  }
+
+  @Override
+  public String toString() {
+    return "PUT {" + key + ", " + value + '}';
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationCodec.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationCodec.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.clustered.client.internal.store.operations.BaseOperation;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Generic operation codec for all {@link BaseOperation}s
+ *
+ * @param <K> the key type
+ */
+public interface OperationCodec<K> {
+
+  ByteBuffer encode(BaseOperation<K> operation);
+
+  BaseOperation<K> decode(ByteBuffer buffer) throws ClassNotFoundException;
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationCodecFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationCodecFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.spi.serialization.Serializer;
+
+/**
+ * Base codec factory for all operations
+ */
+public abstract class OperationCodecFactory {
+
+  public abstract <K, V> OperationCodec<K> getOperationCodec(Serializer<K> keySerializer, Serializer<V> valueSerializer);
+
+  /**
+   * Codec factory for put operation
+   */
+  public static class PutOperationCodecFactory extends OperationCodecFactory {
+
+    public <K, V> OperationCodec<K> getOperationCodec(Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+      return new PutOperationCodec<K, V>(keySerializer, valueSerializer);
+    }
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationCodecProvider.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationCodecProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.clustered.client.internal.store.operations.OperationCode;
+import org.ehcache.spi.serialization.Serializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OperationCodecProvider<K, V> {
+
+  private final Serializer<K> keySerializer;
+  private final Serializer<V> valueSerializer;
+
+  private final Map<OperationCode, OperationCodec<K>> operationCodeVsCodecMap;
+
+  public OperationCodecProvider(final Serializer<K> keySerializer, final Serializer<V> valueSerializer) {
+    this.keySerializer = keySerializer;
+    this.valueSerializer = valueSerializer;
+    operationCodeVsCodecMap = populateCodecMap();
+  }
+
+  private Map<OperationCode, OperationCodec<K>> populateCodecMap() {
+    Map<OperationCode, OperationCodec<K>> map = new HashMap<OperationCode, OperationCodec<K>>();
+    for (OperationCode code : OperationCode.values()) {
+      operationCodeVsCodecMap.put(code, getNewCodec(code));
+    }
+    return map;
+  }
+
+  public OperationCodec<K> getOperationCodec(OperationCode code) {
+    return operationCodeVsCodecMap.get(code);
+  }
+
+  private OperationCodec<K> getNewCodec(OperationCode code) {
+    return code.getCodecFactory().getOperationCodec(keySerializer, valueSerializer);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationsCodec.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationsCodec.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.clustered.client.internal.store.operations.BaseOperation;
+import org.ehcache.clustered.client.internal.store.operations.OperationCode;
+
+import java.nio.ByteBuffer;
+
+public class OperationsCodec<K, V> {
+
+  public static final int BYTE_SIZE_BYTES = 1;
+  public static final int INT_SIZE_BYTES = 4;
+  public static final int LONG_SIZE_BYTES = 8;
+
+  private final OperationCodecProvider<K, V> codecProvider;
+
+  public OperationsCodec(final OperationCodecProvider<K, V> codecProvider) {
+    this.codecProvider = codecProvider;
+  }
+
+  public ByteBuffer encode(BaseOperation<K> operation) {
+    OperationCode opCode = operation.getOpCode();
+    return codecProvider.getOperationCodec(opCode).encode(operation);
+  }
+
+  public BaseOperation<K> decode(ByteBuffer buffer) throws ClassNotFoundException {
+    OperationCode opCode = OperationCode.valueOf(buffer.get());
+    buffer.rewind();
+    return codecProvider.getOperationCodec(opCode).decode(buffer);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/PutOperationCodec.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/codecs/PutOperationCodec.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.clustered.client.internal.store.operations.BaseOperation;
+import org.ehcache.clustered.client.internal.store.operations.OperationCode;
+import org.ehcache.clustered.client.internal.store.operations.PutOperation;
+import org.ehcache.spi.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+
+import static org.ehcache.clustered.client.internal.store.operations.OperationCode.PUT;
+import static org.ehcache.clustered.client.internal.store.operations.codecs.OperationsCodec.BYTE_SIZE_BYTES;
+import static org.ehcache.clustered.client.internal.store.operations.codecs.OperationsCodec.INT_SIZE_BYTES;
+
+public class PutOperationCodec<K, V> implements OperationCodec<K> {
+
+  private final Serializer<K> keySerializer;
+  private final Serializer<V> valueSerializer;
+
+  public PutOperationCodec(final Serializer<K> keySerializer, final Serializer<V> valueSerializer) {
+    this.keySerializer = keySerializer;
+    this.valueSerializer = valueSerializer;
+  }
+
+  public ByteBuffer encode(BaseOperation<K> operation) {
+    if (!(operation instanceof PutOperation)) {
+      throw new IllegalArgumentException(this.getClass().getName() + " can only decode " + PutOperation.class.getName());
+    }
+    PutOperation<K, V> putOperation = (PutOperation<K, V>)operation;
+
+    K key = putOperation.getKey();
+    V value = putOperation.getValue();
+
+    ByteBuffer keyBuf = keySerializer.serialize(key);
+    ByteBuffer valueBuf = valueSerializer.serialize(value);
+
+    /**
+     * Here we need to encode two objects of unknown size: the key and the value.
+     * Encoding should be done in such a way that the key and value can be read
+     * separately while decoding the bytes.
+     * So the way it is done here is by writing the size of the payload along with
+     * the payload. That is, the size of the key payload is written before the key
+     * itself and the same for value.
+     *
+     * While decoding, the size is read first and then reading the same number of
+     * bytes will get you the key payload. Same for value.
+     */
+    ByteBuffer buffer = ByteBuffer.allocate(BYTE_SIZE_BYTES +   // Operation type
+                                            INT_SIZE_BYTES +    // Size of the key payload
+                                            keyBuf.remaining() +  // the kay payload itself
+                                            INT_SIZE_BYTES +    // Size of value payload
+                                            valueBuf.remaining());  // The value payload itself
+    buffer.put(PUT.getValue());
+    buffer.putInt(keyBuf.remaining());
+    buffer.put(keyBuf);
+    buffer.putInt(valueBuf.remaining());
+    buffer.put(valueBuf);
+    buffer.flip();
+    return buffer;
+  }
+
+  public PutOperation<K, V> decode(ByteBuffer buffer) throws ClassNotFoundException {
+
+    OperationCode opCode = OperationCode.valueOf(buffer.get());
+    if (opCode != PUT) {
+      throw new IllegalArgumentException(this.getClass().getName() + " can not decode operation of type " + opCode);
+    }
+
+    int keySize = buffer.getInt();
+    buffer.limit(buffer.position() + keySize);
+    ByteBuffer keyBlob = buffer.slice();
+    buffer.position(buffer.limit());
+    buffer.limit(buffer.capacity());
+    int valueSize = buffer.getInt();
+    buffer.limit(buffer.position() + valueSize);
+    ByteBuffer valueBlob = buffer.slice();
+
+    return new PutOperation<K, V>(
+        keySerializer.read(keyBlob), valueSerializer.read(valueBlob));
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationsCodecTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/codecs/OperationsCodecTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.clustered.client.internal.store.operations.OperationCode;
+import org.ehcache.clustered.client.internal.store.operations.PutOperation;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OperationsCodecTest {
+
+  @Test
+  public void encode() throws Exception {
+    ByteBuffer buffer = mock(ByteBuffer.class);
+    PutOperation putOperation = mock(PutOperation.class);
+    when(putOperation.getOpCode()).thenReturn(OperationCode.PUT);
+    PutOperationCodec putOperationCodec = mock(PutOperationCodec.class);
+    when(putOperationCodec.encode(putOperation)).thenReturn(buffer);
+    OperationCodecProvider codecFactory = mock(OperationCodecProvider.class);
+    when(codecFactory.getOperationCodec(OperationCode.PUT)).thenReturn(putOperationCodec);
+
+    OperationsCodec codec = new OperationsCodec(codecFactory);
+    assertEquals(buffer, codec.encode(putOperation));
+
+    verify(codecFactory).getOperationCodec(OperationCode.PUT);
+    verify(putOperationCodec).encode(putOperation);
+  }
+
+  @Test
+  public void decode() throws Exception {
+    ByteBuffer buffer = mock(ByteBuffer.class);
+    when(buffer.get()).thenReturn((byte)1);
+    PutOperationCodec putOperationCodec = mock(PutOperationCodec.class);
+    PutOperation putOperation = mock(PutOperation.class);
+    when(putOperationCodec.decode(buffer)).thenReturn(putOperation);
+    OperationCodecProvider codecFactory = mock(OperationCodecProvider.class);
+    when(codecFactory.getOperationCodec(OperationCode.PUT)).thenReturn(putOperationCodec);
+
+    OperationsCodec codec = new OperationsCodec(codecFactory);
+    assertEquals(putOperation, codec.decode(buffer));
+
+    verify(codecFactory).getOperationCodec(OperationCode.PUT);
+    verify(putOperationCodec).decode(buffer);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void decodeInvalidOperation() throws Exception {
+    ByteBuffer buffer = mock(ByteBuffer.class);
+    when(buffer.get()).thenReturn((byte)-1);
+    OperationCodecProvider codecFactory = mock(OperationCodecProvider.class);
+
+    OperationsCodec codec = new OperationsCodec(codecFactory);
+    codec.decode(buffer);
+  }
+
+
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/codecs/PutOperationCodecTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/codecs/PutOperationCodecTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations.codecs;
+
+import org.ehcache.clustered.client.internal.store.operations.BaseOperation;
+import org.ehcache.clustered.client.internal.store.operations.PutOperation;
+import org.ehcache.impl.serialization.LongSerializer;
+import org.ehcache.impl.serialization.StringSerializer;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import static org.ehcache.clustered.client.internal.store.operations.codecs.OperationsCodec.BYTE_SIZE_BYTES;
+import static org.ehcache.clustered.client.internal.store.operations.codecs.OperationsCodec.INT_SIZE_BYTES;
+import static org.ehcache.clustered.client.internal.store.operations.codecs.OperationsCodec.LONG_SIZE_BYTES;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class PutOperationCodecTest {
+
+  @Test
+  public void testEncode() throws Exception {
+    Long key = 12L;
+    String value = "The value";
+    PutOperation<Long, String> putOperation = new PutOperation<Long, String>(key, value);
+    PutOperationCodec<Long, String> codec =
+        new PutOperationCodec<Long, String>(new LongSerializer(), new StringSerializer());
+
+    ByteBuffer byteBuffer = codec.encode(putOperation);
+
+    ByteBuffer expected = ByteBuffer.allocate(BYTE_SIZE_BYTES +
+                                              INT_SIZE_BYTES + LONG_SIZE_BYTES + INT_SIZE_BYTES + value.length());
+    expected.put((byte)1);
+    expected.putInt(8);
+    expected.putLong(key);
+    expected.putInt(value.length());
+    expected.put(value.getBytes());
+    expected.flip();
+    assertTrue(Arrays.equals(expected.array(), byteBuffer.array()));
+  }
+
+  @Test
+  public void testDecode() throws Exception {
+    Long key = 12L;
+    String value = "The value";
+
+    ByteBuffer blob = ByteBuffer.allocate(BYTE_SIZE_BYTES +
+                                          INT_SIZE_BYTES + LONG_SIZE_BYTES + INT_SIZE_BYTES + value.length());
+    blob.put((byte)1);
+    blob.putInt(8);
+    blob.putLong(key);
+    blob.putInt(value.length());
+    blob.put(value.getBytes());
+    blob.flip();
+
+    PutOperationCodec<Long, String> codec =
+        new PutOperationCodec<Long, String>(new LongSerializer(), new StringSerializer());
+
+    PutOperation<Long, String> putOperation = codec.decode(blob);
+    assertEquals(key, putOperation.getKey());
+    assertEquals(value, putOperation.getValue());
+  }
+
+  @Test
+  public void testEncodeDecodeInvariant() throws Exception {
+    Long key = 12L;
+    String value = "The value";
+    PutOperation<Long, String> putOperation = new PutOperation<Long, String>(key, value);
+    PutOperationCodec<Long, String> codec =
+        new PutOperationCodec<Long, String>(new LongSerializer(), new StringSerializer());
+
+    PutOperation<Long, String> decodedPutOperation = codec.decode(codec.encode(putOperation));
+    assertEquals(key, decodedPutOperation.getKey());
+    assertEquals(value, decodedPutOperation.getValue());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDecodeThrowsOnInvalidType() throws Exception {
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[] {2});
+    PutOperationCodec<Long, String> codec =
+        new PutOperationCodec<Long, String>(new LongSerializer(), new StringSerializer());
+
+    codec.decode(buffer);
+
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEncodeThrowsOnInvalidType() throws Exception {
+    PutOperationCodec<Long, String> codec =
+        new PutOperationCodec<Long, String>(new LongSerializer(), new StringSerializer());
+
+    codec.encode(mock(BaseOperation.class));
+  }
+}


### PR DESCRIPTION
A few assumptions made during the operation definition:
- The design was limited to simple get and put operations only.
- A sequence of PUT operations get resolved to the last PUT operation. A need for a different type to represent the resolved value does not exist at the moment as there is not metadata associated with operations. Hence PUT operation can be reused. A new type can be added if the need arises in future.
- Since the initial iteration is not gonna have expiry support the metadata has been completely omitted. Addition of metadata for expiry calculations will depend upon the decision taken on #1015.