### PR TITLE
Adapting UnitTestConnectionService with the new changes in Passthroug…

### DIFF
--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
@@ -133,7 +133,7 @@ public class UnitTestConnectionService implements ConnectionService {
     }
 
     SERVERS.put(keyURI, new ServerDescriptor(server));
-    server.start();
+    server.start(true, false);
     LOGGER.info("Started PassthroughServer at {}", keyURI);
   }
 
@@ -273,7 +273,7 @@ public class UnitTestConnectionService implements ConnectionService {
     }
 
     public PassthroughServer build() {
-      PassthroughServer newServer = new PassthroughServer(true);
+      PassthroughServer newServer = new PassthroughServer();
 
       /*
        * If services have been specified, don't establish the "defaults".


### PR DESCRIPTION
This fixes the compilation failure on Ehcache builds caused by the changes in method signatures in  `PassthroughServer`. There are failing integration tests. But AFAIK someone else is looking into that.

I'm not quite familiar with the procedure to follow to address such build failures. Should an issue be created and referred by this PR?