### PR TITLE
[Design Review] Issue #1077 Consistency configuration API

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteredStoreConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteredStoreConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.config;
+
+import org.ehcache.clustered.client.internal.store.ClusteredStore;
+import org.ehcache.spi.service.ServiceConfiguration;
+
+/**
+ * ClusteredStoreConfiguration
+ */
+public class ClusteredStoreConfiguration implements ServiceConfiguration<ClusteredStore.Provider> {
+
+  public enum Consistency {
+    EVENTUAL,
+    STRONG
+  }
+
+  @Override
+  public Class<ClusteredStore.Provider> getServiceType() {
+    return ClusteredStore.Provider.class;
+  }
+
+  public Consistency getConsistency() {
+    return Consistency.EVENTUAL;
+  }
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/builders/ClusteredStoreConfigurationBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/builders/ClusteredStoreConfigurationBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.config.builders;
+
+import org.ehcache.clustered.client.config.ClusteredStoreConfiguration;
+import org.ehcache.config.Builder;
+
+/**
+ * ClusteredStoreConfigurationBuilder
+ */
+public class ClusteredStoreConfigurationBuilder implements Builder<ClusteredStoreConfiguration> {
+
+  public static ClusteredStoreConfigurationBuilder withConsistency(ClusteredStoreConfiguration.Consistency consistency) {
+    return new ClusteredStoreConfigurationBuilder();
+  }
+
+  @Override
+  public ClusteredStoreConfiguration build() {
+    return new ClusteredStoreConfiguration();
+  }
+}

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -165,4 +165,17 @@
       </xs:annotation>
     </xs:attribute>
   </xs:attributeGroup>
+
+  <xs:element name="clustered-store" type="tc:clustered-store-type" substitutionGroup="eh:service-configuration"/>
+
+  <xs:complexType name="clustered-store-type">
+    <xs:attribute name="consistency" type="tc:consistency-type" default="eventual"/>
+  </xs:complexType>
+
+  <xs:simpleType name="consistency-type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="eventual"/>
+      <xs:enumeration value="strong"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/clustered/client/src/test/resources/configs/resource-sample.xml
+++ b/clustered/client/src/test/resources/configs/resource-sample.xml
@@ -32,6 +32,7 @@
       <eh:offheap unit="MB">512</eh:offheap>
       <tc:cluster-fixed unit="GB" from="secondary">128</tc:cluster-fixed>
     </eh:resources>
+    <tc:clustered-store consistency="strong"/>
   </eh:cache>
 
   <eh:cache alias="sharing">


### PR DESCRIPTION
* XML proposal
* Builders proposal

This is decoupled from the resource configuration because it is not really a resource constraint but a mutation visibility guarantee.
This is currently decoupled from what @lorban did in PR #1091 but would of course be based or wired to work in that context.