### PR TITLE
Closes #1003 - Expose a way to fetch/create entities re-using the same connetion

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/AbstractClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/AbstractClientEntityFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.client.internal.service;
+
+import org.ehcache.clustered.client.service.ClientEntityFactory;
+import org.ehcache.clustered.client.service.EntityBusyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.entity.Entity;
+import org.terracotta.connection.entity.EntityRef;
+import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityNotFoundException;
+import org.terracotta.exception.EntityNotProvidedException;
+import org.terracotta.exception.EntityVersionMismatchException;
+
+abstract class AbstractClientEntityFactory<E extends Entity, C> implements ClientEntityFactory<E, C> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractClientEntityFactory.class);
+
+  private final String entityIdentifier;
+  private final Class<E> entityType;
+  private final long entityVersion;
+  private final C configuration;
+
+  /**
+   * @param entityIdentifier the instance identifier for the {@code {@link Entity}}
+   * @param configuration    the {@code {@link Entity}} configuration
+   */
+  AbstractClientEntityFactory(String entityIdentifier, Class<E> entityType, long entityVersion, C configuration) {
+    this.entityIdentifier = entityIdentifier;
+    this.entityType = entityType;
+    this.entityVersion = entityVersion;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public C getConfiguration() {
+    return configuration;
+  }
+
+  @Override
+  public String getEntityIdentifier() {
+    return entityIdentifier;
+  }
+
+  @Override
+  public Class<E> getEntityType() {
+    return entityType;
+  }
+
+  @Override
+  public long getEntityVersion() {
+    return entityVersion;
+  }
+
+  @Override
+  public void create() throws EntityAlreadyExistsException {
+    EntityRef<E, C> ref = getEntityRef();
+    try {
+      while (true) {
+        ref.create(configuration);
+        try {
+          ref.fetchEntity().close();
+          return;
+        } catch (EntityNotFoundException e) {
+          //continue;
+        }
+      }
+    } catch (EntityNotProvidedException e) {
+      LOGGER.error("Unable to create entity {} for id {}", entityType.getName(), entityIdentifier, e);
+      throw new AssertionError(e);
+    } catch (EntityVersionMismatchException e) {
+      LOGGER.error("Unable to create entity {} for id {}", entityType.getName(), entityIdentifier, e);
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override
+  public E retrieve() throws EntityNotFoundException {
+    try {
+      return getEntityRef().fetchEntity();
+    } catch (EntityVersionMismatchException e) {
+      LOGGER.error("Unable to retrieve entity {} for id {}", entityType.getName(), entityIdentifier, e);
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override
+  public void destroy() throws EntityNotFoundException, EntityBusyException {
+    EntityRef<E, C> ref = getEntityRef();
+    try {
+      if (!ref.tryDestroy()) {
+        throw new EntityBusyException("Destroy operation failed; " + entityIdentifier + " clustered tier in use by other clients");
+      }
+    } catch (EntityNotProvidedException e) {
+      LOGGER.error("Unable to destroy entity {} for id {}", entityType.getName(), entityIdentifier, e);
+      throw new AssertionError(e);
+    }
+  }
+
+  private EntityRef<E, C> getEntityRef() {
+    try {
+      return getConnection().getEntityRef(entityType, entityVersion, entityIdentifier);
+    } catch (EntityNotProvidedException e) {
+      LOGGER.error("Unable to find reference for entity {} for id {}", entityType.getName(), entityIdentifier, e);
+      throw new AssertionError(e);
+    }
+  }
+
+  protected abstract Connection getConnection();
+
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/service/ClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/service/ClientEntityFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.client.service;
+
+import org.terracotta.connection.entity.Entity;
+import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityNotFoundException;
+
+/**
+ * Factory used to create, fetch and destroy server entities.
+ * <p>
+ * Such factory is created with {@link EntityService#newClientEntityFactory(String, Class, long, Object)}
+ */
+public interface ClientEntityFactory<E extends Entity, C> {
+
+  /**
+   * @return The server entity name set by this factory
+   */
+  String getEntityIdentifier();
+
+  /**
+   * @return The entity type created by this factory
+   */
+  Class<E> getEntityType();
+
+  /**
+   * @return The entity version
+   */
+  long getEntityVersion();
+
+  /**
+   * @return The optional configuration object passed to the factory for entity creation, or null
+   */
+  C getConfiguration();
+
+  /**
+   * Creates the entity and validate that it can be effectively fetched
+   *
+   * @throws EntityAlreadyExistsException If the entity has already been created
+   */
+  void create() throws EntityAlreadyExistsException;
+
+  /**
+   * @return The created entity matching the type and identifier of this factory
+   * @throws EntityNotFoundException If the entity has not been created yet
+   */
+  E retrieve() throws EntityNotFoundException;
+
+  /**
+   * Destroy the entity matching the factory entity identifier and type
+   *
+   * @throws EntityNotFoundException If the entity does not exist on the server
+   * @throws EntityBusyException     If the entity is used and thus cannot be destroyed
+   */
+  void destroy() throws EntityNotFoundException, EntityBusyException;
+
+}

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/service/EntityBusyException.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/service/EntityBusyException.java
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.ehcache.clustered.client.internal;
+package org.ehcache.clustered.client.service;
 
 /**
- * Thrown by {@link EhcacheClientEntity} operations requiring access to the
- * {@code EhcacheActiveEntity} when the {@code EhcacheActiveEntity} is not available.
+ * Thrown by {@link org.terracotta.connection.entity.Entity} operations requiring access to the
+ * {@code {@link org.terracotta.entity.ActiveServerEntity}} when the {@code {@link org.terracotta.entity.ActiveServerEntity}} is not available.
  */
-public class EhcacheEntityBusyException extends Exception {
+public class EntityBusyException extends Exception {
   private static final long serialVersionUID = -7706902691622092177L;
 
-  public EhcacheEntityBusyException(String message) {
+  public EntityBusyException(String message) {
     super(message);
   }
 
-  public EhcacheEntityBusyException(String message, Throwable cause) {
+  public EntityBusyException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  public EhcacheEntityBusyException(Throwable cause) {
+  public EntityBusyException(Throwable cause) {
     super(cause);
   }
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/service/EntityService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/service/EntityService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.client.service;
+
+import org.ehcache.spi.service.Service;
+import org.terracotta.connection.entity.Entity;
+
+/**
+ * Provides support for accessing server entities through the Cache Manager connection
+ */
+public interface EntityService extends Service {
+
+  /**
+   * Creates a factory class used to create, fetch and destroy server entities through the same connection used by this {@link org.ehcache.CacheManager}
+   *
+   * @param entityIdentifier The entity name
+   * @param entityType       The entity class
+   * @param entityVersion    The entity version
+   * @param configuration    Any configuration object that might be pass when creating the entity, or null if none
+   * @param <E>              The entity type, extending {@link Entity}
+   * @param <C>              The configuration class
+   * @return The created factory
+   */
+  <E extends Entity, C> ClientEntityFactory<E, C> newClientEntityFactory(String entityIdentifier, Class<E> entityType, long entityVersion, C configuration);
+
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/EntityServiceTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/EntityServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.client;
+
+import org.ehcache.CacheManager;
+import org.ehcache.clustered.client.internal.UnitTestConnectionService;
+import org.ehcache.clustered.client.internal.UnitTestConnectionService.PassthroughServerBuilder;
+import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockClient;
+import org.ehcache.clustered.client.service.ClientEntityFactory;
+import org.ehcache.clustered.client.service.ClusteringService;
+import org.ehcache.clustered.client.service.EntityBusyException;
+import org.ehcache.clustered.client.service.EntityService;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceDependencies;
+import org.ehcache.spi.service.ServiceProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.terracotta.exception.EntityAlreadyExistsException;
+
+import java.net.URI;
+
+import static org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder.cluster;
+import static org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class EntityServiceTest {
+
+  private static final URI CLUSTER_URI = URI.create("terracotta://example.com:9540/EntityServiceTest");
+
+  @Before
+  public void definePassthroughServer() throws Exception {
+    UnitTestConnectionService.add(CLUSTER_URI,
+        new PassthroughServerBuilder()
+            .resource("primary-server-resource", 4, MemoryUnit.MB)
+            .build());
+  }
+
+  @After
+  public void removePassthroughServer() throws Exception {
+    UnitTestConnectionService.remove(CLUSTER_URI);
+  }
+
+  @Test
+  public void test() throws Exception {
+    ClusteredManagementService clusteredManagementService = new ClusteredManagementService();
+
+    CacheManager cacheManager = newCacheManagerBuilder()
+        .using(clusteredManagementService)
+        .with(cluster(CLUSTER_URI).autoCreate())
+        .build(true);
+
+    assertThat(clusteredManagementService.clientEntityFactory, is(notNullValue()));
+
+    clusteredManagementService.clientEntityFactory.create();
+
+    try {
+      clusteredManagementService.clientEntityFactory.create();
+      fail();
+    } catch (Exception e) {
+      assertThat(e, instanceOf(EntityAlreadyExistsException.class));
+    }
+
+    VoltronReadWriteLockClient entity = clusteredManagementService.clientEntityFactory.retrieve();
+    assertThat(entity, is(notNullValue()));
+
+    try {
+      clusteredManagementService.clientEntityFactory.destroy();
+      fail();
+    } catch (Exception e) {
+      assertThat(e, instanceOf(EntityBusyException.class));
+    }
+
+    entity.close();
+
+    clusteredManagementService.clientEntityFactory.destroy();
+
+    cacheManager.close();
+  }
+
+  @ServiceDependencies(EntityService.class)
+  public static class ClusteredManagementService implements Service {
+
+    ClientEntityFactory<VoltronReadWriteLockClient, Void> clientEntityFactory;
+
+    @Override
+    public void start(ServiceProvider<Service> serviceProvider) {
+      clientEntityFactory = serviceProvider.getService(EntityService.class).newClientEntityFactory("my-locker", VoltronReadWriteLockClient.class, 1L, null);
+    }
+
+    @Override
+    public void stop() {
+      clientEntityFactory = null;
+    }
+  }
+
+}


### PR DESCRIPTION
This is a proposal for #1003.

The goal is to be able from other Ehcache services (such as management) to fetch other entities through the same cluster connection. This will come in another PR later (that will depend on this one).

I didn't want to reuse the existing `EhcacheClientEntityFactory` which does really special things concerning Ehcache config validation. 

So I instead created an isolated `ClientEntityFactory`, accessible from the `ClusteringService`, responsible to create, retrieve and destroy entities... This only depends on spi stuff and does not expose internal stuff.

Note: I moved `EhcacheEntityBusyException ` to `EntityBusyException `, into the non internal package since this exception is also used and not really related to a special Ehcache op, because it is used the same way for `tryDestroy()` (in case a destroy is not possible).