### PR TITLE
Issue #763 DefaultClusteringService unit tests

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheEntityBusyException.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheEntityBusyException.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.client.internal;
 
 /**
  * Thrown by {@link EhcacheClientEntity} operations requiring exclusive access
- * to the {@code EhcacheActiveEntity} when the {@code EhcacheActiveEntity} is iin use.
+ * to the {@code EhcacheActiveEntity} when the {@code EhcacheActiveEntity} is in use.
  */
 public class EhcacheEntityBusyException extends Exception {
   private static final long serialVersionUID = -7706902691622092177L;

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheEntityBusyException.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheEntityBusyException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal;
+
+/**
+ * Thrown by {@link EhcacheClientEntity} operations requiring exclusive access
+ * to the {@code EhcacheActiveEntity} when the {@code EhcacheActiveEntity} is iin use.
+ */
+public class EhcacheEntityBusyException extends Exception {
+  private static final long serialVersionUID = -7706902691622092177L;
+
+  public EhcacheEntityBusyException(String message) {
+    super(message);
+  }
+
+  public EhcacheEntityBusyException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public EhcacheEntityBusyException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheEntityNotFoundException.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheEntityNotFoundException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal;
+
+/**
+ * Thrown to indicate that the server-side {@code EhcacheActiveEntity} for a clustered
+ * cache operation is not found.
+ */
+public class EhcacheEntityNotFoundException extends Exception {
+  private static final long serialVersionUID = -8806099086689843869L;
+
+  public EhcacheEntityNotFoundException(String message) {
+    super(message);
+  }
+
+  public EhcacheEntityNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public EhcacheEntityNotFoundException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
@@ -148,7 +148,7 @@ class DefaultClusteringService implements ClusteringService {
         clusterConnection.close();
         clusterConnection = null;
       } catch (IOException ex) {
-        LOGGER.info("Error closing cluster connection: " + ex);
+        LOGGER.warn("Error closing cluster connection: " + ex);
       }
       throw e;
     }
@@ -168,7 +168,7 @@ class DefaultClusteringService implements ClusteringService {
         clusterConnection.close();
         clusterConnection = null;
       } catch (IOException e) {
-        LOGGER.info("Error closing cluster connection: " + e);
+        LOGGER.warn("Error closing cluster connection: " + e);
       }
       throw new IllegalStateException("Couldn't acquire cluster-wide maintenance lease");
     }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/service/ClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/service/ClusteringService.java
@@ -50,8 +50,6 @@ public interface ClusteringService extends PersistableResourceService {
    */
   void releaseServerStoreProxy(ServerStoreProxy storeProxy);
 
-  void connect();
-
   /**
    * Identifies a client-side cache to server-based components.
    */

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactoryTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactoryTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.terracotta.connection.entity.EntityRef;
@@ -55,7 +54,7 @@ public class EhcacheClientEntityFactoryTest {
     when(connection.getEntityRef(eq(EhcacheClientEntity.class), anyInt(), anyString())).thenReturn(entityRef);
 
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(connection, winner());
-    assertThat(factory.create("test", null), is(entity));
+    factory.create("test", null);
     verify(entityRef).create(any(UUID.class));
   }
 
@@ -73,33 +72,6 @@ public class EhcacheClientEntityFactoryTest {
     } catch (EntityAlreadyExistsException e) {
       //expected
     }
-  }
-
-  @Test
-  public void testCreateOrRetrieve() throws Exception {
-    EhcacheClientEntity entity = mock(EhcacheClientEntity.class);
-    EntityRef<EhcacheClientEntity, Object> entityRef = mock(EntityRef.class);
-    when(entityRef.fetchEntity()).thenThrow(EntityNotFoundException.class).thenReturn(entity);
-    Connection connection = mock(Connection.class);
-    when(connection.getEntityRef(eq(EhcacheClientEntity.class), anyInt(), anyString())).thenReturn(entityRef);
-
-    EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(connection, winner());
-    assertThat(factory.createOrRetrieve("test", null), is(entity));
-    verify(entityRef).create(any(UUID.class));
-  }
-
-  @Test
-  public void testCreateOrRetrieveWhenExisting() throws Exception {
-    EhcacheClientEntity entity = mock(EhcacheClientEntity.class);
-    EntityRef<EhcacheClientEntity, Object> entityRef = mock(EntityRef.class);
-    when(entityRef.fetchEntity()).thenReturn(entity);
-    doThrow(EntityAlreadyExistsException.class).when(entityRef).create(any());
-    Connection connection = mock(Connection.class);
-    when(connection.getEntityRef(eq(EhcacheClientEntity.class), anyInt(), anyString())).thenReturn(entityRef);
-
-    EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(connection, winner());
-    assertThat(factory.createOrRetrieve("test", null), is(entity));
-    verify(entityRef, never()).create(any(UUID.class));
   }
 
   @Test
@@ -166,8 +138,8 @@ public class EhcacheClientEntityFactoryTest {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(connection, winner());
     try {
       factory.destroy("test");
-      fail("Expected EntityNotFoundException");
-    } catch (EntityNotFoundException e) {
+      fail("Expected EhcacheEntityNotFoundException");
+    } catch (EhcacheEntityNotFoundException e) {
       //expected
     }
   }
@@ -183,8 +155,8 @@ public class EhcacheClientEntityFactoryTest {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(connection, loserThenWinner());
     try {
       factory.destroy("test");
-      fail("Expected EntityNotFoundException");
-    } catch (EntityNotFoundException e) {
+      fail("Expected EhcacheEntityNotFoundException");
+    } catch (EhcacheEntityNotFoundException e) {        // TODO: Is this correct?
       //expected
     }
   }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
@@ -190,8 +190,9 @@ public class UnitTestConnectionService implements ConnectionService {
   }
 
   /**
-   * A builder for a new {@link PassthroughServer} instance.  This builder defined the following for each
-   * {@code PassthroughServer} built:
+   * A builder for a new {@link PassthroughServer} instance.  If no services are added using
+   * {@link #serverEntityService(ServerEntityService)} or {@link #clientEntityService(EntityClientService)},
+   * this builder defines the following services for each {@code PassthroughServer} built:
    * <ul>
    *   <li>{@link EhcacheServerEntityService}</li>
    *   <li>{@link EhcacheClientEntityService}</li>
@@ -267,10 +268,15 @@ public class UnitTestConnectionService implements ConnectionService {
     public PassthroughServer build() {
       PassthroughServer newServer = new PassthroughServer(true);
 
-      newServer.registerServerEntityService(new EhcacheServerEntityService());
-      newServer.registerClientEntityService(new EhcacheClientEntityService());
-      newServer.registerServerEntityService(new CoordinationServerEntityService());
-      newServer.registerClientEntityService(new ClientCoordinationEntityService());
+      /*
+       * If services have been specified, don't establish the "defaults".
+       */
+      if (serverEntityServices.isEmpty() && clientEntityServices.isEmpty()) {
+        newServer.registerServerEntityService(new EhcacheServerEntityService());
+        newServer.registerClientEntityService(new EhcacheClientEntityService());
+        newServer.registerServerEntityService(new CoordinationServerEntityService());
+        newServer.registerClientEntityService(new ClientCoordinationEntityService());
+      }
 
       for (ServerEntityService<?, ?> service : serverEntityServices) {
         newServer.registerServerEntityService(service);

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/DefaultClusteringServiceTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/DefaultClusteringServiceTest.java
@@ -16,37 +16,157 @@
 
 package org.ehcache.clustered.client.internal.service;
 
+import org.ehcache.CachePersistenceException;
+import org.ehcache.clustered.client.config.ClusteredResourcePool;
+import org.ehcache.clustered.client.config.ClusteredResourceType;
 import org.ehcache.clustered.client.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder;
+import org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder;
+import org.ehcache.clustered.client.internal.EhcacheClientEntityService;
+import org.ehcache.clustered.client.internal.EhcacheEntityCreationException;
 import org.ehcache.clustered.client.internal.UnitTestConnectionService;
 import org.ehcache.clustered.client.internal.UnitTestConnectionService.PassthroughServerBuilder;
-import org.ehcache.clustered.client.internal.service.DefaultClusteringService;
+import org.ehcache.clustered.client.internal.store.ServerStoreProxy;
+import org.ehcache.clustered.client.service.ClusteringService.ClusteredCacheIdentifier;
+import org.ehcache.clustered.common.ClusteredStoreValidationException;
+import org.ehcache.clustered.server.ObservableEhcacheServerEntityService;
+import org.ehcache.clustered.server.ObservableEhcacheServerEntityService.ObservableEhcacheActiveEntity;
+import org.ehcache.config.ResourcePool;
+import org.ehcache.config.ResourceType;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.config.store.StoreEventSourceConfiguration;
+import org.ehcache.core.internal.service.ServiceLocator;
+import org.ehcache.core.internal.store.StoreConfigurationImpl;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.impl.internal.spi.serialization.DefaultSerializationProvider;
+import org.ehcache.spi.service.ServiceConfiguration;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.connection.ConnectionPropertyNames;
+import org.terracotta.consensus.entity.CoordinationServerEntityService;
+import org.terracotta.consensus.entity.client.ClientCoordinationEntityService;
+import org.terracotta.exception.EntityNotFoundException;
 
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
+import static org.ehcache.clustered.client.config.ClusteredResourceType.Types.FIXED;
+import static org.ehcache.clustered.client.config.ClusteredResourceType.Types.SHARED;
+import static org.ehcache.clustered.client.internal.service.TestServiceProvider.providerContaining;
+import static org.ehcache.config.ResourceType.Core.DISK;
+import static org.ehcache.config.ResourceType.Core.HEAP;
+import static org.ehcache.config.ResourceType.Core.OFFHEAP;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class DefaultClusteringServiceTest {
 
   private static final String CLUSTER_URI_BASE = "http://example.com:9540/";
+  private ObservableEhcacheServerEntityService observableEhcacheServerEntityService;
 
   @Before
   public void definePassthroughServer() throws Exception {
+    observableEhcacheServerEntityService = new ObservableEhcacheServerEntityService();
     UnitTestConnectionService.add(CLUSTER_URI_BASE,
         new PassthroughServerBuilder()
+            .serverEntityService(observableEhcacheServerEntityService)
+            .clientEntityService(new EhcacheClientEntityService())
+            .serverEntityService(new CoordinationServerEntityService())
+            .clientEntityService(new ClientCoordinationEntityService())
+            .resource("defaultResource", 128, MemoryUnit.MB)
+            .resource("serverResource1", 32, MemoryUnit.MB)
+            .resource("serverResource2", 32, MemoryUnit.MB)
             .build());
   }
 
   @After
   public void removePassthroughServer() throws Exception {
     UnitTestConnectionService.remove(CLUSTER_URI_BASE);
+    observableEhcacheServerEntityService = null;
+  }
+
+  @Test
+  public void testHandlesResourceType() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+
+    assertThat(service.handlesResourceType(DISK), is(false));
+    assertThat(service.handlesResourceType(HEAP), is(false));
+    assertThat(service.handlesResourceType(OFFHEAP), is(false));
+    assertThat(service.handlesResourceType(FIXED), is(true));
+    assertThat(service.handlesResourceType(SHARED), is(true));
+    assertThat(service.handlesResourceType(new ClusteredResourceType<ClusteredResourcePool>() {
+      @Override
+      public Class<ClusteredResourcePool> getResourcePoolClass() {
+        throw new UnsupportedOperationException(".getResourcePoolClass not implemented");
+      }
+
+      @Override
+      public boolean isPersistable() {
+        throw new UnsupportedOperationException(".isPersistable not implemented");
+      }
+
+      @Override
+      public boolean requiresSerialization() {
+        throw new UnsupportedOperationException(".requiresSerialization not implemented");
+      }
+
+      @Override
+      public int getTierHeight() {
+        throw new UnsupportedOperationException(".getTierHeight not implemented");
+      }
+    }), is(false));
+  }
+
+  @Test
+  public void testAdditionalConfigurationForPool() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+
+    Collection<ServiceConfiguration<?>> actual =
+        service.additionalConfigurationsForPool("cacheAlias", ClusteredResourcePoolBuilder.shared("primary"));
+    assertThat(actual.size(), is(1));
+    ServiceConfiguration<?> serviceConfiguration = actual.iterator().next();
+    assertThat(serviceConfiguration, is(instanceOf(ClusteredCacheIdentifier.class)));
+    assertThat(((ClusteredCacheIdentifier)serviceConfiguration).getId(), is("cacheAlias"));
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    CacheConfigurationBuilder<Long, String> configBuilder =
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
+            ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .with(ClusteredResourcePoolBuilder.shared("primary")));
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+
+    try {
+      service.create("cacheAlias", configBuilder.build());
+      fail("Expecting UnsupportedOperationException");
+    } catch (UnsupportedOperationException e) {
+      // Expected
+    }
   }
 
   @Test
