### PR TITLE
Remove TODO from ClusteredStore for proxy #994

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -60,18 +60,6 @@ import static org.ehcache.core.internal.service.ServiceLocator.findSingletonAmon
 /**
  * Supports a {@link Store} in a clustered environment.
  */
-// *********************************************************************************************
-// *********************************************************************************************
-// *                                                                                           *
-// * This is a shell of an implementation that is a placeholder for a real implementation.     *
-// * The methods in this class are, at this point, not expected to function "properly".        *
-// *                                                                                           *
-// * In its present form, the cache configuration must provide some 'core' resource in         *
-// * addition to the clustered resources.                                                      *
-// *                                                                                           *
-// *********************************************************************************************
-// *********************************************************************************************
-// TODO: Remove underlyingStore when ServerStore/ServerStoreProxy is complete
 public class ClusteredStore<K, V> implements Store<K, V> {
 
   private final OperationsCodec<K, V> codec;


### PR DESCRIPTION
Removing the comment as well, since all the operations are having specific `TODO`s.
And we have a `TODO` for tiering as well 