### PR TITLE
Issue #763 Unit tests for EhcacheClientEntityFactory

### DIFF
--- a/clustered/client/src/test/java/org/ehcache/clustered/client/NonClusteredCacheTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/NonClusteredCacheTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client;
+
+import org.ehcache.CacheManager;
+import org.ehcache.clustered.client.internal.store.ClusteredStore;
+import org.ehcache.clustered.client.service.ClusteringService;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.internal.util.ClassLoading;
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Ensures that a non-clustered {@code CacheManager} can be created when clustered classes are
+ * available in classpath.
+ */
+public class NonClusteredCacheTest {
+
+  @Test
+  public void testNonClustered() throws Exception {
+
+    /*
+     * Ensure the cluster provider classes are loadable through the ServiceLoader mechanism.
+     */
+    Set<Class<?>> targetProviders = new HashSet<Class<?>>();
+    targetProviders.add(ClusteredStore.Provider.class);
+    targetProviders.add(ClusteringService.class);
+    for (ServiceFactory factory : ClassLoading.libraryServiceLoaderFor(ServiceFactory.class)) {
+      if (targetProviders.remove(factory.getServiceType())) {
+        if (targetProviders.isEmpty()) {
+          break;
+        }
+      }
+    }
+    assertThat(targetProviders, is(Matchers.empty()));
+
+    CacheConfiguration<String, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        String.class,
+        String.class,
+        ResourcePoolsBuilder.newResourcePoolsBuilder()
+            .heap(10, EntryUnit.ENTRIES)
+            .offheap(1, MemoryUnit.MB)
+            .build())
+        .build();
+
+
+    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
+
+    cacheManager.createCache("cache-1", cacheConfiguration);
+    cacheManager.createCache("cache-2", cacheConfiguration);
+
+    cacheManager.close();
+  }
+}

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/EhcacheClientEntityFactoryIntegrationTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/EhcacheClientEntityFactoryIntegrationTest.java
@@ -27,7 +27,6 @@ import org.ehcache.clustered.common.ServerSideConfiguration.Pool;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.connection.Connection;
 import org.terracotta.exception.EntityAlreadyExistsException;
@@ -122,20 +121,18 @@ public class EhcacheClientEntityFactoryIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void testDestroy() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
-    factory.create("testDestroy", null);
+    factory.create("testDestroy", new ServerSideConfiguration(null, Collections.<String, Pool>emptyMap()));
     factory.destroy("testDestroy");
   }
 
   @Test
-  @Ignore
   public void testDestroyWhenNotExisting() throws Exception {
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(CONNECTION);
     try {
       factory.destroy("testDestroyWhenNotExisting");
-      fail("Expected EntityNotFoundException");
+      fail("Expected EhcacheEntityNotFoundException");
     } catch (EhcacheEntityNotFoundException e) {
       //expected
     }

--- a/transactions/src/test/java/org/ehcache/transactions/NonXACacheTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/NonXACacheTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.transactions;
+
+import org.ehcache.CacheManager;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.internal.util.ClassLoading;
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.ehcache.transactions.xa.internal.XAStore;
+import org.ehcache.transactions.xa.txmgr.provider.TransactionManagerProvider;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Ensures that a non-XA {@code CacheManager} can be created when XA classes are
+ * available in classpath.
+ */
+public class NonXACacheTest {
+
+  @Test
+  public void testNonXA() throws Exception {
+
+    /*
+     * Ensure the XA provider classes are loadable through the ServiceLoader mechanism.
+     */
+    Set<Class<?>> targetProviders = new HashSet<Class<?>>();
+    targetProviders.add(XAStore.Provider.class);
+    targetProviders.add(TransactionManagerProvider.class);
+    for (ServiceFactory factory : ClassLoading.libraryServiceLoaderFor(ServiceFactory.class)) {
+      if (targetProviders.remove(factory.getServiceType())) {
+        if (targetProviders.isEmpty()) {
+          break;
+        }
+      }
+    }
+    assertThat(targetProviders, is(Matchers.empty()));
+
+    CacheConfiguration<String, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        String.class,
+        String.class,
+        ResourcePoolsBuilder.newResourcePoolsBuilder()
+            .heap(10, EntryUnit.ENTRIES)
+            .offheap(1, MemoryUnit.MB)
+            .build())
+        .build();
+
+
+    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
+
+    cacheManager.createCache("cache-1", cacheConfiguration);
+    cacheManager.createCache("cache-2", cacheConfiguration);
+
+    cacheManager.close();
+  }
+}


### PR DESCRIPTION
This commit stream closes #763 by updating tests for `EhcacheClientEntityFactory`, `ClusteringServiceConfiguration`, and `DefaultClusteringService`.  This commit stream enables previously disabled tests for the `EhcacheClientEntity.destroy` and `DefaultClusteringService.destroyAll` methods.

A test for #1098 along with a parallel test for XA is also included in this commit stream.