### PR TITLE
Issue #1112 Prevent test failures closing PassthroughConnection

### DIFF
--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
@@ -167,6 +167,8 @@ public class UnitTestConnectionService implements ConnectionService {
         try {
           LOGGER.warn("Force close {}", formatConnectionId(connection));
           connection.close();
+        } catch (AssertionError e) {
+          // Ignored -- https://github.com/Terracotta-OSS/terracotta-apis/issues/102
         } catch (IOException e) {
           // Ignored
         }


### PR DESCRIPTION
This commit changes UnitTestConnectionService.remove to absorb the
AssertionError that may be thrown by PassthroughConnection.close after
PassthroughServer.stop is called.  The PassthroughConnection.close
behavior appears to be introduced at Terracotta-OSS/terracotta-apis
build 65.

This commit closes issue #1112.