### PR TITLE
Improving the byte consumption of store operation messages

### DIFF
--- a/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/messages/ServerStoreOpMessage.java
@@ -64,19 +64,13 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
   }
 
   private final String cacheId;
-  private final long key;
 
-  private ServerStoreOpMessage(String cacheId, long key) {
+  private ServerStoreOpMessage(String cacheId) {
     this.cacheId = cacheId;
-    this.key = key;
   }
 
   public String getCacheId() {
     return cacheId;
-  }
-
-  public long getKey() {
-    return key;
   }
 
   @Override
@@ -91,7 +85,21 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     return operation().getStoreOpCode();
   }
 
-  public static class GetMessage extends ServerStoreOpMessage {
+  private static abstract class KeyBasedServerStoreOpMessage extends ServerStoreOpMessage {
+
+    private final long key;
+
+    KeyBasedServerStoreOpMessage(final String cacheId, final long key) {
+      super(cacheId);
+      this.key = key;
+    }
+
+    public long getKey() {
+      return key;
+    }
+  }
+
+  public static class GetMessage extends KeyBasedServerStoreOpMessage {
 
     GetMessage(String cacheId, long key) {
       super(cacheId, key);
@@ -103,7 +111,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     }
   }
 
-  public static class GetAndAppendMessage extends ServerStoreOpMessage {
+  public static class GetAndAppendMessage extends KeyBasedServerStoreOpMessage {
 
     private final ByteBuffer payload;
 
@@ -123,7 +131,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
 
   }
 
-  public static class AppendMessage extends ServerStoreOpMessage {
+  public static class AppendMessage extends KeyBasedServerStoreOpMessage {
 
     private final ByteBuffer payload;
 
@@ -143,7 +151,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
 
   }
 
-  public static class ReplaceAtHeadMessage extends ServerStoreOpMessage {
+  public static class ReplaceAtHeadMessage extends KeyBasedServerStoreOpMessage {
 
     private final Chain expect;
     private final Chain update;
@@ -168,19 +176,13 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     }
   }
 
-  // TODO: ClientInvalidationAck does not need a key
   public static class ClientInvalidationAck extends ServerStoreOpMessage {
 
     private final int invalidationId;
 
     ClientInvalidationAck(String cacheId, int invalidationId) {
-      super(cacheId, 0L);
+      super(cacheId);
       this.invalidationId = invalidationId;
-    }
-
-    @Override
-    public long getKey() {
-      throw new UnsupportedOperationException("ClientInvalidationAck message does not have a key parameter");
     }
 
     public int getInvalidationId() {
@@ -198,11 +200,10 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     }
   }
 
-  // TODO: ClearMessage does not need a key
   static class ClearMessage extends ServerStoreOpMessage {
 
     ClearMessage(final String cacheId) {
-      super(cacheId, 0L);
+      super(cacheId);
     }
 
     @Override
@@ -213,11 +214,6 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public byte getOpCode() {
       return ServerStoreOp.CLEAR.getStoreOpCode();
-    }
-
-    @Override
-    public long getKey() {
-      throw new UnsupportedOperationException("Clear message does not have a key a parameter");
     }
   }
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/messages/ServerStoreMessageFactoryTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/messages/ServerStoreMessageFactoryTest.java
@@ -29,40 +29,57 @@ public class ServerStoreMessageFactoryTest {
 
   @Test
   public void testAppendMessage() {
-    EhcacheEntityMessage appendMessage = MESSAGE_FACTORY.appendOperation(1L, createPayload(1L));
+    ServerStoreOpMessage.AppendMessage appendMessage =
+        (ServerStoreOpMessage.AppendMessage) MESSAGE_FACTORY.appendOperation(1L, createPayload(1L));
 
-    assertThat(((ServerStoreOpMessage)appendMessage).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)appendMessage).getKey(), is(1L));
-    assertThat(readPayLoad(((ServerStoreOpMessage.AppendMessage)appendMessage).getPayload()), is(1L));
+    assertThat(appendMessage.getCacheId(), is("test"));
+    assertThat(appendMessage.getKey(), is(1L));
+    assertThat(readPayLoad(appendMessage.getPayload()), is(1L));
   }
 
   @Test
   public void testGetMessage() {
-    EhcacheEntityMessage getMessage = MESSAGE_FACTORY.getOperation(2L);
+    ServerStoreOpMessage.GetMessage getMessage = (ServerStoreOpMessage.GetMessage) MESSAGE_FACTORY.getOperation(2L);
 
-    assertThat(((ServerStoreOpMessage)getMessage).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)getMessage).getKey(), is(2L));
+    assertThat(getMessage.getCacheId(), is("test"));
+    assertThat(getMessage.getKey(), is(2L));
   }
 
   @Test
   public void testGetAndAppendMessage() {
-    EhcacheEntityMessage getAndAppendMessage = MESSAGE_FACTORY.getAndAppendOperation(10L, createPayload(10L));
+    ServerStoreOpMessage.GetAndAppendMessage getAndAppendMessage =
+        (ServerStoreOpMessage.GetAndAppendMessage) MESSAGE_FACTORY.getAndAppendOperation(10L, createPayload(10L));
 
-    assertThat(((ServerStoreOpMessage)getAndAppendMessage).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)getAndAppendMessage).getKey(), is(10L));
-    assertThat(readPayLoad(((ServerStoreOpMessage.GetAndAppendMessage)getAndAppendMessage).getPayload()), is(10L));
+    assertThat(getAndAppendMessage.getCacheId(), is("test"));
+    assertThat(getAndAppendMessage.getKey(), is(10L));
+    assertThat(readPayLoad(getAndAppendMessage.getPayload()), is(10L));
   }
 
   @Test
   public void testReplaceAtHeadMessage() {
-    EhcacheEntityMessage replaceAtHeadMessage = MESSAGE_FACTORY.replaceAtHeadOperation(10L,
-        getChain(true, createPayload(10L), createPayload(100L), createPayload(1000L)),
-        getChain(false, createPayload(2000L)));
+    ServerStoreOpMessage.ReplaceAtHeadMessage replaceAtHeadMessage =
+        (ServerStoreOpMessage.ReplaceAtHeadMessage) MESSAGE_FACTORY.replaceAtHeadOperation(10L,
+            getChain(true, createPayload(10L), createPayload(100L), createPayload(1000L)),
+            getChain(false, createPayload(2000L))
+        );
 
-    assertThat(((ServerStoreOpMessage)replaceAtHeadMessage).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)replaceAtHeadMessage).getKey(), is(10L));
-    Util.assertChainHas(((ServerStoreOpMessage.ReplaceAtHeadMessage)replaceAtHeadMessage).getExpect(), 10L, 100L, 1000L);
-    Util.assertChainHas(((ServerStoreOpMessage.ReplaceAtHeadMessage)replaceAtHeadMessage).getUpdate(), 2000L);
+    assertThat(replaceAtHeadMessage.getCacheId(), is("test"));
+    assertThat(replaceAtHeadMessage.getKey(), is(10L));
+    Util.assertChainHas(replaceAtHeadMessage.getExpect(), 10L, 100L, 1000L);
+    Util.assertChainHas(replaceAtHeadMessage.getUpdate(), 2000L);
   }
 
