### PR TITLE
Issue #1108 Prevent client stall on CacheManager.close

### DIFF
--- a/clustered/integration-test/build.gradle
+++ b/clustered/integration-test/build.gradle
@@ -42,5 +42,7 @@ test {
   environment 'JAVA_HOME', MavenToolchain.javaHome(JavaVersion.VERSION_1_8)
   environment 'JAVA_OPTS', '-Dcom.tc.l2.lockmanager.greedy.locks.enabled=false'
   systemProperty 'kitInstallationPath', "$unzipKit.destinationDir/ehcache-clustered-$project.version-kit/terracotta-$parent.terracottaCoreVersion"
+  // Uncomment to include client logging in console output
+  // testLogging.showStandardStreams = true
 }
 

--- a/clustered/integration-test/src/test/java/com/tc/logging/TestLoggingService.java
+++ b/clustered/integration-test/src/test/java/com/tc/logging/TestLoggingService.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tc.logging;
+
+import java.net.URI;
+
+/**
+ * A Terracotta logger writing to {@code System.out}.
+ */
+public class TestLoggingService implements TCLoggingService {
+
+  @Override
+  public TCLogger getLogger(final String name) {
+    return new TCLogger() {
+
+      private void log(String level, String message) {
+        System.out.println(level + " [" + getName() + "] : " + message);
+      }
+
+      @Override
+      public void debug(Object message) {
+        log("DEBUG", message.toString());
+      }
+
+      @Override
+      public void debug(Object message, Throwable t) {
+        debug(message + " : " + t);
+      }
+
+      @Override
+      public void error(Object message) {
+        log("ERROR", message.toString());
+      }
+
+      @Override
+      public void error(Object message, Throwable t) {
+        error(message + " : " + t);
+      }
+
+      @Override
+      public void fatal(Object message) {
+        log("FATAL", message.toString());
+      }
+
+      @Override
+      public void fatal(Object message, Throwable t) {
+        fatal(message + " : " + t);
+      }
+
+      @Override
+      public void info(Object message) {
+        log("INFO", message.toString());
+      }
+
+      @Override
+      public void info(Object message, Throwable t) {
+        info(message + " : " + t);
+      }
+
+      @Override
+      public void warn(Object message) {
+        log("WARN", message.toString());
+      }
+
+      @Override
+      public void warn(Object message, Throwable t) {
+        warn(message + " : " + t);
+      }
+
+      @Override
+      public boolean isDebugEnabled() {
+        return true;
+      }
+
+      @Override
+      public boolean isInfoEnabled() {
+        return true;
+      }
+
+      @Override
+      public void setLevel(LogLevel level) {
+        //no-op
+      }
+
+      @Override
+      public LogLevel getLevel() {
+        return null;
+      }
+
+      @Override
+      public String getName() {
+        return name;
+      }
+    };
+  }
+
+  @Override
+  public TCLogger getLogger(Class<?> c) {
+    return getLogger(c.getName());
+  }
+
+  @Override
+  public TCLogger getTestingLogger(String name) {
+    return getLogger(name);
+  }
+
+  @Override
+  public TCLogger getConsoleLogger() {
+    return getLogger("console.logger");
+  }
+
+  @Override
+  public TCLogger getOperatorEventLogger() {
+    return getLogger("operator.event");
+  }
+
+  @Override
+  public TCLogger getDumpLogger() {
+    return getLogger("dump.logger");
+  }
+
+  @Override
+  public TCLogger getCustomerLogger(String name) {
+    return getLogger("customer.logger." + name);
+  }
+
+  @Override
+  public void setLogLocationAndType(URI location, int processType) {
+  }
+}