@@ -67,5 +187,1142 @@ public class DefaultClusteringServiceTest {
         props.getProperty(ConnectionPropertyNames.CONNECTION_NAME),
         DefaultClusteringService.CONNECTION_PREFIX + entityIdentifier
     );
+  }
+
+  @Test
+  public void testStartStopAutoCreate() throws Exception {
+    URI clusterUri = URI.create(CLUSTER_URI_BASE + "my-application?auto-create");
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(clusterUri)
+        .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+    service.start(null);
+
+    assertThat(UnitTestConnectionService.getConnectionProperties(clusterUri).size(), is(1));
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+
+    service.stop();
+
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(UnitTestConnectionService.getConnectionProperties(clusterUri).size(), is(0));
+  }
+
+  @Test
+  public void testStartStopNoAutoCreate() throws Exception {
+    URI clusterUri = URI.create(CLUSTER_URI_BASE + "my-application");
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(clusterUri)
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+    try {
+      service.start(null);
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getCause(), is(instanceOf(EntityNotFoundException.class)));
+    }
+
+    assertThat(UnitTestConnectionService.getConnectionProperties(clusterUri).size(), is(0));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+
+    service.stop();
+  }
+
+  /**
+   * Ensures a second client specifying {@code auto-create} can start {@link DefaultClusteringService} while the
+   * creator is still connected.
+   */
+  @Test
+  public void testStartStopAutoCreateTwiceA() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService firstService = new DefaultClusteringService(configuration);
+    firstService.start(null);
+
+    DefaultClusteringService secondService = new DefaultClusteringService(configuration);
+    secondService.start(null);
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(2));
+
+    firstService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+
+    secondService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+  }
+
+  /**
+   * Ensures a second client specifying {@code auto-create} can start {@link DefaultClusteringService} while the
+   * creator is not connected.
+   */
+  @Test
+  public void testStartStopAutoCreateTwiceB() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService firstService = new DefaultClusteringService(configuration);
+    firstService.start(null);
+    firstService.stop();
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+
+    DefaultClusteringService secondService = new DefaultClusteringService(configuration);
+    secondService.start(null);
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+
+    secondService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+  }
+
+  @Test
+  public void testStartForMaintenanceAutoStart() throws Exception {
+    URI clusterUri = URI.create(CLUSTER_URI_BASE + "my-application?auto-create");
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(clusterUri)
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+    service.startForMaintenance(null);
+
+    assertThat(UnitTestConnectionService.getConnectionProperties(clusterUri).size(), is(1));
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+
+    // startForMaintenance does **not** create an EhcacheActiveEntity
+
+    service.stop();
+
+    assertThat(UnitTestConnectionService.getConnectionProperties(clusterUri).size(), is(0));
+  }
+
+  @Test
+  public void testStartForMaintenanceOtherAutoCreate() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService createService = new DefaultClusteringService(configuration);
+    createService.start(null);
+
+    DefaultClusteringService maintenanceService = new DefaultClusteringService(configuration);
+    try {
+      maintenanceService.startForMaintenance(null);
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      // Expected
+    }
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+
+    createService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+
+    maintenanceService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+  }
+
+  @Test
+  public void testStartForMaintenanceOtherCreated() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService createService = new DefaultClusteringService(configuration);
+    createService.start(null);
+    createService.stop();
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+
+    DefaultClusteringService maintenanceService = new DefaultClusteringService(configuration);
+    maintenanceService.startForMaintenance(null);
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+
+    // startForMaintenance does **not** establish a link with the EhcacheActiveEntity
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+
+    maintenanceService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+  }
+
+  /**
+   * This test ensures that an auto-create client can't perform an auto-creation while a startForMaintenance client
+   * is active.
+   */
+  @Test
+  public void testStartForMaintenanceCreateInterlock() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService maintenanceService = new DefaultClusteringService(configuration);
+    maintenanceService.startForMaintenance(null);
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+
+    DefaultClusteringService createService = new DefaultClusteringService(configuration);
+    try {
+      createService.start(null);
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getCause(), is(instanceOf(EhcacheEntityCreationException.class)));
+    }
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+
+    maintenanceService.stop();
+
+    createService.start(null);
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+
+    createService.stop();
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+  }
+
+  @Test
+  public void testStartForMaintenanceInterlock() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService maintenanceService1 = new DefaultClusteringService(configuration);
+    maintenanceService1.startForMaintenance(null);
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+
+    DefaultClusteringService maintenanceService2 = new DefaultClusteringService(configuration);
+    try {
+      maintenanceService2.startForMaintenance(null);
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString(" acquire cluster-wide "));
+    }
+
+    maintenanceService1.stop();
+  }
+
+  @Test
+  public void testStartForMaintenanceSequence() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .build();
+    DefaultClusteringService maintenanceService1 = new DefaultClusteringService(configuration);
+    maintenanceService1.startForMaintenance(null);
+    maintenanceService1.stop();
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+
+    DefaultClusteringService maintenanceService2 = new DefaultClusteringService(configuration);
+    maintenanceService2.startForMaintenance(null);
+    maintenanceService2.stop();
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(0));
+  }
+
+  @Test
+  public void testBasicConfiguration() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService createService = new DefaultClusteringService(configuration);
+    createService.start(null);
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+
+    createService.stop();
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+  }
+
+  @Ignore("Needs Terracotta-OSS/terracotta-apis#95")
+  @Test
+  public void testBasicDestroyAll() throws Exception {
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService createService = new DefaultClusteringService(configuration);
+    createService.start(null);
+    createService.stop();
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+
+    try {
+      createService.destroyAll();
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString("Maintenance mode required"));
+    }
+
+    createService.startForMaintenance(null);
+
+    createService.destroyAll();
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is(nullValue()));
+    assertThat(activeEntity.getSharedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+  }
+
+  @Test
+  public void testGetServerStoreProxySharedAutoCreate() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetPool = "sharedPrimary";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+    service.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy serverStoreProxy = service.getServerStoreProxy(
+        getClusteredCacheIdentifier(service, cacheAlias, storeConfiguration), storeConfiguration);
+
+    assertThat(serverStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    service.stop();
+
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+  }
+
+  @Test
+  public void testGetServerStoreProxySharedNoAutoCreateNonExistent() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetPool = "sharedPrimary";
+    ClusteringServiceConfiguration creationConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(creationConfig);
+    creationService.start(null);
+    creationService.stop();
+
+    ClusteringServiceConfiguration accessConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService accessService = new DefaultClusteringService(accessConfig);
+    accessService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    try {
+      accessService.getServerStoreProxy(
+          getClusteredCacheIdentifier(accessService, cacheAlias, storeConfiguration), storeConfiguration);
+      fail("Expecting ClusteredStoreValidationException");
+    } catch (ClusteredStoreValidationException e) {
+      // Expected
+    }
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getInUseStores().keySet(), is(Matchers.<String>empty()));
+
+    accessService.stop();
+
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getInUseStores().keySet(), is(Matchers.<String>empty()));
+  }
+
+  @Test
+  public void testGetServerStoreProxySharedNoAutoCreateExists() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetPool = "sharedPrimary";
+    ClusteringServiceConfiguration creationConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(creationConfig);
+    creationService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> creationStoreConfig =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy creationServerStoreProxy = creationService.getServerStoreProxy(
+        getClusteredCacheIdentifier(creationService, cacheAlias, creationStoreConfig), creationStoreConfig);
+    assertThat(creationServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    creationService.stop();
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+
+
+    ClusteringServiceConfiguration accessConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService accessService = new DefaultClusteringService(accessConfig);
+    accessService.start(null);
+
+    Store.Configuration<Long, String> accessStoreConfiguration =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy accessServerStoreProxy = accessService.getServerStoreProxy(
+        getClusteredCacheIdentifier(accessService, cacheAlias, accessStoreConfiguration), accessStoreConfiguration);
+    assertThat(accessServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    accessService.stop();
+
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+  }
+
+  /**
+   * Ensures that two clients using {@code auto-create} can gain access to the same {@code ServerStore}.
+   */
+  @Test
+  public void testGetServerStoreProxySharedAutoCreateTwice() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetPool = "sharedPrimary";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService firstService = new DefaultClusteringService(configuration);
+    firstService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> firstSharedStoreConfig =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy firstServerStoreProxy = firstService.getServerStoreProxy(
+        getClusteredCacheIdentifier(firstService, cacheAlias, firstSharedStoreConfig), firstSharedStoreConfig);
+    assertThat(firstServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    DefaultClusteringService secondService = new DefaultClusteringService(configuration);
+    secondService.start(null);
+
+    Store.Configuration<Long, String> secondSharedStoreConfig =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy secondServerStoreProxy = secondService.getServerStoreProxy(
+        getClusteredCacheIdentifier(firstService, cacheAlias, secondSharedStoreConfig), secondSharedStoreConfig);
+    assertThat(secondServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(2));
+    for (Set<String> storeIds : activeEntity.getConnectedClients().values()) {
+      assertThat(storeIds, containsInAnyOrder(cacheAlias));
+    }
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(2));
+
+    firstService.stop();
+
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    secondService.stop();
+
+    assertThat(activeEntity.getSharedResourcePoolIds(), containsInAnyOrder(targetPool, "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+  }
+
+  @Test
+  public void testReleaseServerStoreProxyShared() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetPool = "sharedPrimary";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(configuration);
+    creationService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy serverStoreProxy = creationService.getServerStoreProxy(
+        getClusteredCacheIdentifier(creationService, cacheAlias, storeConfiguration), storeConfiguration);
+    assertThat(serverStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    creationService.releaseServerStoreProxy(serverStoreProxy);
+
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+
+    try {
+      creationService.releaseServerStoreProxy(serverStoreProxy);
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString(" not in use "));
+    }
+
+    creationService.stop();
+  }
+
+  @Test
+  public void testGetServerStoreProxyFixedAutoCreate() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetResource = "serverResource2";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService service = new DefaultClusteringService(configuration);
+    service.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy serverStoreProxy = service.getServerStoreProxy(
+        getClusteredCacheIdentifier(service, cacheAlias, storeConfiguration), storeConfiguration);
+
+    assertThat(serverStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    service.stop();
+
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+  }
+
+  @Test
+  public void testGetServerStoreProxyFixedNoAutoCreateNonExistent() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetResource = "serverResource2";
+    ClusteringServiceConfiguration creationConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(creationConfig);
+    creationService.start(null);
+    creationService.stop();
+
+    ClusteringServiceConfiguration accessConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService accessService = new DefaultClusteringService(accessConfig);
+    accessService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    try {
+      accessService.getServerStoreProxy(
+          getClusteredCacheIdentifier(accessService, cacheAlias, storeConfiguration), storeConfiguration);
+      fail("Expecting ClusteredStoreValidationException");
+    } catch (ClusteredStoreValidationException e) {
+      // Expected
+    }
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getInUseStores().keySet(), is(Matchers.<String>empty()));
+
+    accessService.stop();
+
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getInUseStores().keySet(), is(Matchers.<String>empty()));
+  }
+
+  @Test
+  public void testGetServerStoreProxyFixedNoAutoCreateExists() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetResource = "serverResource2";
+    ClusteringServiceConfiguration creationConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(creationConfig);
+    creationService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> creationStoreConfig =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy creationServerStoreProxy = creationService.getServerStoreProxy(
+        getClusteredCacheIdentifier(creationService, cacheAlias, creationStoreConfig), creationStoreConfig);
+    assertThat(creationServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    creationService.stop();
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+
+    ClusteringServiceConfiguration accessConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService accessService = new DefaultClusteringService(accessConfig);
+    accessService.start(null);
+
+    Store.Configuration<Long, String> accessStoreConfiguration =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy accessServerStoreProxy = accessService.getServerStoreProxy(
+        getClusteredCacheIdentifier(accessService, cacheAlias, accessStoreConfiguration), accessStoreConfiguration);
+    assertThat(accessServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    accessService.stop();
+
+    assertThat(activeEntity.getDefaultServerResource(), is("defaultResource"));
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+  }
+
+  /**
+   * Ensures that two clients using {@code auto-create} can gain access to the same {@code ServerStore}.
+   */
+  @Test
+  public void testGetServerStoreProxyFixedAutoCreateTwice() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetResource = "serverResource2";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService firstService = new DefaultClusteringService(configuration);
+    firstService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> firstSharedStoreConfig =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy firstServerStoreProxy = firstService.getServerStoreProxy(
+        getClusteredCacheIdentifier(firstService, cacheAlias, firstSharedStoreConfig), firstSharedStoreConfig);
+    assertThat(firstServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    DefaultClusteringService secondService = new DefaultClusteringService(configuration);
+    secondService.start(null);
+
+    Store.Configuration<Long, String> secondSharedStoreConfig =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy secondServerStoreProxy = secondService.getServerStoreProxy(
+        getClusteredCacheIdentifier(firstService, cacheAlias, secondSharedStoreConfig), secondSharedStoreConfig);
+    assertThat(secondServerStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    assertThat(activeEntities.size(), is(1));
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(2));
+    for (Set<String> storeIds : activeEntity.getConnectedClients().values()) {
+      assertThat(storeIds, containsInAnyOrder(cacheAlias));
+    }
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(2));
+
+    firstService.stop();
+
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    secondService.stop();
+
+    assertThat(activeEntity.getSharedResourcePoolIds(),
+        containsInAnyOrder("sharedPrimary", "sharedSecondary", "sharedTertiary"));
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(0));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+  }
+
+  @Test
+  public void testReleaseServerStoreProxyFixed() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetResource = "serverResource2";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(configuration);
+    creationService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy serverStoreProxy = creationService.getServerStoreProxy(
+        getClusteredCacheIdentifier(creationService, cacheAlias, storeConfiguration), storeConfiguration);
+    assertThat(serverStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    creationService.releaseServerStoreProxy(serverStoreProxy);
+
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+
+    try {
+      creationService.releaseServerStoreProxy(serverStoreProxy);
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString(" not in use "));
+    }
+
+    creationService.stop();
+  }
+
+  @Test
+  public void testReleaseServerStoreProxyNonExistent() throws Exception {
+    String cacheAlias = "cacheAlias";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(configuration);
+    creationService.start(null);
+
+    try {
+      creationService.releaseServerStoreProxy(new ServerStoreProxy(cacheAlias, null));
+      fail("Expecting IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage(), containsString(" does not exist"));
+    }
+
+    creationService.stop();
+  }
+
+  @Test
+  public void testGetServerStoreProxySharedDestroy() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetPool = "sharedPrimary";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool(targetPool, 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(configuration);
+    creationService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getSharedStoreConfig(targetPool, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy serverStoreProxy = creationService.getServerStoreProxy(
+        getClusteredCacheIdentifier(creationService, cacheAlias, storeConfiguration), storeConfiguration);
+    assertThat(serverStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    try {
+      creationService.destroy(cacheAlias);
+      fail("Expecting CachePersistenceException");
+    } catch (CachePersistenceException e) {
+      assertThat(e.getMessage(), containsString(" in use by "));
+    }
+
+    creationService.releaseServerStoreProxy(serverStoreProxy);
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+
+    creationService.destroy(cacheAlias);
+
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getInUseStores().keySet(), is(Matchers.<String>empty()));
+
+    creationService.stop();
+  }
+
+  @Test
+  public void testGetServerStoreProxyFixedDestroy() throws Exception {
+    String cacheAlias = "cacheAlias";
+    String targetResource = "serverResource2";
+    ClusteringServiceConfiguration configuration =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application?auto-create"))
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(configuration);
+    creationService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getFixedStoreConfig(targetResource, serializationProvider, Long.class, String.class);
+
+    ServerStoreProxy serverStoreProxy = creationService.getServerStoreProxy(
+        getClusteredCacheIdentifier(creationService, cacheAlias, storeConfiguration), storeConfiguration);
+    assertThat(serverStoreProxy.getCacheId(), is(cacheAlias));
+
+    List<ObservableEhcacheActiveEntity> activeEntities = observableEhcacheServerEntityService.getServedActiveEntities();
+    ObservableEhcacheActiveEntity activeEntity = activeEntities.get(0);
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(1));
+
+    try {
+      creationService.destroy(cacheAlias);
+      fail("Expecting CachePersistenceException");
+    } catch (CachePersistenceException e) {
+      assertThat(e.getMessage(), containsString(" in use by "));
+    }
+
+    creationService.releaseServerStoreProxy(serverStoreProxy);
+    assertThat(activeEntity.getFixedResourcePoolIds(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getStores(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().keySet(), containsInAnyOrder(cacheAlias));
+    assertThat(activeEntity.getInUseStores().get(cacheAlias).size(), is(0));
+
+    creationService.destroy(cacheAlias);
+
+    assertThat(activeEntity.getFixedResourcePoolIds(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getConnectedClients().size(), is(1));
+    assertThat(activeEntity.getConnectedClients().values().iterator().next(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getStores(), is(Matchers.<String>empty()));
+    assertThat(activeEntity.getInUseStores().keySet(), is(Matchers.<String>empty()));
+
+    creationService.stop();
+  }
+
+  private <K, V> Store.Configuration<K, V> getSharedStoreConfig(
+      String targetPool, DefaultSerializationProvider serializationProvider, Class<K> keyType, Class<V> valueType)
+      throws org.ehcache.spi.serialization.UnsupportedTypeException {
+    return new StoreConfigurationImpl<K, V>(
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(keyType, valueType,
+            ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .with(ClusteredResourcePoolBuilder.shared(targetPool)))
+            .build(),
+        StoreEventSourceConfiguration.DEFAULT_DISPATCHER_CONCURRENCY,
+        serializationProvider.createKeySerializer(keyType, getClass().getClassLoader()),
+        serializationProvider.createValueSerializer(valueType, getClass().getClassLoader()));
+  }
+
+  private <K, V> Store.Configuration<K, V> getFixedStoreConfig(
+      String targetResource, DefaultSerializationProvider serializationProvider, Class<K> keyType, Class<V> valueType)
+      throws org.ehcache.spi.serialization.UnsupportedTypeException {
+    return new StoreConfigurationImpl<K, V>(
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(keyType, valueType,
+            ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .with(ClusteredResourcePoolBuilder.fixed(targetResource, 8, MemoryUnit.MB)))
+            .build(),
+        StoreEventSourceConfiguration.DEFAULT_DISPATCHER_CONCURRENCY,
+        serializationProvider.createKeySerializer(keyType, getClass().getClassLoader()),
+        serializationProvider.createValueSerializer(valueType, getClass().getClassLoader()));
+  }
+
+  private ClusteredCacheIdentifier getClusteredCacheIdentifier(
+      DefaultClusteringService service, String cacheAlias, Store.Configuration<Long, String> storeConfiguration)
+      throws CachePersistenceException {
+
+    for (ResourceType<?> resourceType : ClusteredResourceType.Types.values()) {
+      ResourcePool resourcePool = storeConfiguration.getResourcePools().getPoolForResource(resourceType);
+      if (resourcePool != null) {
+        ClusteredCacheIdentifier clusteredCacheIdentifier =
+            ServiceLocator.findSingletonAmongst(ClusteredCacheIdentifier.class,
+                service.additionalConfigurationsForPool(cacheAlias, resourcePool));
+        if (clusteredCacheIdentifier != null) {
+          return clusteredCacheIdentifier;
+        }
+      }
+    }
+    throw new AssertionError("ClusteredCacheIdentifier not available for configuration");
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/TestServiceProvider.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/TestServiceProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.service;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceProvider;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ */
+public final class TestServiceProvider {
+
+  public static ServiceProvider<Service> providerContaining(final Service... services) {
+    final Map<Class<? extends Service>, Service> servicesMap = new HashMap<Class<? extends Service>, Service>();
+
+    for (Service s : services) {
+      servicesMap.put(s.getClass(), s);
+    }
+
+    return new ServiceProvider<Service>() {
+
+      @Override
+      public <T extends Service> T getService(Class<T> serviceType) {
+        return serviceType.cast(servicesMap.get(serviceType));
+      }
+
+      @Override
+      public <U extends Service> Collection<U> getServicesOfType(final Class<U> serviceType) {
+        throw new UnsupportedOperationException(".getServicesOfType not implemented");
+      }
+    };
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ServerStoreProxyTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ServerStoreProxyTest.java
@@ -62,8 +62,10 @@ public class ServerStoreProxyTest {
 
     EhcacheClientEntityFactory entityFactory = new EhcacheClientEntityFactory(connection);
 
-    clientEntity = entityFactory.create("TestCacheManager",
-        new ServerSideConfiguration("defaultResource", Collections.<String, ServerSideConfiguration.Pool>emptyMap()));
+    ServerSideConfiguration serverConfig =
+        new ServerSideConfiguration("defaultResource", Collections.<String, ServerSideConfiguration.Pool>emptyMap());
+    entityFactory.create("TestCacheManager", serverConfig);
+    clientEntity = entityFactory.retrieve("TestCacheManager", serverConfig);
 
     ClusteredResourcePool resourcePool = ClusteredResourcePoolBuilder.fixed(16L, MemoryUnit.MB);
 

--- a/clustered/client/src/test/java/org/ehcache/clustered/server/ObservableEhcacheServerEntityService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/server/ObservableEhcacheServerEntityService.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.server;
+
+import org.ehcache.clustered.common.messages.EhcacheEntityMessage;
+import org.ehcache.clustered.common.messages.EhcacheEntityResponse;
+import org.terracotta.entity.ActiveServerEntity;
+import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.ConcurrencyStrategy;
+import org.terracotta.entity.MessageCodec;
+import org.terracotta.entity.PassiveServerEntity;
+import org.terracotta.entity.ServerEntityService;
+import org.terracotta.entity.ServiceRegistry;
+import org.terracotta.entity.SyncMessageCodec;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides an alternative to {@link EhcacheServerEntityService} for unit tests to enable observing
+ * the state of the {@link EhcacheActiveEntity} instances served.
+ */
+public class ObservableEhcacheServerEntityService
+    implements ServerEntityService<EhcacheEntityMessage, EhcacheEntityResponse> {
+  private final EhcacheServerEntityService delegate = new EhcacheServerEntityService();
+
+  private final List<EhcacheActiveEntity> servedActiveEntities = new ArrayList<EhcacheActiveEntity>();
+
+  /**
+   * Gets a list of {@link ObservableEhcacheActiveEntity} instances wrapping the
+   * {@link EhcacheActiveEntity} instances served by this {@link ServerEntityService}.
+   *
+   * @return an unmodifiable list of {@code ObservableEhcacheActiveEntity} instances
+   */
+  public List<ObservableEhcacheActiveEntity> getServedActiveEntities() {
+    List<ObservableEhcacheActiveEntity> observables = new ArrayList<ObservableEhcacheActiveEntity>(servedActiveEntities.size());
+    for (EhcacheActiveEntity servedActiveEntity : servedActiveEntities) {
+      observables.add(new ObservableEhcacheActiveEntity(servedActiveEntity));
+    }
+    return Collections.unmodifiableList(observables);
+  }
+
+  @Override
+  public long getVersion() {
+    return delegate.getVersion();
+  }
+
+  @Override
+  public boolean handlesEntityType(String typeName) {
+    return delegate.handlesEntityType(typeName);
+  }
+
+  @Override
+  public EhcacheActiveEntity createActiveEntity(ServiceRegistry registry, byte[] configuration) {
+    EhcacheActiveEntity activeEntity = delegate.createActiveEntity(registry, configuration);
+    servedActiveEntities.add(activeEntity);
+    return activeEntity;
+  }
+
+  @Override
+  public PassiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> createPassiveEntity(ServiceRegistry registry, byte[] configuration) {
+    return delegate.createPassiveEntity(registry, configuration);
+  }
+
+  @Override
+  public ConcurrencyStrategy<EhcacheEntityMessage> getConcurrencyStrategy(byte[] config) {
+    return delegate.getConcurrencyStrategy(config);
+  }
+
+  @Override
+  public MessageCodec<EhcacheEntityMessage, EhcacheEntityResponse> getMessageCodec() {
+    return delegate.getMessageCodec();
+  }
+
+  @Override
+  public SyncMessageCodec<EhcacheEntityMessage> getSyncMessageCodec() {
+    return delegate.getSyncMessageCodec();
+  }
+
+  /**
+   * Provides access to unit test state methods in an {@link EhcacheActiveEntity} instance.
+   */
+  public static final class ObservableEhcacheActiveEntity {
+    private final EhcacheActiveEntity activeEntity;
+
+    private ObservableEhcacheActiveEntity(EhcacheActiveEntity activeEntity) {
+      this.activeEntity = activeEntity;
+    }
+
+    public ActiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> getActiveEntity() {
+      return this.activeEntity;
+    }
+
+    public Map<ClientDescriptor, Set<String>> getConnectedClients() {
+      return activeEntity.getConnectedClients();
+    }
+
+    public Set<String> getStores() {
+      return activeEntity.getStores();
+    }
+
+    public Map<String, Set<ClientDescriptor>> getInUseStores() {
+      return activeEntity.getInUseStores();
+    }
+
+    public String getDefaultServerResource() {
+      return activeEntity.getDefaultServerResource();
+    }
+
+    public Set<String> getSharedResourcePoolIds() {
+      return activeEntity.getSharedResourcePoolIds();
+    }
+
+    public Set<String> getFixedResourcePoolIds() {
+      return activeEntity.getFixedResourcePoolIds();
+    }
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/server/package-info.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/server/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Introduced to bridge visibility gaps between client and server for unit testing purposes.
+ */
+package org.ehcache.clustered.server;

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/EhcacheClientEntityFactoryIntegrationTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/EhcacheClientEntityFactoryIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.ehcache.clustered.client.internal.EhcacheClientEntityFactory;
+import org.ehcache.clustered.client.internal.EhcacheEntityNotFoundException;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.ServerSideConfiguration.Pool;
 import org.junit.AfterClass;
@@ -70,13 +71,13 @@ public class EhcacheClientEntityFactoryIntegrationTest {
   public void testCreate() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
 
-    assertThat(factory.create("testCreate", new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP)), notNullValue());
+    factory.create("testCreate", new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP));
   }
 
   @Test
   public void testCreateWhenExisting() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
-    factory.create("testCreateWhenExisting", new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP)).close();
+    factory.create("testCreateWhenExisting", new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP));
     try {
       factory.create("testCreateWhenExisting",
           new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("bar", 42L))));
@@ -87,40 +88,10 @@ public class EhcacheClientEntityFactoryIntegrationTest {
   }
 
   @Test
-  public void testCreateOrRetrieve() throws Exception {
-    EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
-    assertThat(factory.createOrRetrieve("testCreateOrRetrieve",
-        new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP)), notNullValue());
-  }
-
-  @Test
-  public void testCreateOrRetrieveWhenExisting() throws Exception {
-    EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
-    factory.create("testCreateOrRetrieveWhenExisting", new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP)).close();
-    assertThat(factory.createOrRetrieve("testCreateOrRetrieveWhenExisting",
-        new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP)), notNullValue());
-  }
-
-  @Test
-  public void testCreateOrRetrieveWhenExistingWithBadConfig() throws Exception {
-    EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
-    factory.create("testCreateOrRetrieveWhenExistingWithBadConfig",
-        new ServerSideConfiguration(null, EMPTY_RESOURCE_MAP)).close();
-    try {
-      factory.createOrRetrieve("testCreateOrRetrieveWhenExistingWithBadConfig",
-          new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("bar", 42L))));
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      //expected
-    }
-  }
-
-  @Test
   public void testRetrieveWithGoodConfig() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
     factory.create("testRetrieveWithGoodConfig",
-        new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("primary", 42L))))
-        .close();
+        new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("primary", 42L))));
     assertThat(factory.retrieve("testRetrieveWithGoodConfig",
         new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("primary", 43L)))), notNullValue());
   }