+  @Test
+  public void testClearMessage() throws Exception {
+    ServerStoreOpMessage.ClearMessage clearMessage = (ServerStoreOpMessage.ClearMessage) MESSAGE_FACTORY.clearOperation();
+    assertThat(clearMessage.getCacheId(), is("test"));
+  }
+
+  @Test
+  public void testClientInvalidationAckMessage() throws Exception {
+    ServerStoreOpMessage.ClientInvalidationAck invalidationAck =
+        (ServerStoreOpMessage.ClientInvalidationAck) MESSAGE_FACTORY.clientInvalidationAck(1234);
+    assertThat(invalidationAck.getCacheId(), is("test"));
+    assertThat(invalidationAck.getInvalidationId(), is(1234));
+  }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/messages/ServerStoreOpCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/messages/ServerStoreOpCodecTest.java
@@ -37,10 +37,11 @@ public class ServerStoreOpCodecTest {
     EhcacheEntityMessage appendMessage = MESSAGE_FACTORY.appendOperation(1L, createPayload(1L));
 
     EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)appendMessage));
+    ServerStoreOpMessage.AppendMessage decodedAppendMessage = (ServerStoreOpMessage.AppendMessage) decodedMsg;
 
-    assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)decodedMsg).getKey(), is(1L));
-    assertThat(readPayLoad(((ServerStoreOpMessage.AppendMessage)decodedMsg).getPayload()), is(1L));
+    assertThat(decodedAppendMessage.getCacheId(), is("test"));
+    assertThat(decodedAppendMessage.getKey(), is(1L));
+    assertThat(readPayLoad(decodedAppendMessage.getPayload()), is(1L));
   }
 
   @Test
@@ -48,9 +49,10 @@ public class ServerStoreOpCodecTest {
     EhcacheEntityMessage getMessage = MESSAGE_FACTORY.getOperation(2L);
 
     EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)getMessage));
+    ServerStoreOpMessage.GetMessage decodedGetMessage = (ServerStoreOpMessage.GetMessage) decodedMsg;
 
-    assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)decodedMsg).getKey(), is(2L));
+    assertThat(decodedGetMessage.getCacheId(), is("test"));
+    assertThat(decodedGetMessage.getKey(), is(2L));
   }
 
   @Test
@@ -58,10 +60,11 @@ public class ServerStoreOpCodecTest {
     EhcacheEntityMessage getAndAppendMessage = MESSAGE_FACTORY.getAndAppendOperation(10L, createPayload(10L));
 
     EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)getAndAppendMessage));
