### PR TITLE
Replaces #1128 to solve classpath issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ import scripts.*
 ext {
   baseVersion = '3.1.0-SNAPSHOT'
   offheapVersion = '2.2.2'
-  managementVersion = '2.5.0'
+  managementVersion = '2.6.0-SNAPSHOT'
   statisticVersion = '1.1.0'
   jcacheVersion = '1.0.0'
   slf4jVersion = '1.7.7'

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -20,3 +20,7 @@ dependencies {
   compile project(':api'), project(':core'), project(':impl')
   compile group: 'org.terracotta.management', name: 'management-registry', version: parent.managementVersion
 }
+
+repositories {
+  maven { url "http://snapshots.terracotta.org/" }
+}


### PR DESCRIPTION
Replaces #1128 to solve classpath issue.

- management jars must be the same everywhere
- Ehcache master can point to management's snapshots
