### PR TITLE
don't embed management  in Ehcache Clustered

### DIFF
--- a/clustered/dist/build.gradle
+++ b/clustered/dist/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   compile project(':api')
   compile project(':core')
   compile project(':impl')
-  compile project(':management')
   compile project(':107')
   compile project(':xml')
   compile project(':transactions')


### PR DESCRIPTION
This module brings external dependencies (terracotta management-model) that could cause classpath clashing issues
More concretely, when we launch an ehcache client from our ide, some management model classes are loaded from ehcache-clustered (since it shades them) instead of the "official" management-model jar