+    ServerStoreOpMessage.GetAndAppendMessage decodedGetAndAppendMessage = (ServerStoreOpMessage.GetAndAppendMessage) decodedMsg;
 
-    assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)decodedMsg).getKey(), is(10L));
-    assertThat(readPayLoad(((ServerStoreOpMessage.GetAndAppendMessage)decodedMsg).getPayload()), is(10L));
+    assertThat(decodedGetAndAppendMessage.getCacheId(), is("test"));
+    assertThat(decodedGetAndAppendMessage.getKey(), is(10L));
+    assertThat(readPayLoad(decodedGetAndAppendMessage.getPayload()), is(10L));
   }
 
   @Test
@@ -71,11 +74,12 @@ public class ServerStoreOpCodecTest {
         getChain(false, createPayload(2000L)));
 
     EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)replaceAtHeadMessage));
+    ServerStoreOpMessage.ReplaceAtHeadMessage decodedReplaceAtHeadMessage = (ServerStoreOpMessage.ReplaceAtHeadMessage) decodedMsg;
 
-    assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
-    assertThat(((ServerStoreOpMessage)decodedMsg).getKey(), is(10L));
-    Util.assertChainHas(((ServerStoreOpMessage.ReplaceAtHeadMessage)decodedMsg).getExpect(), 10L, 100L, 1000L);
-    Util.assertChainHas(((ServerStoreOpMessage.ReplaceAtHeadMessage)decodedMsg).getUpdate(), 2000L);
+    assertThat(decodedReplaceAtHeadMessage.getCacheId(), is("test"));
+    assertThat(decodedReplaceAtHeadMessage.getKey(), is(10L));
+    Util.assertChainHas(decodedReplaceAtHeadMessage.getExpect(), 10L, 100L, 1000L);
+    Util.assertChainHas(decodedReplaceAtHeadMessage.getUpdate(), 2000L);
   }
 
   @Test
@@ -84,5 +88,16 @@ public class ServerStoreOpCodecTest {
     byte[] encodedBytes = STORE_OP_CODEC.encode((ServerStoreOpMessage)clearMessage);
     EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(encodedBytes);
     assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
+  }
+
+  @Test
+  public void testClientInvalidationAckMessageCodec() throws Exception {
+    EhcacheEntityMessage invalidationAckMessage = MESSAGE_FACTORY.clientInvalidationAck(123);
+    byte[] encodedBytes = STORE_OP_CODEC.encode((ServerStoreOpMessage)invalidationAckMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(encodedBytes);
+    ServerStoreOpMessage.ClientInvalidationAck decodedInvalidationAckMessage = (ServerStoreOpMessage.ClientInvalidationAck)decodedMsg;
+
+    assertThat(decodedInvalidationAckMessage.getCacheId(), is("test"));
+    assertThat(decodedInvalidationAckMessage.getInvalidationId(), is(123));
   }
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -348,15 +348,20 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
 
     try {
       switch (message.operation()) {
-        case GET: return responseFactory.response(cacheStore.get(message.getKey()));
+        case GET:
+          ServerStoreOpMessage.GetMessage getMessage = (ServerStoreOpMessage.GetMessage)message;
+          return responseFactory.response(cacheStore.get(getMessage.getKey()));
         case APPEND: {
-          cacheStore.append(message.getKey(), ((ServerStoreOpMessage.AppendMessage) message).getPayload());
-          invalidateHash(clientDescriptor, message.getCacheId(), message.getKey());
+          ServerStoreOpMessage.AppendMessage appendMessage = (ServerStoreOpMessage.AppendMessage)message;
+          cacheStore.append(appendMessage.getKey(), appendMessage.getPayload());
+          invalidateHash(clientDescriptor, appendMessage.getCacheId(), appendMessage.getKey());
           return responseFactory.success();
         }
         case GET_AND_APPEND: {
-          EhcacheEntityResponse response = responseFactory.response(cacheStore.getAndAppend(message.getKey(), ((ServerStoreOpMessage.GetAndAppendMessage) message).getPayload()));
-          invalidateHash(clientDescriptor, message.getCacheId(), message.getKey());
+          ServerStoreOpMessage.GetAndAppendMessage getAndAppendMessage = (ServerStoreOpMessage.GetAndAppendMessage)message;
+          EhcacheEntityResponse response =
+              responseFactory.response(cacheStore.getAndAppend(getAndAppendMessage.getKey(), getAndAppendMessage.getPayload()));
+          invalidateHash(clientDescriptor, getAndAppendMessage.getCacheId(), getAndAppendMessage.getKey());
           return response;
         }
         case REPLACE: {


### PR DESCRIPTION
The intention was to avoid using the extra 8 bytes for key in the clear message and the invalidation ack message. But while I was at it I could minimize the byte consumption of the get message and replace message as well by doing some reordering of the fields in encoding and decoding.