### PR TITLE
Issue #1075 Completing CRUD operations on clustered store

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -70,8 +70,17 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
 
   @Override
   public ValueHolder<V> get(final K key) throws StoreAccessException {
+    V value = getInternal(key);
+    if(value == null) {
+      return null;
+    } else {
+      return new ClusteredValueHolder<V>(value);
+    }
+  }
+
+  private V getInternal(K key) {
     Chain chain = storeProxy.get(key.hashCode());
-    V value = null;
+    V value;
     if(!chain.isEmpty()) {
       ResolvedChain<K, V> resolvedChain = resolver.resolve(chain, key);
 
@@ -87,13 +96,16 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
     } else {
       return null;
     }
-    return new ClusteredValueHolder<V>(value);
+    return value;
   }
 
   @Override
   public boolean containsKey(final K key) throws StoreAccessException {
-    // TODO: Make appropriate ServerStoreProxy call
-    throw new UnsupportedOperationException("Implement me");
+    if(getInternal(key) == null) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -155,7 +155,7 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
 
   @Override
   public void clear() throws StoreAccessException {
-    // TODO: Make appropriate ServerStoreProxy call
+    storeProxy.clear();
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -101,11 +101,7 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
 
   @Override
   public boolean containsKey(final K key) throws StoreAccessException {
-    if(getInternal(key) == null) {
-      return false;
-    } else {
-      return true;
-    }
+    return getInternal(key) != null;
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ServerStoreProxy.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ServerStoreProxy.java
@@ -98,4 +98,13 @@ public class ServerStoreProxy implements ServerStore {
       throw new ServerStoreProxyException(e);
     }
   }
+
+  @Override
+  public void clear() {
+    try {
+      entity.invoke(EhcacheEntityMessage.clearOperation(cacheId), true);
+    } catch (Exception e) {
+      throw new ServerStoreProxyException(e);
+    }
+  }
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ServerStoreProxy.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ServerStoreProxy.java
@@ -102,7 +102,7 @@ public class ServerStoreProxy implements ServerStore {
   @Override
   public void clear() {
     try {
-      entity.invoke(EhcacheEntityMessage.clearOperation(cacheId), true);
+      entity.invoke(messageFactory.clearOperation(), true);
     } catch (Exception e) {
       throw new ServerStoreProxyException(e);
     }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
@@ -115,8 +115,8 @@ public class GettingStarted {
   }
 
   @Test
-  public void clusteredCachePutGet() throws Exception {
-    // tag::clusteredCachePutGet[]
+  public void clusteredCacheCRUD() throws Exception {
+    // tag::clusteredCacheCRUD[]
     final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder
         = CacheManagerBuilder.newCacheManagerBuilder()
         .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("terracotta://localhost:9510/my-application?auto-create"))
@@ -138,10 +138,12 @@ public class GettingStarted {
       assertThat(cache.get(1L), equalTo("Another one"));
       assertThat(cache.get(2L), equalTo("The two"));
       assertThat(cache.get(3L), equalTo("The three"));
+      cache.remove(1L);
+      assertThat(cache.get(1L), is(nullValue()));
     } finally {
       cacheManager.close();
     }
-    // tag::clusteredCachePutGet[]
+    // tag::clusteredCacheCRUD[]
   }
 
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
@@ -132,7 +132,9 @@ public class GettingStarted {
       Cache<Long, String> cache = cacheManager.createCache("clustered-cache", config);
       assertThat(cache.get(1L), is(nullValue()));
       cache.put(1L, "The one");
+      assertThat(cache.containsKey(2L), is(false));
       cache.put(2L, "The two");
+      assertThat(cache.containsKey(2L), is(true));
       cache.put(1L, "Another one");
       cache.put(3L, "The three");
       assertThat(cache.get(1L), equalTo("Another one"));

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
@@ -114,43 +114,4 @@ public class GettingStarted {
     // end::clusteredCacheManagerWithDynamicallyAddedCacheExample[]
   }
 
-  @Test
-  public void clusteredCacheCRUD() throws Exception {
-    // tag::clusteredCacheCRUD[]
-    final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder
-        = CacheManagerBuilder.newCacheManagerBuilder()
-        .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("terracotta://localhost:9510/my-application?auto-create"))
-            .defaultServerResource("primary-server-resource"));
-    final PersistentCacheManager cacheManager = clusteredCacheManagerBuilder.build(false);
-    cacheManager.init();
-
-    try {
-      CacheConfiguration<Long, String> config = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
-          ResourcePoolsBuilder.newResourcePoolsBuilder()
-              .with(ClusteredResourcePoolBuilder.fixed("primary-server-resource", 1, MemoryUnit.MB))).build();
-
-      Cache<Long, String> cache = cacheManager.createCache("clustered-cache", config);
-      assertThat(cache.get(1L), is(nullValue()));
-      cache.put(1L, "The one");
-      assertThat(cache.containsKey(2L), is(false));
-      cache.put(2L, "The two");
-      assertThat(cache.containsKey(2L), is(true));
-      cache.put(1L, "Another one");
-      cache.put(3L, "The three");
-      assertThat(cache.get(1L), equalTo("Another one"));
-      assertThat(cache.get(2L), equalTo("The two"));
-      assertThat(cache.get(3L), equalTo("The three"));
-      cache.remove(1L);
-      assertThat(cache.get(1L), is(nullValue()));
-
-      cache.clear();
-      assertThat(cache.get(1L), is(nullValue()));
-      assertThat(cache.get(2L), is(nullValue()));
-      assertThat(cache.get(3L), is(nullValue()));
-    } finally {
-      cacheManager.close();
-    }
-    // tag::clusteredCacheCRUD[]
-  }
-
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/docs/GettingStarted.java
@@ -142,6 +142,11 @@ public class GettingStarted {
       assertThat(cache.get(3L), equalTo("The three"));
       cache.remove(1L);
       assertThat(cache.get(1L), is(nullValue()));
+
+      cache.clear();
+      assertThat(cache.get(1L), is(nullValue()));
+      assertThat(cache.get(2L), is(nullValue()));
+      assertThat(cache.get(3L), is(nullValue()));
     } finally {
       cacheManager.close();
     }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ServerStoreProxyTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ServerStoreProxyTest.java
@@ -167,12 +167,8 @@ public class ServerStoreProxyTest {
   public void testClear() {
     serverStoreProxy.append(1L, createPayload(100L));
 
-    Chain chain = serverStoreProxy.get(1);
-    assertThat(chain.isEmpty(), is(false));
-    assertThat(readPayLoad(chain.iterator().next().getPayload()), is(100L));
-
     serverStoreProxy.clear();
-    chain = serverStoreProxy.get(1);
+    Chain chain = serverStoreProxy.get(1);
     assertThat(chain.isEmpty(), is(true));
   }
 

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ServerStoreProxyTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ServerStoreProxyTest.java
@@ -163,6 +163,19 @@ public class ServerStoreProxyTest {
     assertChainHas(anotherReplace, 800L, 4000L, 40000L);
   }
 
+  @Test
+  public void testClear() {
+    serverStoreProxy.append(1L, createPayload(100L));
+
+    Chain chain = serverStoreProxy.get(1);
+    assertThat(chain.isEmpty(), is(false));
+    assertThat(readPayLoad(chain.iterator().next().getPayload()), is(100L));
+
+    serverStoreProxy.clear();
+    chain = serverStoreProxy.get(1);
+    assertThat(chain.isEmpty(), is(true));
+  }
+
   private static void assertChainHas(Chain chain, long... payLoads) {
     Iterator<Element> elements = chain.iterator();
     for (long payLoad : payLoads) {

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreMessageFactory.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreMessageFactory.java
@@ -42,5 +42,9 @@ public class ServerStoreMessageFactory {
   public EhcacheEntityMessage replaceAtHeadOperation(long key, Chain expect, Chain update) {
     return new ServerStoreOpMessage.ReplaceAtHeadMessage(this.cacheId, key, expect, update);
   }
+
+  public EhcacheEntityMessage clearOperation() {
+    return new ServerStoreOpMessage.ClearMessage(this.cacheId);
+  }
 }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpCodec.java
@@ -77,6 +77,14 @@ class ServerStoreOpCodec {
         encodedMsg.putInt(encodedUpdatedChain.length);
         encodedMsg.put(encodedUpdatedChain);
         return encodedMsg.array();
+      case CLEAR:
+        encodedMsg = ByteBuffer.allocate(MSG_TYPE_OFFSET + STORE_OP_CODE_OFFSET + CACHE_ID_LEN_OFFSET + KEY_OFFSET + cacheIdLen);
+        encodedMsg.put(EhcacheEntityMessage.Type.SERVER_STORE_OP.getOpCode());
+        encodedMsg.putInt(cacheIdLen);
+        encodedMsg.put(message.getCacheId().getBytes(UTF_8));
+        encodedMsg.putLong(message.getKey());
+        encodedMsg.put(message.operation().getStoreOpCode());
+        return encodedMsg.array();
       default:
         throw new UnsupportedOperationException("This operation is not supported : " + message.operation());
     }
@@ -122,6 +130,8 @@ class ServerStoreOpCodec {
         replaceBuf.get(encodedUpdateChain);
         return new ReplaceAtHeadMessage(cacheId, key, chainCodec.decode(encodedExpectChain),
             chainCodec.decode(encodedUpdateChain));
+      case CLEAR:
+        return EhcacheEntityMessage.clearOperation(cacheId);
       default:
         throw new UnsupportedOperationException("This operation code is not supported : " + opCode);
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
@@ -27,7 +27,8 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     GET((byte) 10),
     GET_AND_APPEND((byte) 11),
     APPEND((byte) 12),
-    REPLACE((byte) 13);
+    REPLACE((byte) 13),
+    CLEAR((byte) 14);
 
     private final byte storeOpCode;
 
@@ -49,6 +50,8 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
           return APPEND;
         case 13:
           return REPLACE;
+        case 4:
+          return CLEAR;
         default:
           throw new IllegalArgumentException("Store operation not defined for : " + storeOpCode);
       }
@@ -176,5 +179,24 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     }
 
   }
+
+  public static class ClearMessage extends ServerStoreOpMessage {
+
+
+    ClearMessage(final String cacheId) {
+      super(cacheId, 0L);
+    }
+
+    @Override
+    public ServerStoreOp operation() {
+      return ServerStoreOp.CLEAR;
+    }
+
+    @Override
+    public byte getOpCode() {
+      return ServerStoreOp.CLEAR.getStoreOpCode();
+    }
+  }
+
 }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
@@ -50,7 +50,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
           return APPEND;
         case 13:
           return REPLACE;
-        case 4:
+        case 14:
           return CLEAR;
         default:
           throw new IllegalArgumentException("Store operation not defined for : " + storeOpCode);
@@ -82,6 +82,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
 
   public abstract ServerStoreOp operation();
 
+  @Override
+  public byte getOpCode() {
+    return operation().getStoreOpCode();
+  }
+
   public static class GetMessage extends ServerStoreOpMessage {
 
     GetMessage(String cacheId, long key) {
@@ -91,11 +96,6 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public ServerStoreOp operation() {
       return ServerStoreOp.GET;
-    }
-
-    @Override
-    public byte getOpCode() {
-      return ServerStoreOp.GET.getStoreOpCode();
     }
   }
 
@@ -111,11 +111,6 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public ServerStoreOp operation() {
       return ServerStoreOp.GET_AND_APPEND;
-    }
-
-    @Override
-    public byte getOpCode() {
-      return ServerStoreOp.GET_AND_APPEND.getStoreOpCode();
     }
 
     public ByteBuffer getPayload() {
@@ -136,11 +131,6 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public ServerStoreOp operation() {
       return ServerStoreOp.APPEND;
-    }
-
-    @Override
-    public byte getOpCode() {
-      return ServerStoreOp.APPEND.getStoreOpCode();
     }
 
     public ByteBuffer getPayload() {
@@ -165,11 +155,6 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
       return ServerStoreOp.REPLACE;
     }
 
-    @Override
-    public byte getOpCode() {
-      return ServerStoreOp.REPLACE.getStoreOpCode();
-    }
-
     public Chain getExpect() {
       return expect;
     }
@@ -180,7 +165,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
 
   }
 
-  public static class ClearMessage extends ServerStoreOpMessage {
+  static class ClearMessage extends ServerStoreOpMessage {
 
 
     ClearMessage(final String cacheId) {
@@ -195,6 +180,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public byte getOpCode() {
       return ServerStoreOp.CLEAR.getStoreOpCode();
+    }
+
+    @Override
+    public long getKey() {
+      throw new UnsupportedOperationException("Clear message does not have a key a parameter");
     }
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/store/ServerStore.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/store/ServerStore.java
@@ -109,4 +109,11 @@ public interface ServerStore {
    * @param update the new Chain to be replaced
    */
   void replaceAtHead(long key, Chain expect, Chain update);
+
+  /**
+   * Removes all the mappings from this store. But this operation is not atomic.
+   * If appends are happening in parallel, this operation does not guarantee an
+   * empty store on the completion of this operation.
+   */
+  void clear();
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/messages/ServerStoreOpCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/messages/ServerStoreOpCodecTest.java
@@ -78,4 +78,11 @@ public class ServerStoreOpCodecTest {
     Util.assertChainHas(((ServerStoreOpMessage.ReplaceAtHeadMessage)decodedMsg).getUpdate(), 2000L);
   }
 
+  @Test
+  public void testClearMessageCodec() throws Exception {
+    EhcacheEntityMessage clearMessage = MESSAGE_FACTORY.clearOperation();
+    byte[] encodedBytes = STORE_OP_CODEC.encode((ServerStoreOpMessage)clearMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(encodedBytes);
+    assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
+  }
 }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicCacheCrudTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicCacheCrudTest.java
@@ -85,6 +85,11 @@ public class BasicCacheCrudTest {
       assertThat(cache.get(3L), equalTo("The three"));
       cache.remove(1L);
       assertThat(cache.get(1L), is(nullValue()));
+
+      cache.clear();
+      assertThat(cache.get(1L), is(nullValue()));
+      assertThat(cache.get(2L), is(nullValue()));
+      assertThat(cache.get(3L), is(nullValue()));
     } finally {
       cacheManager.close();
     }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicCacheCrudTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicCacheCrudTest.java
@@ -75,7 +75,9 @@ public class BasicCacheCrudTest {
 
       Cache<Long, String> cache = cacheManager.createCache("clustered-cache", config);
       cache.put(1L, "The one");
+      assertThat(cache.containsKey(2L), is(false));
       cache.put(2L, "The two");
+      assertThat(cache.containsKey(2L), is(true));
       cache.put(1L, "Another one");
       cache.put(3L, "The three");
       assertThat(cache.get(1L), equalTo("Another one"));

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicCacheCrudTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicCacheCrudTest.java
@@ -37,6 +37,8 @@ import java.net.URI;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class BasicCacheCrudTest {
@@ -58,7 +60,7 @@ public class BasicCacheCrudTest {
   }
 
   @Test
-  public void basicCacheGetPut() throws Exception {
+  public void basicCacheCRUD() throws Exception {
     final CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder
         = CacheManagerBuilder.newCacheManagerBuilder()
         .with(ClusteringServiceConfigurationBuilder.cluster(CLUSTER.getConnectionURI().resolve("/myCacheManager?auto-create"))
@@ -79,6 +81,8 @@ public class BasicCacheCrudTest {
       assertThat(cache.get(1L), equalTo("Another one"));
       assertThat(cache.get(2L), equalTo("The two"));
       assertThat(cache.get(3L), equalTo("The three"));
+      cache.remove(1L);
+      assertThat(cache.get(1L), is(nullValue()));
     } finally {
       cacheManager.close();
     }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -282,6 +282,9 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
           ServerStoreOpMessage.ReplaceAtHeadMessage replaceAtHeadMessage = (ServerStoreOpMessage.ReplaceAtHeadMessage)message;
           cacheStore.replaceAtHead(replaceAtHeadMessage.getKey(), replaceAtHeadMessage.getExpect(), replaceAtHeadMessage.getUpdate());
           return responseFactory.success();
+        case CLEAR:
+          cacheStore.clear();
+          return responseFactory.success();
         default:
           String msg = "Unknown Server Store operation " + message;
           IllegalArgumentException cause = new IllegalArgumentException(msg);

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
@@ -70,4 +70,9 @@ class ServerStoreImpl implements ServerStore {
   public void replaceAtHead(long key, Chain expect, Chain update) {
     store.replaceAtHead(key, expect, update);
   }
+
+  @Override
+  public void clear() {
+    store.clear();
+  }
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
@@ -129,6 +129,15 @@ class OffHeapChainMap<K> implements MapInternals {
     }
   }
 
+  public void clear() {
+    heads.writeLock().lock();
+    try {
+      this.heads.clear();
+    } finally {
+      heads.writeLock().unlock();
+    }
+  }
+
   private static final Chain EMPTY_CHAIN = new Chain() {
     @Override
     public Iterator<Element> reverseIterator() {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
@@ -133,6 +133,13 @@ public class OffHeapServerStore implements ServerStore {
     }
   }
 
+  @Override
+  public void clear() {
+    for (OffHeapChainMap<Long> segment : segments) {
+      segment.clear();
+    }
+  }
+
   private OffHeapChainMap<Long> segmentFor(long key) {
     return segments.get(Math.abs((int) (key % segments.size())));
   }

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/store/impl/ReferenceStoreImpl.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/store/impl/ReferenceStoreImpl.java
@@ -145,6 +145,28 @@ public class ReferenceStoreImpl implements ServerStore  {
     }
   }
 
+  private void writeLockAll() {
+    for (ReadWriteLock lock : locks) {
+      lock.writeLock().lock();
+    }
+  }
+
+  private void writeUnlockAll() {
+    for (ReadWriteLock lock : locks) {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public void clear() {
+    writeLockAll();
+    try {
+      map.clear();
+    } finally {
+      writeUnlockAll();
+    }
+  }
+
   private HeapChainImpl cast(Chain chain) {
     return (HeapChainImpl)chain;
   }


### PR DESCRIPTION
The message encoding of `ServerStoreOpMessage.ClearMessage` can  definitely be improved. Currently it is unnecessarily encoding a key along with the *cacheId*. This is really not required but to fix that I'd have had to refactor some code in the codec class. Since @AbfrmBlr is already working on refactoring that part of the code I did not want to cause a conflict. So I'll fix this once his work gets merged.

Now containsKey could have been implemented like _return get(key) != null_ as @lorban suggested.
But just to avoid the new `ClusteredValueHolder` creation and the meta-data updates that would happen with a get in future, I have done it differently(which caused some code duplication). If no one really cares about that difference then I could revert. I was just trying to keep it as different as I can from a store.get()