### PR TITLE
Issue #1144 Clustered store bulk operations

### DIFF
--- a/core/src/main/java/org/ehcache/core/Ehcache.java
+++ b/core/src/main/java/org/ehcache/core/Ehcache.java
@@ -52,6 +52,7 @@ import org.ehcache.core.statistics.CacheOperationOutcomes.PutOutcome;
 import org.ehcache.core.statistics.CacheOperationOutcomes.RemoveAllOutcome;
 import org.ehcache.core.statistics.CacheOperationOutcomes.RemoveOutcome;
 import org.ehcache.core.statistics.CacheOperationOutcomes.ReplaceOutcome;
+import org.ehcache.expiry.Expiry;
 import org.ehcache.spi.loaderwriter.BulkCacheLoadingException;
 import org.ehcache.spi.loaderwriter.BulkCacheWritingException;
 import org.ehcache.core.spi.store.StoreAccessException;
@@ -326,24 +327,9 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
       return Collections.emptyMap();
     }
 
-    Function<Iterable<? extends K>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> computeFunction =
-        new Function<Iterable<? extends K>, Iterable<? extends Map.Entry<? extends K, ? extends V>>>() {
-      @Override
-      public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(Iterable<? extends K> keys) {
-        Map<K, V> computeResult = new LinkedHashMap<K ,V>();
-
-        // put all the entries to get ordering correct
-        for (K key : keys) {
-          computeResult.put(key, null);
-        }
-
-        return computeResult.entrySet();
-      }
-    };
-
     Map<K, V> result = new HashMap<K, V>();
     try {
-      Map<K, Store.ValueHolder<V>> computedMap = store.bulkComputeIfAbsent(keys, computeFunction);
+      Map<K, Store.ValueHolder<V>> computedMap = store.bulkComputeIfAbsent(keys, new GetAllFunction<K, V>());
 
       int hits = 0;
       int keyCount = 0;
@@ -401,39 +387,10 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
       entriesToRemap.put(entry.getKey(), entry.getValue());
     }
 
-    final AtomicInteger actualPutCount = new AtomicInteger();
-
-    // The compute function that will return the keys to their NEW values, taking the keys to their old values as input;
-    // but this could happen in batches, i.e. not necessary containing all of the entries of the Iterable passed to this method
-    Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> computeFunction =
-      new Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>>() {
-      @Override
-      public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries) {
-
-        Map<K, V> mutations = new LinkedHashMap<K, V>();
-
-        // then record we handled these mappings
-        for (Map.Entry<? extends K, ? extends V> entry: entries) {
-          K key = entry.getKey();
-          V existingValue = entry.getValue();
-          V newValue = entriesToRemap.remove(key);
-
-          if (newValueAlreadyExpired(key, existingValue, newValue)) {
-            mutations.put(key, null);
-          } else {
-            actualPutCount.incrementAndGet();
-            mutations.put(key, newValue);
-          }
-        }
-
-        // Finally return the values to be installed in the Cache's Store
-        return mutations.entrySet();
-      }
-    };
-
     try {
-      store.bulkCompute(entries.keySet(), computeFunction);
-      addBulkMethodEntriesCount(BulkOps.PUT_ALL, actualPutCount.get());
+      PutAllFunction<K, V> putAllFunction = new PutAllFunction<K, V>(logger, entriesToRemap, runtimeConfiguration.getExpiry());
+      store.bulkCompute(entries.keySet(), putAllFunction);
+      addBulkMethodEntriesCount(BulkOps.PUT_ALL, putAllFunction.getActualPutCount().get());
       putAllObserver.end(PutAllOutcome.SUCCESS);
     } catch (StoreAccessException e) {
       try {
@@ -463,32 +420,11 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
       }
     }
 
