### PR TITLE
Issue #1256 Wrap Exception in server response in client-side exception

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
@@ -258,7 +258,7 @@ public class EhcacheClientEntity implements Entity {
          */
         Exception cause = ((Failure)response).getCause();
         if (cause instanceof ClusteredEhcacheException) {
-          throw ((ClusteredEhcacheException) cause).copyInContext();
+          throw ((ClusteredEhcacheException) cause).withClientStackTrace();
         }
         throw new RuntimeException(message + " error: " + cause.toString(), cause);
       } else {

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/EhcacheClientEntityExceptionTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/EhcacheClientEntityExceptionTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.service;
+
+import org.ehcache.CachePersistenceException;
+import org.ehcache.clustered.client.config.ClusteringServiceConfiguration;
+import org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder;
+import org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder;
+import org.ehcache.clustered.client.internal.EhcacheClientEntity;
+import org.ehcache.clustered.client.internal.UnitTestConnectionService;
+import org.ehcache.clustered.client.service.ClusteringService;
+import org.ehcache.clustered.common.Consistency;
+import org.ehcache.clustered.common.internal.exceptions.InvalidStoreException;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.config.store.StoreEventSourceConfiguration;
+import org.ehcache.core.internal.store.StoreConfigurationImpl;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.impl.internal.spi.serialization.DefaultSerializationProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.ehcache.clustered.client.internal.service.TestServiceProvider.providerContaining;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * This class includes tests to ensure server-side exceptions returned as responses to
+ * {@link EhcacheClientEntity} messages are wrapped before being re-thrown.  This class
+ * relies on {@link DefaultClusteringService} to set up conditions for the test and
+ * is placed accordingly.
+ */
+public class EhcacheClientEntityExceptionTest {
+  private static final String CLUSTER_URI_BASE = "terracotta://example.com:9540/";
+
+  @Before
+  public void definePassThroughServer() throws Exception {
+    UnitTestConnectionService.add(CLUSTER_URI_BASE,
+        new UnitTestConnectionService.PassthroughServerBuilder()
+            .resource("defaultResource", 128, MemoryUnit.MB)
+            .resource("serverResource1", 32, MemoryUnit.MB)
+            .resource("serverResource2", 32, MemoryUnit.MB)
+            .build());
+  }
+
+  @After
+  public void removePassThroughServer() throws Exception {
+    UnitTestConnectionService.remove(CLUSTER_URI_BASE);
+  }
+
+  /**
+   * Tests to ensure that a {@link org.ehcache.clustered.common.internal.exceptions.ClusteredEhcacheException ClusteredEhcacheException}
+   * originating in the server is properly wrapped on the client before being re-thrown.
+   */
+  @Test
+  public void testServerExceptionPassThrough() throws Exception {
+    ClusteringServiceConfiguration creationConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application"))
+            .autoCreate()
+            .defaultServerResource("defaultResource")
+            .resourcePool("sharedPrimary", 16, MemoryUnit.MB, "serverResource1")
+            .resourcePool("sharedSecondary", 16, MemoryUnit.MB, "serverResource2")
+            .resourcePool("sharedTertiary", 32, MemoryUnit.MB)
+            .build();
+    DefaultClusteringService creationService = new DefaultClusteringService(creationConfig);
+    creationService.start(null);
+    creationService.stop();
+
+    ClusteringServiceConfiguration accessConfig =
+        ClusteringServiceConfigurationBuilder.cluster(URI.create(CLUSTER_URI_BASE + "my-application"))
+            .build();
+    DefaultClusteringService accessService = new DefaultClusteringService(accessConfig);
+    accessService.start(null);
+
+    DefaultSerializationProvider serializationProvider = new DefaultSerializationProvider(null);
+    serializationProvider.start(providerContaining());
+    Store.Configuration<Long, String> storeConfiguration =
+        getDedicatedStoreConfig("serverResource2", serializationProvider, Long.class, String.class);
+
+    /*
+     * Induce an "InvalidStoreException: Clustered tier 'cacheAlias' does not exist" on the server.
+     */
+    try {
+      accessService.getServerStoreProxy(
+          getClusteredCacheIdentifier(accessService, "cacheAlias"), storeConfiguration, Consistency.EVENTUAL);
+      fail("Expecting CachePersistenceException");
+    } catch (CachePersistenceException e) {
+
+      /*
+       * Find the last EhcacheClientEntity involved exception in the causal chain.  This
+       * is where the server-side exception should have entered the client.
+       */
+      Throwable clientSideException = null;
+      for (Throwable t = e; t.getCause() != null && t.getCause() != t; t = t.getCause()) {
+        for (StackTraceElement element : t.getStackTrace()) {
+          if (element.getClassName().endsWith("EhcacheClientEntity")) {
+            clientSideException = t;
+          }
+        }
+      }
+      assert clientSideException != null;
+
+      /*
+       * In this specific failure case, the exception is expected to be an InvalidStoreException from
+       * the server and re-thrown in the client.
+       */
+      Throwable clientSideCause = clientSideException.getCause();
+      assertThat(clientSideCause, is(instanceOf(InvalidStoreException.class)));
+
+      serverCheckLoop:
+      {
+        for (StackTraceElement element : clientSideCause.getStackTrace()) {
+          if (element.getClassName().endsWith("EhcacheActiveEntity")) {
+            break serverCheckLoop;
+          }
+        }
+        fail(clientSideException + " lacks server-based cause");
+      }
+
+      assertThat("EhcacheClientEntity did not rethrow InvalidStoreException",
+          clientSideException, is(instanceOf(InvalidStoreException.class)));
+
+    } finally {
+      accessService.stop();
+    }
+  }
+
+  private <K, V> Store.Configuration<K, V> getDedicatedStoreConfig(
+      String targetResource, DefaultSerializationProvider serializationProvider, Class<K> keyType, Class<V> valueType)
+      throws org.ehcache.spi.serialization.UnsupportedTypeException {
+    return new StoreConfigurationImpl<K, V>(
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(keyType, valueType,
+            ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .with(ClusteredResourcePoolBuilder.clusteredDedicated(targetResource, 8, MemoryUnit.MB)))
+            .build(),
+        StoreEventSourceConfiguration.DEFAULT_DISPATCHER_CONCURRENCY,
+        serializationProvider.createKeySerializer(keyType, getClass().getClassLoader()),
+        serializationProvider.createValueSerializer(valueType, getClass().getClassLoader()));
+  }
+
+  private ClusteringService.ClusteredCacheIdentifier getClusteredCacheIdentifier(
+      DefaultClusteringService service, String cacheAlias)
+      throws CachePersistenceException {
+
+    ClusteringService.ClusteredCacheIdentifier clusteredCacheIdentifier = (ClusteringService.ClusteredCacheIdentifier) service.getPersistenceSpaceIdentifier(cacheAlias, null);
+    if (clusteredCacheIdentifier != null) {
+      return clusteredCacheIdentifier;
+    }
+    throw new AssertionError("ClusteredCacheIdentifier not available for configuration");
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ClusteredEhcacheException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ClusteredEhcacheException.java
@@ -17,6 +17,7 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 public abstract class ClusteredEhcacheException extends Exception {
+  private static final long serialVersionUID = 38615046229882871L;
 
   public ClusteredEhcacheException(String message) {
     super(message);
@@ -29,4 +30,14 @@ public abstract class ClusteredEhcacheException extends Exception {
   public ClusteredEhcacheException(Throwable cause) {
     super(cause);
   }
+
+  /**
+   * Makes a copy of this {@code ClusteredEhcacheException}, retaining the type,
+   * in the current context.  This method is used to prepare exceptions originating in
+   * tbe server to be re-thrown in the client.
+   *
+   * @return a new {@code ClusteredEhcacheException} of {@code this} subtype with {@code this}
+   *      instance as the cause
+   */
+  public abstract ClusteredEhcacheException copyInContext();
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ClusteredEhcacheException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ClusteredEhcacheException.java
@@ -32,12 +32,12 @@ public abstract class ClusteredEhcacheException extends Exception {
   }
 
   /**
-   * Makes a copy of this {@code ClusteredEhcacheException}, retaining the type,
-   * in the current context.  This method is used to prepare exceptions originating in
-   * tbe server to be re-thrown in the client.
+   * Makes a copy of this {@code ClusteredEhcacheException}, retaining the type, in the current
+   * client context.  This method is used to prepare exceptions originating in the server to be
+   * re-thrown in the client.
    *
    * @return a new {@code ClusteredEhcacheException} of {@code this} subtype with {@code this}
    *      instance as the cause
    */
-  public abstract ClusteredEhcacheException copyInContext();
+  public abstract ClusteredEhcacheException withClientStackTrace();
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageException.java
@@ -31,7 +31,7 @@ public class IllegalMessageException extends ClusteredEhcacheException {
   }
 
   @Override
-  public IllegalMessageException copyInContext() {
+  public IllegalMessageException withClientStackTrace() {
     return new IllegalMessageException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageException.java
@@ -20,7 +20,18 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate an unexpected failure an {@code Entity} supporting clustered operations.
  */
 public class IllegalMessageException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = -6202125337269820200L;
+
   public IllegalMessageException(String message) {
     super(message);
+  }
+
+  private IllegalMessageException(IllegalMessageException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public IllegalMessageException copyInContext() {
+    return new IllegalMessageException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationException.java
@@ -39,7 +39,7 @@ public class InvalidServerSideConfigurationException extends ClusteredEhcacheExc
   }
 
   @Override
-  public InvalidServerSideConfigurationException copyInContext() {
+  public InvalidServerSideConfigurationException withClientStackTrace() {
     return new InvalidServerSideConfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationException.java
@@ -20,6 +20,8 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate a configuration mismatch on an {@code Entity} supporting clustered operations.
  */
 public class InvalidServerSideConfigurationException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = -7055831050639925875L;
+
   public InvalidServerSideConfigurationException(String message) {
     super(message);
   }
@@ -30,5 +32,14 @@ public class InvalidServerSideConfigurationException extends ClusteredEhcacheExc
 
   public InvalidServerSideConfigurationException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  private InvalidServerSideConfigurationException(InvalidServerSideConfigurationException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public InvalidServerSideConfigurationException copyInContext() {
+    return new InvalidServerSideConfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationException.java
@@ -20,11 +20,22 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate a configuration mismatch on a clustered store.
  */
 public class InvalidServerStoreConfigurationException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = 7390173198205796763L;
+
   public InvalidServerStoreConfigurationException(String message) {
     super(message);
   }
 
   public InvalidServerStoreConfigurationException(Throwable cause) {
     super(cause);
+  }
+
+  private InvalidServerStoreConfigurationException(InvalidServerStoreConfigurationException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public InvalidServerStoreConfigurationException copyInContext() {
+    return new InvalidServerStoreConfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationException.java
@@ -35,7 +35,7 @@ public class InvalidServerStoreConfigurationException extends ClusteredEhcacheEx
   }
 
   @Override
-  public InvalidServerStoreConfigurationException copyInContext() {
+  public InvalidServerStoreConfigurationException withClientStackTrace() {
     return new InvalidServerStoreConfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreException.java
@@ -35,7 +35,7 @@ public class InvalidStoreException extends ClusteredEhcacheException {
   }
 
   @Override
-  public InvalidStoreException copyInContext() {
+  public InvalidStoreException withClientStackTrace() {
     return new InvalidStoreException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreException.java
@@ -20,11 +20,22 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate an operation cannot be performed on a certain clustered store.
  */
 public class InvalidStoreException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = 7717112794546075917L;
+
   public InvalidStoreException(String message) {
     super(message);
   }
 
   public InvalidStoreException(Throwable cause) {
     super(cause);
+  }
+
+  private InvalidStoreException(InvalidStoreException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public InvalidStoreException copyInContext() {
+    return new InvalidStoreException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreManagerException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreManagerException.java
@@ -35,7 +35,7 @@ public class InvalidStoreManagerException extends ClusteredEhcacheException {
   }
 
   @Override
-  public InvalidStoreManagerException copyInContext() {
+  public InvalidStoreManagerException withClientStackTrace() {
     return new InvalidStoreManagerException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/LifecycleException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/LifecycleException.java
@@ -20,7 +20,22 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate the lifecycle of a clustered entity hasn't been respected.
  */
 public class LifecycleException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = 8296083644864873465L;
+
   public LifecycleException(String message) {
     super(message);
+  }
+
+  private LifecycleException(Throwable cause) {
+    super(cause);
+  }
+
+  private LifecycleException(LifecycleException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public LifecycleException copyInContext() {
+    return new LifecycleException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/LifecycleException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/LifecycleException.java
@@ -35,7 +35,7 @@ public class LifecycleException extends ClusteredEhcacheException {
   }
 
   @Override
-  public LifecycleException copyInContext() {
+  public LifecycleException withClientStackTrace() {
     return new LifecycleException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyException.java
@@ -20,6 +20,8 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate a clustered entity is busy.
  */
 public class ResourceBusyException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = 3830614247618106338L;
+
   public ResourceBusyException(String message) {
     super(message);
   }
@@ -30,5 +32,14 @@ public class ResourceBusyException extends ClusteredEhcacheException {
 
   public ResourceBusyException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  private ResourceBusyException(ResourceBusyException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public ResourceBusyException copyInContext() {
+    return new ResourceBusyException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyException.java
@@ -39,7 +39,7 @@ public class ResourceBusyException extends ClusteredEhcacheException {
   }
 
   @Override
-  public ResourceBusyException copyInContext() {
+  public ResourceBusyException withClientStackTrace() {
     return new ResourceBusyException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationException.java
@@ -20,6 +20,8 @@ package org.ehcache.clustered.common.internal.exceptions;
  * Thrown to indicate some clustered resource being mis-configured.
  */
 public class ResourceConfigurationException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = -8886869788915700432L;
+
   public ResourceConfigurationException(String message) {
     super(message);
   }
@@ -30,5 +32,14 @@ public class ResourceConfigurationException extends ClusteredEhcacheException {
 
   public ResourceConfigurationException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  private ResourceConfigurationException(ResourceConfigurationException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public ResourceConfigurationException copyInContext() {
+    return new ResourceConfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationException.java
@@ -39,7 +39,7 @@ public class ResourceConfigurationException extends ClusteredEhcacheException {
   }
 
   @Override
-  public ResourceConfigurationException copyInContext() {
+  public ResourceConfigurationException withClientStackTrace() {
     return new ResourceConfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationException.java
@@ -17,6 +17,7 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 public class ServerMisconfigurationException extends ClusteredEhcacheException {
+  private static final long serialVersionUID = -1412283170898723994L;
 
   public ServerMisconfigurationException(final String message) {
     super(message);
@@ -28,5 +29,14 @@ public class ServerMisconfigurationException extends ClusteredEhcacheException {
 
   public ServerMisconfigurationException(final Throwable cause) {
     super(cause);
+  }
+
+  private ServerMisconfigurationException(ServerMisconfigurationException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  @Override
+  public ServerMisconfigurationException copyInContext() {
+    return new ServerMisconfigurationException(this);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationException.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationException.java
@@ -36,7 +36,7 @@ public class ServerMisconfigurationException extends ClusteredEhcacheException {
   }
 
   @Override
-  public ServerMisconfigurationException copyInContext() {
+  public ServerMisconfigurationException withClientStackTrace() {
     return new ServerMisconfigurationException(this);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/BaseClusteredEhcacheExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/BaseClusteredEhcacheExceptionTest.java
@@ -45,7 +45,8 @@ public abstract class BaseClusteredEhcacheExceptionTest<T extends ClusteredEhcac
 
   /**
    * Creates a new {@code <T>} exception using the message text provided.
-   * The base implementation of this method returns a {@code null}.
+   * If {@code <T>} has no {@code T(String)} constructor, the test calling this method is
+   * skipped using with an assumption failure.
    *
    * @param message the message text to apply to the exception
    *
@@ -63,7 +64,8 @@ public abstract class BaseClusteredEhcacheExceptionTest<T extends ClusteredEhcac
 
   /**
    * Creates a new {@code <T>} exception using the message text and cause provided.
-   * The base implementation of this method returns a {@code null}.
+   * If {@code <T>} has no {@code T(String, Throwable)} constructor, the test calling this method is
+   * skipped using with an assumption failure.
    *
    * @param message the message text to apply to the exception
    * @param cause the {@code Throwable} to apply as the cause of the new exception
@@ -82,7 +84,8 @@ public abstract class BaseClusteredEhcacheExceptionTest<T extends ClusteredEhcac
 
   /**
    * Creates a new {@code <T>} exception using the cause provided.
-   * The base implementation of this method returns a {@code null}.
+   * If {@code <T>} has no {@code T(Throwable)} constructor, the test calling this method is
+   * skipped using with an assumption failure.
    *
    * @param cause the {@code Throwable} to apply as the cause of the new exception
    *
@@ -109,43 +112,39 @@ public abstract class BaseClusteredEhcacheExceptionTest<T extends ClusteredEhcac
   }
 
   @Test
-  public final void copyInContextMessage() throws Exception {
+  public final void ctorMessage() throws Exception {
     T baseException = this.create("message text");
 
     assertThat(baseException.getMessage(), is("message text"));
     assertThat(baseException.getCause(), is(nullValue()));
 
-    ClusteredEhcacheException copyException = baseException.copyInContext();
-    assertThat(copyException, is(notNullValue()));
-    assertThat(copyException, is(instanceOf(testClass)));
-    assertThat(copyException.getMessage(), is(baseException.getMessage()));
-    assertThat(copyException.getCause(), Matchers.<Throwable>is(baseException));
+    checkWithClientStack(baseException);
   }
 
   @Test
-  public final void copyInContextMessageThrowable() throws Exception {
+  public final void ctorMessageThrowable() throws Exception {
     Throwable baseCause = new Throwable("base cause");
     T baseException = this.create("message text", baseCause);
 
     assertThat(baseException.getMessage(), is("message text"));
     assertThat(baseException.getCause(), is(baseCause));
 
-    ClusteredEhcacheException copyException = baseException.copyInContext();
-    assertThat(copyException, is(notNullValue()));
-    assertThat(copyException, is(instanceOf(testClass)));
-    assertThat(copyException.getMessage(), is(baseException.getMessage()));
-    assertThat(copyException.getCause(), Matchers.<Throwable>is(baseException));
+    checkWithClientStack(baseException);
   }
 
   @Test
-  public final void copyInContextThrowable() throws Exception {
+  public final void ctorThrowable() throws Exception {
     Throwable baseCause = new Throwable("base cause");
     T baseException = this.create(baseCause);
 
     assertThat(baseException.getMessage(), is(baseCause.toString()));
     assertThat(baseException.getCause(), is(baseCause));
 
-    ClusteredEhcacheException copyException = baseException.copyInContext();
+    checkWithClientStack(baseException);
+  }
+
+  private void checkWithClientStack(T baseException) {
+    ClusteredEhcacheException copyException = baseException.withClientStackTrace();
     assertThat(copyException, is(notNullValue()));
     assertThat(copyException, is(instanceOf(testClass)));
     assertThat(copyException.getMessage(), is(baseException.getMessage()));

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/BaseClusteredEhcacheExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/BaseClusteredEhcacheExceptionTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.exceptions;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
+
+import java.lang.reflect.Constructor;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.typeCompatibleWith;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Foundation for tests on {@link ClusteredEhcacheException} subclasses.
+ */
+public abstract class BaseClusteredEhcacheExceptionTest<T extends ClusteredEhcacheException> {
+
+  private final Class<T> testClass;
+
+  protected BaseClusteredEhcacheExceptionTest(Class<T> testClass) {
+    if (testClass == null) {
+      throw new NullPointerException("testClass");
+    }
+    this.testClass = testClass;
+  }
+
+  /**
+   * Creates a new {@code <T>} exception using the message text provided.
+   * The base implementation of this method returns a {@code null}.
+   *
+   * @param message the message text to apply to the exception
+   *
+   * @return a new {@code <T>} exception
+   */
+  private T create(String message) throws Exception {
+    Constructor<T> constructor;
+    try {
+      constructor = testClass.getConstructor(String.class);
+    } catch (NoSuchMethodException e) {
+      throw new AssumptionViolatedException("No public " + testClass.getSimpleName() +"(String) constructor");
+    }
+    return constructor.newInstance(message);
+  }
+
+  /**
+   * Creates a new {@code <T>} exception using the message text and cause provided.
+   * The base implementation of this method returns a {@code null}.
+   *
+   * @param message the message text to apply to the exception
+   * @param cause the {@code Throwable} to apply as the cause of the new exception
+   *
+   * @return a new {@code <T>} exception
+   */
+  private T create(String message, Throwable cause) throws Exception {
+    Constructor<T> constructor;
+    try {
+      constructor = testClass.getConstructor(String.class, Throwable.class);
+    } catch (NoSuchMethodException e) {
+      throw new AssumptionViolatedException("No public " + testClass.getSimpleName() +"(String, Throwable) constructor");
+    }
+    return constructor.newInstance(message, cause);
+  }
+
+  /**
+   * Creates a new {@code <T>} exception using the cause provided.
+   * The base implementation of this method returns a {@code null}.
+   *
+   * @param cause the {@code Throwable} to apply as the cause of the new exception
+   *
+   * @return a new {@code <T>} exception
+   */
+  private T create(Throwable cause) throws Exception {
+    Constructor<T> constructor;
+    try {
+      constructor = testClass.getConstructor(Throwable.class);
+    } catch (NoSuchMethodException e) {
+      throw new AssumptionViolatedException("No public " + testClass.getSimpleName() +"(Throwable) constructor");
+    }
+    return constructor.newInstance(cause);
+  }
+
+  @Test
+  public void testHasServerVersionUID() throws Exception {
+    testClass.getDeclaredField("serialVersionUID");
+  }
+
+  @Test
+  public void testType() throws Exception {
+    assertThat(testClass, is(typeCompatibleWith(ClusteredEhcacheException.class)));
+  }
+
+  @Test
+  public final void copyInContextMessage() throws Exception {
+    T baseException = this.create("message text");
+
+    assertThat(baseException.getMessage(), is("message text"));
+    assertThat(baseException.getCause(), is(nullValue()));
+
+    ClusteredEhcacheException copyException = baseException.copyInContext();
+    assertThat(copyException, is(notNullValue()));
+    assertThat(copyException, is(instanceOf(testClass)));
+    assertThat(copyException.getMessage(), is(baseException.getMessage()));
+    assertThat(copyException.getCause(), Matchers.<Throwable>is(baseException));
+  }
+
+  @Test
+  public final void copyInContextMessageThrowable() throws Exception {
+    Throwable baseCause = new Throwable("base cause");
+    T baseException = this.create("message text", baseCause);
+
+    assertThat(baseException.getMessage(), is("message text"));
+    assertThat(baseException.getCause(), is(baseCause));
+
+    ClusteredEhcacheException copyException = baseException.copyInContext();
+    assertThat(copyException, is(notNullValue()));
+    assertThat(copyException, is(instanceOf(testClass)));
+    assertThat(copyException.getMessage(), is(baseException.getMessage()));
+    assertThat(copyException.getCause(), Matchers.<Throwable>is(baseException));
+  }
+
+  @Test
+  public final void copyInContextThrowable() throws Exception {
+    Throwable baseCause = new Throwable("base cause");
+    T baseException = this.create(baseCause);
+
+    assertThat(baseException.getMessage(), is(baseCause.toString()));
+    assertThat(baseException.getCause(), is(baseCause));
+
+    ClusteredEhcacheException copyException = baseException.copyInContext();
+    assertThat(copyException, is(notNullValue()));
+    assertThat(copyException, is(instanceOf(testClass)));
+    assertThat(copyException.getMessage(), is(baseException.getMessage()));
+    assertThat(copyException.getCause(), Matchers.<Throwable>is(baseException));
+  }
+}

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link IllegalMessageException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class IllegalMessageExceptionTest extends BaseClusteredEhcacheExceptionTest<IllegalMessageException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public IllegalMessageExceptionTest() {
+    super(IllegalMessageException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/IllegalMessageExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link IllegalMessageException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class IllegalMessageExceptionTest extends BaseClusteredEhcacheExceptionTest<IllegalMessageException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link InvalidServerSideConfigurationException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class InvalidServerSideConfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidServerSideConfigurationException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public InvalidServerSideConfigurationExceptionTest() {
+    super(InvalidServerSideConfigurationException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerSideConfigurationExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link InvalidServerSideConfigurationException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class InvalidServerSideConfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidServerSideConfigurationException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link InvalidServerStoreConfigurationException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class InvalidServerStoreConfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidServerStoreConfigurationException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidServerStoreConfigurationExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link InvalidServerStoreConfigurationException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class InvalidServerStoreConfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidServerStoreConfigurationException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public InvalidServerStoreConfigurationExceptionTest() {
+    super(InvalidServerStoreConfigurationException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link InvalidStoreException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class InvalidStoreExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidStoreException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link InvalidStoreException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class InvalidStoreExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidStoreException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public InvalidStoreExceptionTest() {
+    super(InvalidStoreException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreManagerExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreManagerExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link InvalidStoreManagerException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class InvalidStoreManagerExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidStoreManagerException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreManagerExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/InvalidStoreManagerExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link InvalidStoreManagerException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class InvalidStoreManagerExceptionTest extends BaseClusteredEhcacheExceptionTest<InvalidStoreManagerException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public InvalidStoreManagerExceptionTest() {
+    super(InvalidStoreManagerException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/LifecycleExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/LifecycleExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link LifecycleException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class LifecycleExceptionTest extends BaseClusteredEhcacheExceptionTest<LifecycleException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public LifecycleExceptionTest() {
+    super(LifecycleException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/LifecycleExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/LifecycleExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link LifecycleException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class LifecycleExceptionTest extends BaseClusteredEhcacheExceptionTest<LifecycleException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link ResourceBusyException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class ResourceBusyExceptionTest extends BaseClusteredEhcacheExceptionTest<ResourceBusyException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceBusyExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link ResourceBusyException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class ResourceBusyExceptionTest extends BaseClusteredEhcacheExceptionTest<ResourceBusyException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public ResourceBusyExceptionTest() {
+    super(ResourceBusyException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link ResourceConfigurationException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class ResourceConfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<ResourceConfigurationException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public ResourceConfigurationExceptionTest() {
+    super(ResourceConfigurationException.class);
   }
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ResourceConfigurationExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link ResourceConfigurationException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class ResourceConfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<ResourceConfigurationException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationExceptionTest.java
@@ -18,7 +18,7 @@ package org.ehcache.clustered.common.internal.exceptions;
 
 /**
  * Tests {@link ServerMisconfigurationException} functions including
- * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
+ * {@link ClusteredEhcacheException#withClientStackTrace() withClientStackTrace}.
  */
 public class ServerMisconfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<ServerMisconfigurationException> {
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationExceptionTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/exceptions/ServerMisconfigurationExceptionTest.java
@@ -17,25 +17,12 @@
 package org.ehcache.clustered.common.internal.exceptions;
 
 /**
- * Thrown to indicate an operation cannot be performed on a certain clustered store manager.
+ * Tests {@link ServerMisconfigurationException} functions including
+ * {@link ClusteredEhcacheException#copyInContext() copyInContext}.
  */
-public class InvalidStoreManagerException extends ClusteredEhcacheException {
-  private static final long serialVersionUID = 8706722895064395931L;
+public class ServerMisconfigurationExceptionTest extends BaseClusteredEhcacheExceptionTest<ServerMisconfigurationException> {
 
-  public InvalidStoreManagerException(String message) {
-    super(message);
-  }
-
-  public InvalidStoreManagerException(Throwable cause) {
-    super(cause);
-  }
-
-  private InvalidStoreManagerException(InvalidStoreManagerException cause) {
-    super(cause.getMessage(), cause);
-  }
-
-  @Override
-  public InvalidStoreManagerException copyInContext() {
-    return new InvalidStoreManagerException(this);
+  public ServerMisconfigurationExceptionTest() {
+    super(ServerMisconfigurationException.class);
   }
 }


### PR DESCRIPTION
This commit restores the behavior of wrapping a server-wide exception
received as a clustered operation response in a client-side exception.
This ensures that the client-side stack trace is available in the thrown
exception.

Closes #1256 