### PR TITLE
Improving collector speed and auto-start at CM init (#1004)

### DIFF
--- a/management/src/test/java/org/ehcache/management/registry/DefaultCollectorServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultCollectorServiceTest.java
@@ -109,13 +109,6 @@ public class DefaultCollectorServiceTest {
         .execute()
         .getSingleResult();
 
-    managementRegistry.withCapability("StatisticCollectorCapability")
-        .call("startStatisticCollector")
-        .on(Context.create("cacheManagerName", "my-cm-1"))
-        .build()
-        .execute()
-        .getSingleResult();
-
     Cache<String, String> cache = cacheManager.createCache("my-cache", cacheConfiguration);
     cache.put("key", "val");
 


### PR DESCRIPTION
Prepares #1004, do not include any clustering work.

Collector service, if setup, is automatically started once CM is initialized.