### PR TITLE
Closes #1276 Add TIMEOUT as an operation outcome for get operation stats

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -124,7 +124,7 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
     try {
       value = getInternal(key);
     } catch (TimeoutException e) {
-      // Don't count as a MISS
+      getObserver.end(StoreOperationOutcomes.GetOutcome.TIMEOUT);
       return null;
     }
     if(value == null) {

--- a/core/src/main/java/org/ehcache/core/statistics/StoreOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/core/statistics/StoreOperationOutcomes.java
@@ -31,7 +31,11 @@ public interface StoreOperationOutcomes {
     /**
      * miss
      */
-    MISS
+    MISS,
+    /**
+     * timeout
+     */
+    TIMEOUT
   }
 
   /**


### PR DESCRIPTION
Added the outcome only for get operations. Handling of mutative operations yet to be decided.