-    final AtomicInteger actualRemoveCount = new AtomicInteger();
-
-    Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> removalFunction =
-      new Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>>() {
-        @Override
-        public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries) {
-
-          Map<K, V> results = new LinkedHashMap<K, V>();
-
-          for (Map.Entry<? extends K, ? extends V> entry : entries) {
-            K key = entry.getKey();
-            V existingValue = entry.getValue();
-
-          if (existingValue != null) {
-            actualRemoveCount.incrementAndGet();
-          }
-          results.put(key, null);
-          }
-
-          return results.entrySet();
-        }
-      };
 
     try {
-      store.bulkCompute(keys, removalFunction);
-      addBulkMethodEntriesCount(BulkOps.REMOVE_ALL, actualRemoveCount.get());
+      RemoveAllFunction<K, V> removeAllFunction = new RemoveAllFunction<K, V>();
+      store.bulkCompute(keys, removeAllFunction);
+      addBulkMethodEntriesCount(BulkOps.REMOVE_ALL, removeAllFunction.getActualRemoveCount().get());
       removeAllObserver.end(RemoveAllOutcome.SUCCESS);
     } catch (StoreAccessException e) {
       try {
@@ -1029,6 +965,118 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
       return storeEntry.getValue().value();
     }
 
+  }
+
+  // The compute function that will return the keys to their NEW values, taking the keys to their old values as input;
+  // but this could happen in batches, i.e. not necessary containing all of the entries of the Iterable passed to this method
+  public static class PutAllFunction<K, V> implements Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> {
+
+    private final Logger logger;
+    private final Map<K, V> entriesToRemap;
+    private final Expiry<? super K, ? super V> expiry;
+    private final AtomicInteger actualPutCount = new AtomicInteger();
+
+    public PutAllFunction(Logger logger, Map<K, V> entriesToRemap, Expiry<? super K, ? super V> expiry) {
+      this.logger = logger;
+      this.entriesToRemap = entriesToRemap;
+      this.expiry = expiry;
+    }
+
+    @Override
+    public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(final Iterable<? extends Map.Entry<? extends K, ? extends V>> entries) {
+      Map<K, V> mutations = new LinkedHashMap<K, V>();
+
+      // then record we handled these mappings
+      for (Map.Entry<? extends K, ? extends V> entry: entries) {
+        K key = entry.getKey();
+        V existingValue = entry.getValue();
+        V newValue = entriesToRemap.remove(key);
+
+        if (newValueAlreadyExpired(key, existingValue, newValue)) {
+          mutations.put(key, null);
+        } else {
+          actualPutCount.incrementAndGet();
+          mutations.put(key, newValue);
+        }
+      }
+
+      // Finally return the values to be installed in the Cache's Store
+      return mutations.entrySet();
+    }
+
+    public Map<K, V> getEntriesToRemap() {
+      return entriesToRemap;
+    }
+
+    private boolean newValueAlreadyExpired(K key, V oldValue, V newValue) {
+      if (newValue == null) {
+        return false;
+      }
+
+      final Duration duration;
+      if (oldValue == null) {
+        try {
+          duration = expiry.getExpiryForCreation(key, newValue);
+        } catch (RuntimeException re) {
+          logger.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+          return true;
+        }
+      } else {
+        try {
+          duration = expiry.getExpiryForUpdate(key, supplierOf(oldValue), newValue);
+        } catch (RuntimeException re) {
+          logger.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+          return true;
+        }
+      }
+
+      return Duration.ZERO.equals(duration);
+    }
+
+    public AtomicInteger getActualPutCount() {
+      return actualPutCount;
+    }
+  }
+
+  public static class RemoveAllFunction<K, V> implements Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> {
+
+    private final AtomicInteger actualRemoveCount = new AtomicInteger();
+
+    @Override
+    public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(final Iterable<? extends Map.Entry<? extends K, ? extends V>> entries) {
+      Map<K, V> results = new LinkedHashMap<K, V>();
+
+      for (Map.Entry<? extends K, ? extends V> entry : entries) {
+        K key = entry.getKey();
+        V existingValue = entry.getValue();
+
+        if (existingValue != null) {
+          actualRemoveCount.incrementAndGet();
+        }
+        results.put(key, null);
+      }
+
+      return results.entrySet();
+    }
+
+    public AtomicInteger getActualRemoveCount() {
+      return actualRemoveCount;
+    }
+  }
+
+  public static class GetAllFunction<K, V> implements Function<Iterable<? extends K>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> {
+
+    @Override
+    public Iterable<? extends Map.Entry<? extends K, ? extends V>> apply(final Iterable<? extends K> keys) {
+      Map<K, V> computeResult = new LinkedHashMap<K ,V>();
+
+      // put all the entries to get ordering correct
+      for (K key : keys) {
+        computeResult.put(key, null);
+      }
+
+      return computeResult.entrySet();
+    }
   }
 
 }


### PR DESCRIPTION
This is a bloody hack of the store's bulk compute methods tailored to work with only cache's get, put and remove methods ONLY. The stats are not wired in. There is no test coverage except for an integration test that I wrote to check if things would work with this hack. Raising this PR just to validate my approach. Don't wanna waste time doing this if this isn't what's expected.