@@ -129,8 +100,7 @@ public class EhcacheClientEntityFactoryIntegrationTest {
   public void testRetrieveWithBadConfig() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
     factory.create("testRetrieveWithBadConfig",
-        new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("primary", 42L))))
-        .close();
+        new ServerSideConfiguration(null, Collections.singletonMap("foo", new Pool("primary", 42L))));
     try {
       factory.retrieve("testRetrieveWithBadConfig",
           new ServerSideConfiguration(null, Collections.singletonMap("bar", new Pool("primary", 42L))));
@@ -155,7 +125,7 @@ public class EhcacheClientEntityFactoryIntegrationTest {
   @Ignore
   public void testDestroy() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
-    factory.create("testDestroy", null).close();
+    factory.create("testDestroy", null);
     factory.destroy("testDestroy");
   }
 
@@ -166,7 +136,7 @@ public class EhcacheClientEntityFactoryIntegrationTest {
     try {
       factory.destroy("testDestroyWhenNotExisting");
       fail("Expected EntityNotFoundException");
-    } catch (EntityNotFoundException e) {
+    } catch (EhcacheEntityNotFoundException e) {
       //expected
     }
   }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -304,6 +304,9 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
    */
   @Override
   public void destroy() {
+
+    defaultServerResource = null;
+
     /*
      * Ensure the allocated stores are closed out.
      */
@@ -327,6 +330,8 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
      */
     releasePools("shared", this.sharedResourcePools);
     releasePools("fixed", this.fixedResourcePools);
+
+    this.sharedResourcePools = null;
   }
 
   /**


### PR DESCRIPTION
This commit focuses on implementing unit tests on
DefaultClusteringService.  It also includes corrections for defects
discovered during unit test construction.

* DefaultClusteringServiceTest is substantially extended; this was the
  primary objective of this commit.
* ObservableEhcacheServerEntityService is added to permit making
  assertions about the EhcacheActiveEntity during unit tests performed
  with the aid of PassthroughServer.  This class is intentionally
  added in a package "owned" by the clustered/server module to permit
  access to otherwise package-private details during unit tests.
* DefaultClusteringService.create was creating and holding a client
  entity (logical connection); this commit closes that entity and no
  longer returns an EhcacheClientEntity from create.
* EhcacheClientEntityFactory.destroy was implemented providing support
  for DefaultClusteringService.destroyAll.
* The EhcacheEntityBusyException and EhcacheEntityNotFoundException
  are introduced.
* ClusteringService.connect is removed; connect handling is entirely
  internal to DefaultClusteringService.
* EhcacheClientEntityFactory.createOrRetrieve was removed along with
  the associated tests.
* UnitTestConnectionService is amended to omit the "default"
  ServerEntityServices and ClientEntityServices when one is provided.
  This was done to allow replacement implementations for these
  services.
* EhcacheActiveEntity.destroy was to return the instance to a state
  more closely resembling the initial instance state.