### PR TITLE
Conditionally disable TerminatedServerTest concurrency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ ext {
 
   utils = new Utils(baseVersion, logger)
   isReleaseVersion = !baseVersion.endsWith('SNAPSHOT')
+  isCloudbees = System.getenv('JENKINS_URL')?.contains('cloudbees')
+  logger.info("Is cloudbees? $isCloudbees")
 }
 
 subprojects {
@@ -75,6 +77,9 @@ subprojects {
   test {
     maxHeapSize = "512m"
     systemProperty 'java.awt.headless', 'true'
+    if (parent.isCloudbees) {
+      systemProperty 'disable.concurrent.tests', 'true'
+    }
   }
 
   task slowTest(type: Test) {

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/TerminatedServerTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/TerminatedServerTest.java
@@ -106,9 +106,20 @@ public class TerminatedServerTest {
   public static void setConcurrency() {
     int availableProcessors = Runtime.getRuntime().availableProcessors();
     int testCount = TEST_COUNTER.getTestCount();
-    TEST_PERMITS.release(Math.min(Math.max(1, testCount / 3), availableProcessors));
-    System.out.format("TerminatedServerTest: testCount=%d, availableProcessors=%d, TEST_PERMITS.availablePermits()=%d%n",
-        testCount, availableProcessors, TEST_PERMITS.availablePermits());
+    /*
+     * Some build environments can't reliably handle running tests in this class concurrently.
+     * If the 'disable.concurrent.tests' system property is 'true', restrict the tests to
+     * single operation using a single test permit.
+     */
+    boolean disableConcurrentTests = Boolean.getBoolean("disable.concurrent.tests");
+    if (disableConcurrentTests) {
+      TEST_PERMITS.release(1);
+    } else {
+      TEST_PERMITS.release(Math.min(Math.max(1, testCount / 2), availableProcessors));
+    }
+    System.out.format("TerminatedServerTest:" +
+        " disableConcurrentTests=%b, testCount=%d, availableProcessors=%d, TEST_PERMITS.availablePermits()=%d%n",
+        disableConcurrentTests, testCount, availableProcessors, TEST_PERMITS.availablePermits());
   }
 
   private static final String RESOURCE_CONFIG =


### PR DESCRIPTION
Test concurrency is disabled in TerminatedServerTest if the
'disable.concurrent.tests' Java system property is set.  build.gradle
is changed to set this property to 'true' if running on CloudBees.
The concurrency level for non-CloudBees environments is changed
to the lesser of 1/2 the number of tests and the number of available
processors.

CloudBees detection is done by checking for 'cloudbees' in the
JENKINS_URL environment variable.  Setting JENKINS_URL to
'cloudbees' can be used to inhibit concurrent test execution in
non-CloudBees environments.