### PR TITLE
 #1007 ServerStore.clear() invalidation handling, both strong and eventual

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
@@ -81,16 +81,20 @@ public class EhcacheClientEntity implements Entity {
 
       @Override
       public void didDisconnectUnexpectedly() {
-        connected = false;
         fireDisconnectionEvent();
       }
     });
   }
 
-  private void fireDisconnectionEvent() {
+  void fireDisconnectionEvent() {
+    connected = false;
     for (DisconnectionListener listener : disconnectionListeners) {
       listener.onDisconnection();
     }
+  }
+
+  void setConnected(boolean connected) {
+    this.connected = connected;
   }
 
   private void fireResponseEvent(EhcacheEntityResponse response) {
@@ -98,6 +102,7 @@ public class EhcacheClientEntity implements Entity {
     if (responseListeners == null) {
       return;
     }
+    LOGGER.debug("{} registered response listener(s) for {}", responseListeners.size(), response.getClass());
     for (ResponseListener responseListener : responseListeners) {
       responseListener.onResponse(response);
     }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -341,14 +341,27 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
       clusteredStore.storeProxy = clusteringService.getServerStoreProxy(storeConfig.getCacheIdentifier(), storeConfig.getStoreConfig(), storeConfig.getConsistency());
       clusteredStore.storeProxy.addInvalidationListener(new ServerStoreProxy.InvalidationListener() {
         @Override
-        public void onInvalidationRequest(long hash) {
+        public void onInvalidateHash(long hash) {
           if (clusteredStore.invalidationValve != null) {
             try {
-              LOGGER.debug("CLIENT: calling invalidation valve");
+              LOGGER.debug("CLIENT: calling invalidation valve for hash {}", hash);
               clusteredStore.invalidationValve.invalidateAllWithHash(hash);
             } catch (StoreAccessException sae) {
               //TODO: what should be done here? delegate to resilience strategy?
               LOGGER.error("Error invalidating hash {}", hash, sae);
+            }
+          }
+        }
+
+        @Override
+        public void onInvalidateAll() {
+          if (clusteredStore.invalidationValve != null) {
+            try {
+              LOGGER.debug("CLIENT: calling invalidation valve for all");
+              clusteredStore.invalidationValve.invalidateAll();
+            } catch (StoreAccessException sae) {
+              //TODO: what should be done here? delegate to resilience strategy?
+              LOGGER.error("Error invalidating all", sae);
             }
           }
         }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/EventualServerStoreProxy.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/EventualServerStoreProxy.java
@@ -47,7 +47,19 @@ public class EventualServerStoreProxy implements ServerStoreProxy {
 
         LOGGER.debug("CLIENT: doing work to invalidate hash {} from cache {} (ID {})", key, cacheId, invalidationId);
         for (InvalidationListener listener : invalidationListeners) {
-          listener.onInvalidationRequest(key);
+          listener.onInvalidateHash(key);
+        }
+      }
+    });
+    entity.addResponseListener(EhcacheEntityResponse.ClientInvalidateAll.class, new EhcacheClientEntity.ResponseListener<EhcacheEntityResponse.ClientInvalidateAll>() {
+      @Override
+      public void onResponse(EhcacheEntityResponse.ClientInvalidateAll response) {
+        final String cacheId = response.getCacheId();
+        final int invalidationId = response.getInvalidationId();
+
+        LOGGER.debug("CLIENT: doing work to invalidate all from cache {} (ID {})", cacheId, invalidationId);
+        for (InvalidationListener listener : invalidationListeners) {
+          listener.onInvalidateAll();
         }
       }
     });
@@ -61,6 +73,11 @@ public class EventualServerStoreProxy implements ServerStoreProxy {
   @Override
   public void addInvalidationListener(InvalidationListener listener) {
     invalidationListeners.add(listener);
+  }
+
+  @Override
+  public boolean removeInvalidationListener(InvalidationListener listener) {
+    return invalidationListeners.remove(listener);
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/NoInvalidationServerStoreProxy.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/NoInvalidationServerStoreProxy.java
@@ -47,6 +47,11 @@ class NoInvalidationServerStoreProxy implements ServerStoreProxy {
   }
 
   @Override
+  public boolean removeInvalidationListener(InvalidationListener listener) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Chain get(long key) {
     EhcacheEntityResponse response;
     try {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ServerStoreProxy.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ServerStoreProxy.java
@@ -27,11 +27,16 @@ public interface ServerStoreProxy extends ServerStore {
    */
   interface InvalidationListener {
     /**
-     * Callback for invalidation requests
+     * Callback for invalidation of hash requests
      *
      * @param hash the hash of the keys to invalidate
      */
-    void onInvalidationRequest(long hash);
+    void onInvalidateHash(long hash);
+
+    /**
+     * Callback for invalidation of all requests
+     */
+    void onInvalidateAll();
   }
 
   /**
@@ -44,8 +49,15 @@ public interface ServerStoreProxy extends ServerStore {
   /**
    * Add a listener called when invalidation requests arrive.
    *
-   * @param listener the listener
+   * @param listener the listener to add
    */
   void addInvalidationListener(InvalidationListener listener);
+
+  /**
+   * Remove a listener
+   *
+   * @param listener the listener to remove
+   */
+  boolean removeInvalidationListener(InvalidationListener listener);
 
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/EhcacheClientEntityHelper.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/EhcacheClientEntityHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.client.internal;
+
+/**
+ * @author Ludovic Orban
+ */
+public class EhcacheClientEntityHelper {
+
+  public static void fireDisconnectionEvent(EhcacheClientEntity entity) {
+    entity.fireDisconnectionEvent();
+  }
+
+  public static void setConnected(EhcacheClientEntity entity, boolean connected) {
+    entity.setConnected(connected);
+  }
+
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/EhcacheEntityResponse.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/EhcacheEntityResponse.java
@@ -29,8 +29,10 @@ public abstract class EhcacheEntityResponse implements EntityResponse {
     SUCCESS((byte) 0),
     FAILURE((byte) 1),
     GET_RESPONSE((byte) 2),
-    INVALIDATION_DONE((byte) 3),
-    CLIENT_INVALIDATE_HASH((byte) 4),
+    HASH_INVALIDATION_DONE((byte) 3),
+    ALL_INVALIDATION_DONE((byte) 4),
+    CLIENT_INVALIDATE_HASH((byte) 5),
+    CLIENT_INVALIDATE_ALL((byte) 6),
     ;
 
     private final byte opCode;
@@ -52,9 +54,13 @@ public abstract class EhcacheEntityResponse implements EntityResponse {
         case 2:
           return GET_RESPONSE;
         case 3:
-          return INVALIDATION_DONE;
+          return HASH_INVALIDATION_DONE;
         case 4:
+          return ALL_INVALIDATION_DONE;
+        case 5:
           return CLIENT_INVALIDATE_HASH;
+        case 6:
+          return CLIENT_INVALIDATE_ALL;
         default:
           throw new IllegalArgumentException("Store operation not defined for : " + opCode);
       }
@@ -116,15 +122,15 @@ public abstract class EhcacheEntityResponse implements EntityResponse {
 
   }
 
-  public static InvalidationDone invalidationDone(String cacheId, long key) {
-    return new InvalidationDone(cacheId, key);
+  public static HashInvalidationDone hashInvalidationDone(String cacheId, long key) {
+    return new HashInvalidationDone(cacheId, key);
   }
 
-  public static class InvalidationDone extends EhcacheEntityResponse {
+  public static class HashInvalidationDone extends EhcacheEntityResponse {
     private final String cacheId;
     private final long key;
 
-    public InvalidationDone(String cacheId, long key) {
+    HashInvalidationDone(String cacheId, long key) {
       this.cacheId = cacheId;
       this.key = key;
     }
@@ -139,7 +145,29 @@ public abstract class EhcacheEntityResponse implements EntityResponse {
 
     @Override
     public Type getType() {
-      return Type.INVALIDATION_DONE;
+      return Type.HASH_INVALIDATION_DONE;
+    }
+
+  }
+
+  public static AllInvalidationDone allInvalidationDone(String cacheId) {
+    return new AllInvalidationDone(cacheId);
+  }
+
+  public static class AllInvalidationDone extends EhcacheEntityResponse {
+    private final String cacheId;
+
+    AllInvalidationDone(String cacheId) {
+      this.cacheId = cacheId;
+    }
+
+    public String getCacheId() {
+      return cacheId;
+    }
+
+    @Override
+    public Type getType() {
+      return Type.ALL_INVALIDATION_DONE;
     }
 
   }
@@ -174,6 +202,33 @@ public abstract class EhcacheEntityResponse implements EntityResponse {
     @Override
     public Type getType() {
       return Type.CLIENT_INVALIDATE_HASH;
+    }
+  }
+
+  public static ClientInvalidateAll clientInvalidateAll(String cacheId, int invalidationId) {
+    return new ClientInvalidateAll(cacheId, invalidationId);
+  }
+
+  public static class ClientInvalidateAll extends EhcacheEntityResponse {
+    private final String cacheId;
+    private final int invalidationId;
+
+    public ClientInvalidateAll(String cacheId, int invalidationId) {
+      this.cacheId = cacheId;
+      this.invalidationId = invalidationId;
+    }
+
+    public String getCacheId() {
+      return cacheId;
+    }
+
+    public int getInvalidationId() {
+      return invalidationId;
+    }
+
+    @Override
+    public Type getType() {
+      return Type.CLIENT_INVALIDATE_ALL;
     }
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreMessageFactory.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreMessageFactory.java
@@ -43,8 +43,8 @@ public class ServerStoreMessageFactory {
     return new ServerStoreOpMessage.ReplaceAtHeadMessage(this.cacheId, key, expect, update);
   }
 
-  public EhcacheEntityMessage clientInvalidateHashAck(long key, int invalidationId) {
-    return new ServerStoreOpMessage.ClientInvalidateHashAck(this.cacheId, key, invalidationId);
+  public EhcacheEntityMessage clientInvalidationAck(int invalidationId) {
+    return new ServerStoreOpMessage.ClientInvalidationAck(this.cacheId, invalidationId);
   }
 
   public EhcacheEntityMessage clearOperation() {

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpCodec.java
@@ -20,7 +20,7 @@ import org.ehcache.clustered.common.messages.ServerStoreOpMessage.ClearMessage;
 import org.ehcache.clustered.common.messages.ServerStoreOpMessage.GetAndAppendMessage;
 import org.ehcache.clustered.common.messages.ServerStoreOpMessage.GetMessage;
 import org.ehcache.clustered.common.messages.ServerStoreOpMessage.ReplaceAtHeadMessage;
-import org.ehcache.clustered.common.messages.ServerStoreOpMessage.ClientInvalidateHashAck;
+import org.ehcache.clustered.common.messages.ServerStoreOpMessage.ClientInvalidationAck;
 import org.ehcache.clustered.common.messages.ServerStoreOpMessage.ServerStoreOp;
 
 import java.nio.ByteBuffer;
@@ -79,11 +79,11 @@ class ServerStoreOpCodec {
         encodedMsg.putInt(encodedUpdatedChain.length);
         encodedMsg.put(encodedUpdatedChain);
         return encodedMsg.array();
-      case CLIENT_INVALIDATE_HASH_ACK:
-        ReplaceAtHeadMessage.ClientInvalidateHashAck clientInvalidateHashAck = (ReplaceAtHeadMessage.ClientInvalidateHashAck) message;
+      case CLIENT_INVALIDATION_ACK:
+        ClientInvalidationAck clientInvalidationAck = (ClientInvalidationAck) message;
         encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + CACHE_ID_LEN_SIZE + KEY_SIZE + 2 * cacheIdLen + 4);
-        putCacheIdKeyAndOpCode(encodedMsg, message.getCacheId(), message.getKey(), message.operation().getStoreOpCode());
-        encodedMsg.putInt(clientInvalidateHashAck.getInvalidationId());
+        putCacheIdKeyAndOpCode(encodedMsg, message.getCacheId(), 0L, message.operation().getStoreOpCode());
+        encodedMsg.putInt(clientInvalidationAck.getInvalidationId());
         return encodedMsg.array();
       case CLEAR:
         ClearMessage clearMessage = (ClearMessage)message;
@@ -140,10 +140,10 @@ class ServerStoreOpCodec {
         replaceBuf.get(encodedUpdateChain);
         return new ReplaceAtHeadMessage(cacheId, key, chainCodec.decode(encodedExpectChain),
             chainCodec.decode(encodedUpdateChain));
-      case CLIENT_INVALIDATE_HASH_ACK:
+      case CLIENT_INVALIDATION_ACK:
         ByteBuffer remainingBuf = ByteBuffer.wrap(remaining);
         int invalidationId = remainingBuf.getInt();
-        return new ClientInvalidateHashAck(cacheId, key, invalidationId);
+        return new ClientInvalidationAck(cacheId, invalidationId);
       default:
         throw new UnsupportedOperationException("This operation code is not supported : " + opCode);
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
@@ -28,7 +28,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     GET_AND_APPEND((byte) 11),
     APPEND((byte) 12),
     REPLACE((byte) 13),
-    CLIENT_INVALIDATE_HASH_ACK((byte) 14),
+    CLIENT_INVALIDATION_ACK((byte) 14),
     CLEAR((byte) 15),
     ;
 
@@ -53,7 +53,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
         case 13:
           return REPLACE;
         case 14:
-          return CLIENT_INVALIDATE_HASH_ACK;
+          return CLIENT_INVALIDATION_ACK;
         case 15:
           return CLEAR;
         default:
@@ -168,14 +168,19 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     }
   }
 
-
-  public static class ClientInvalidateHashAck extends ServerStoreOpMessage {
+  // TODO: ClientInvalidationAck does not need a key
+  public static class ClientInvalidationAck extends ServerStoreOpMessage {
 
     private final int invalidationId;
 
-    public ClientInvalidateHashAck(String cacheId, long key, int invalidationId) {
-      super(cacheId, key);
+    ClientInvalidationAck(String cacheId, int invalidationId) {
+      super(cacheId, 0L);
       this.invalidationId = invalidationId;
+    }
+
+    @Override
+    public long getKey() {
+      throw new UnsupportedOperationException("ClientInvalidationAck message does not have a key parameter");
     }
 
     public int getInvalidationId() {
@@ -184,17 +189,17 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
 
     @Override
     public ServerStoreOp operation() {
-      return ServerStoreOp.CLIENT_INVALIDATE_HASH_ACK;
+      return ServerStoreOp.CLIENT_INVALIDATION_ACK;
     }
 
     @Override
     public byte getOpCode() {
-      return ServerStoreOp.CLIENT_INVALIDATE_HASH_ACK.getStoreOpCode();
+      return ServerStoreOp.CLIENT_INVALIDATION_ACK.getStoreOpCode();
     }
   }
 
+  // TODO: ClearMessage does not need a key
   static class ClearMessage extends ServerStoreOpMessage {
-
 
     ClearMessage(final String cacheId) {
       super(cacheId, 0L);


### PR DESCRIPTION
I added a couple more TODO's in `ServerStoreOpMessage` as we now have two messages that do not need a key but do have to send 8 bytes on the wire to act as that key.