--- a/clustered/integration-test/src/test/java/org/ehcache/Diagnostics.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/Diagnostics.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Calendar;
+import java.util.Date;
+
+import javax.management.MBeanServer;
+
+/**
+ * Provides methods to produce diagnostic output.
+ */
+@SuppressWarnings({ "UnusedDeclaration", "WeakerAccess" })
+public final class Diagnostics {
+
+  private static final String HOTSPOT_DIAGNOSTIC_MXBEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
+  private static final String HEAP_DUMP_FILENAME_TEMPLATE = "java_%1$04d_%2$tFT%2$tH%2$tM%2$tS.%2$tL.hprof";
+  private static final File WORKING_DIRECTORY = new File(System.getProperty("user.dir"));
+
+  /**
+   * Private niladic constructor to prevent instantiation.
+   */
+  private Diagnostics() {
+  }
+
+  /**
+   * Writes a complete thread dump to {@code System.err}.
+   */
+  public static void threadDump() {
+    threadDump(System.err);
+  }
+
+  /**
+   * Writes a complete thread dump to the designated {@code PrintStream}.
+   *
+   * @param out the {@code PrintStream} to which the thread dump is written
+   */
+  public static void threadDump(final PrintStream out) {
+    if (out == null) {
+      throw new NullPointerException("out");
+    }
+
+    final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+    final Calendar when = Calendar.getInstance();
+    final ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(
+        threadMXBean.isObjectMonitorUsageSupported(), threadMXBean.isSynchronizerUsageSupported());
+
+    out.format("%nFull thread dump %1$tF %1$tT.%1$tL %1$tz%n", when);
+    for (final ThreadInfo threadInfo : threadInfos) {
+      out.print(format(threadInfo));
+    }
+  }
+
+  /**
+   * Format a {@code ThreadInfo} instance <i>without</i> a stack depth limitation.  This method reproduces the
+   * formatting performed in {@code java.lang.management.ThreadInfo.toString()} without the stack depth limit.
+   *
+   * @param threadInfo the {@code ThreadInfo} instance to foramt
+   *
+   * @return a {@code CharSequence} instance containing the formatted {@code ThreadInfo}
+   */
+  private static CharSequence format(final ThreadInfo threadInfo) {
+    StringBuilder sb = new StringBuilder(4096);
+
+    Thread.State threadState = threadInfo.getThreadState();
+    sb.append('"')
+        .append(threadInfo.getThreadName())
+        .append('"')
+        .append(" Id=")
+        .append(threadInfo.getThreadId())
+        .append(' ')
+        .append(threadState);
+
+    if (threadInfo.getLockName() != null) {
+      sb.append(" on ").append(threadInfo.getLockName());
+    }
+    if (threadInfo.getLockOwnerName() != null) {
+      sb.append(" owned by ").append('"').append(threadInfo.getLockOwnerName()).append('"')
+          .append(" Id=").append(threadInfo.getLockOwnerId());
+    }
+
+    if (threadInfo.isSuspended()) {
+      sb.append(" (suspended)");
+    }
+    if (threadInfo.isInNative()) {
+      sb.append(" (in native)");
+    }
+    sb.append('\n');
+
+    StackTraceElement[] stackTrace = threadInfo.getStackTrace();
+    for (int i = 0; i < stackTrace.length; i++) {
+      StackTraceElement element = stackTrace[i];
+      sb.append("\tat ").append(element);
+      sb.append('\n');
+      if (i == 0) {
+        if (threadInfo.getLockInfo() != null) {
+          switch (threadState) {
+            case BLOCKED:
+              sb.append("\t- blocked on ").append(threadInfo.getLockInfo());
+              sb.append('\n');
+              break;
+            case WAITING:
+              sb.append("\t- waiting on ").append(threadInfo.getLockInfo());
+              sb.append('\n');
+              break;
+            case TIMED_WAITING:
+              sb.append("\t- waiting on ").append(threadInfo.getLockInfo());
+              sb.append('\n');
+              break;
+            default:
+          }
+        }
+      }
+
+      for (MonitorInfo monitorInfo : threadInfo.getLockedMonitors()) {
+        if (monitorInfo.getLockedStackDepth() == i) {
+          sb.append("\t- locked ").append(monitorInfo);
+          sb.append('\n');
+        }
+      }
+    }
+
+    LockInfo[] lockedSynchronizers = threadInfo.getLockedSynchronizers();
+    if (lockedSynchronizers.length > 0) {
+      sb.append("\n\tNumber of locked synchronizers = ").append(lockedSynchronizers.length);
+      sb.append('\n');
+      for (LockInfo lockedSynchronizer : lockedSynchronizers) {
+        sb.append("\t- ").append(lockedSynchronizer);
+        sb.append('\n');
+      }
+    }
+
+    sb.append('\n');
+    return sb;
+  }
+
+  /**
+   * Take a Java heap dump into a file whose name is produced from the template
+   * <code>{@value #HEAP_DUMP_FILENAME_TEMPLATE}</code> where {@code 1$} is the PID of
+   * the current process obtained from {@link #getPid()}.
+   *
+   * @param dumpLiveObjects if {@code true}, only "live" (reachable) objects are dumped;
+   *                        if {@code false}, all objects in the heap are dumped
+   *
+   * @return the name of the dump file; the file is written to the current directory (generally {@code user.dir})
+   */
+  public static String dumpHeap(final boolean dumpLiveObjects) {
+
+    String dumpName;
+    final int pid = getPid();
+    final Date currentTime = new Date();
+    if (pid > 0) {
+      dumpName = String.format(HEAP_DUMP_FILENAME_TEMPLATE, pid, currentTime);
+    } else {
+      dumpName = String.format(HEAP_DUMP_FILENAME_TEMPLATE, 0, currentTime);
+    }
+
+    dumpName = new File(WORKING_DIRECTORY, dumpName).getAbsolutePath();
+
+    try {
+      dumpHeap(dumpLiveObjects, dumpName);
+    } catch (IOException e) {
+      System.err.printf("Unable to write heap dump to %s: %s%n", dumpName, e);
+      e.printStackTrace(System.err);
+      return null;
+    }
+
+    return dumpName;
+  }
+
+  /**
+   * Write a Java heap dump to the named file.  If the dump file exists, this method will
+   * fail.
+   *
+   * @param dumpLiveObjects if {@code true}, only "live" (reachable) objects are dumped;
+   *                        if {@code false}, all objects in the heap are dumped
+   * @param dumpName the name of the file to which the heap dump is written; relative names
+   *                 are relative to the current directory ({@code user.dir}).  If the value
+   *                 of {@code dumpName} does not end in {@code .hprof}, it is appended.
+   *
+   * @throws IOException if thrown while loading the HotSpot Diagnostic MXBean or writing the heap dump
+   *
+   * @see <a href="http://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/HotSpotDiagnosticMXBean.html">
+   *        com.sun.management.HotSpotDiagnosticMXBean</a>
+   */
+  public static void dumpHeap(final boolean dumpLiveObjects, String dumpName) throws IOException {
+    if (dumpName == null) {
+      throw new NullPointerException("dumpName");
+    }
+
+    if (!dumpName.endsWith(".hprof")) {
+      dumpName += ".hprof";
+    }
+
+    final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    final HotSpotDiagnosticMXBean hotSpotDiagnosticMXBean =
+        ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_DIAGNOSTIC_MXBEAN_NAME, HotSpotDiagnosticMXBean.class);
+    hotSpotDiagnosticMXBean.dumpHeap(dumpName, dumpLiveObjects);
+  }
+
+  /**
+   * Gets the PID of the current process.  This method is dependent upon "common"
+   * operation of the {@code java.lang.management.RuntimeMXBean#getName()} method.
+   *
+   * @return the PID of the current process or {@code -1} if the PID can not be determined
+   */
+  public static int getPid() {
+    // Expected to be of the form "<pid>@<hostname>"
+    final String jvmProcessName = ManagementFactory.getRuntimeMXBean().getName();
+    try {
+      return Integer.valueOf(jvmProcessName.substring(0, jvmProcessName.indexOf('@')));
+    } catch (NumberFormatException e) {
+      return -1;
+    } catch (IndexOutOfBoundsException e) {
+      return -1;
+    }
+  }
+}

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/TerminatedServerTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/TerminatedServerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.CacheManager;
+import org.ehcache.Diagnostics;
+import org.ehcache.PersistentCacheManager;
+import org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.terracotta.testing.rules.BasicExternalCluster;
+import org.terracotta.testing.rules.Cluster;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides integration tests in which the server is terminated before the Ehcache operation completes.
+ */
+public class TerminatedServerTest {
+
+  private static final String RESOURCE_CONFIG =
+      "<service xmlns:ohr='http://www.terracotta.org/config/offheap-resource' id=\"resources\">"
+          + "<ohr:offheap-resources>"
+          + "<ohr:resource name=\"primary-server-resource\" unit=\"MB\">64</ohr:resource>"
+          + "</ohr:offheap-resources>" +
+          "</service>\n";
+
+  @Rule
+  public final TestName testName = new TestName();
+
+  @Rule
+  public final Cluster cluster =
+      new BasicExternalCluster(new File("build/cluster"), 1, Collections.<File>emptyList(), "", RESOURCE_CONFIG);
+
+  @Before
+  public void waitForActive() throws Exception {
+    cluster.getClusterControl().waitForActive();
+  }
+
+  /**
+   * Tests if {@link CacheManager#close()} blocks if the client/server connection is disconnected.
+   */
+  @Test
+  public void testTerminationBeforeCacheManagerClose() throws Exception {
+    CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder =
+        CacheManagerBuilder.newCacheManagerBuilder()
+        .with(ClusteringServiceConfigurationBuilder.cluster(cluster.getConnectionURI().resolve("/MyCacheManagerName?auto-create"))
+            .defaultServerResource("primary-server-resource"));
+    PersistentCacheManager cacheManager = clusteredCacheManagerBuilder.build(false);
+    cacheManager.init();
+
+    cluster.getClusterControl().tearDown();
+
+    Future<Void> future = interruptAfter(2, TimeUnit.SECONDS);
+    try {
+      cacheManager.close();
+    } finally {
+      future.cancel(true);
+    }
+
+    // TODO: Add assertion for successful CacheManager.init() following cluster restart (https://github.com/Terracotta-OSS/galvan/issues/30)
+  }
+
+  /**
+   * Starts a {@code Thread} to terminate the calling thread after a specified interval.
+   * If the timeout expires, a thread dump is taken and the current thread interrupted.
+   *
+   * @param interval the amount of time to wait
+   * @param unit the unit for {@code interval}
+   *
+   * @return a {@code Future} that may be used to cancel the timeout.
+   */
+  private Future<Void> interruptAfter(final int interval, final TimeUnit unit) {
+    final Thread targetThread = Thread.currentThread();
+    FutureTask<Void> killer = new FutureTask<Void>(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          unit.sleep(interval);
+          if (targetThread.isAlive()) {
+            System.out.format("%n%n%s test is stalled; taking a thread dump and terminating the test%n%n",
+                testName.getMethodName());
+            Diagnostics.threadDump(System.out);
+            targetThread.interrupt();
+
+            /*
+             *                NEVER DO THIS AT HOME!
+             * This code block uses a BAD, BAD, BAD, BAD deprecated method to ensure the target thread
+             * is terminated.  This is done to prevent a test stall from methods using a "non-interruptible"
+             * looping wait where the interrupt status is recorded but ignored until the awaited event
+             * occurs.
+             */
+            unit.timedJoin(targetThread, interval);
+            if (targetThread.isAlive()) {
+              System.out.format("%s test thread did not respond to Thread.interrupt; forcefully stopping %s%n",
+                  testName.getMethodName(), targetThread);
+              targetThread.stop();   // BAD CODE!
+            }
+          }
+        } catch (InterruptedException e) {
+          // Interrupted when canceled; simple exit
+        }
+      }
+    }, null);
+    Thread killerThread = new Thread(killer, "Timeout Task - " + testName.getMethodName());
+    killerThread.setDaemon(true);
+    killerThread.start();
+
+    return killer;
+  }
+}

--- a/clustered/integration-test/src/test/resources/META-INF/services/com.tc.logging.TCLoggingService
+++ b/clustered/integration-test/src/test/resources/META-INF/services/com.tc.logging.TCLoggingService
@@ -1,0 +1,16 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+com.tc.logging.TestLoggingService


### PR DESCRIPTION
This commit changes the behavior of DefaultClusteringService.close to
avoid Entity calls that might result in an interaction with the server.
Server interactions made when the server is disconnected can result in
operation stalls which are not resolved until the server returns to
service.  This kind of stall makes little sense when closing a
CacheManager.

This commit also adds an integration-test test case to reproduce the
symptoms of the issue.  TestLoggingService is added to enable
client-side logging from integration-test unit tests.

Fixes #1108.