### PR TITLE
#1282 Add close() method down ServerStoreImpl chain.

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -544,8 +544,8 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
       }
 
       LOGGER.info("Destroying clustered tier '{}' for clustered tier manager destroy", storeEntry.getKey());
-      // TODO: ServerStore closure here ...
       storeClientMap.remove(storeEntry.getKey());
+      storeEntry.getValue().close();
       storeIterator.remove();
     }
 
@@ -860,8 +860,8 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
         }
       }
 
-      // TODO: ServerStore closure here ...
       storeClientMap.remove(name);
+      store.close();
     }
   }
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
@@ -79,4 +79,8 @@ class ServerStoreImpl implements ServerStore {
   public void clear() {
     store.clear();
   }
+
+  public void close() {
+    store.close();
+  }
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
@@ -182,4 +182,15 @@ public class OffHeapServerStore implements ServerStore {
 
     return evicted;
   }
+
+  public void close() {
+    writeLockAll();
+    try {
+      clear();
+      segments.clear();
+    } finally {
+      writeUnlockAll();
+    }
+  }
+
 }


### PR DESCRIPTION
During rapid creation/destruction of caches/cache managers,
I observed that GC did not cleanup the dangling offheap resources
leading to extremely high memory consumption and an eventual
failure to allocate more buffers.

The theory was that the object was to complex for easy GC'ing in the
direct buffer allocation path. By closing the server store, we
eventually remove the reference to each of the ChainMaps, which then
makes it easy for the GC to clean up the memory.