### PR TITLE
Issue #1004 - Clustered management support 

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteringServiceConfiguration.java
@@ -36,8 +36,6 @@ public class ClusteringServiceConfiguration
     implements ServiceCreationConfiguration<ClusteringService>,
     CacheManagerConfiguration<PersistentCacheManager> {
 
-  private static final String CLUSTER_SCHEME = "terracotta";
-
   private final URI clusterUri;
   private final boolean autoCreate;
   private final ServerSideConfiguration serverConfiguration;
@@ -157,10 +155,6 @@ public class ClusteringServiceConfiguration
   private static void validateClusterUri(URI clusterUri) {
     if (clusterUri == null) {
       throw new NullPointerException("Cluster URI cannot be null.");
-    }
-
-    if (!CLUSTER_SCHEME.equals(clusterUri.getScheme())) {
-      throw new IllegalArgumentException("Cluster Uri is not valid, clusterUri : " + clusterUri.toString());
     }
   }
 

--- a/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
+++ b/clustered/client/src/main/resources/ehcache-clustered-ext.xsd
@@ -77,7 +77,7 @@
 
   <xs:simpleType name="connectionUrl">
     <xs:restriction base="xs:anyURI">
-      <xs:pattern value="terracotta://([^\]\[/?#@]+@)?[^:?#/]+(:[1-9][0-9]{0,4})?(/[^\?#]*)?(\?[^#]*)?(#.*)?"/>
+      <xs:pattern value="\w+://([^\]\[/?#@]+@)?[^:?#/]+(:[1-9][0-9]{0,4})?(/[^\?#]*)?(\?[^#]*)?(#.*)?"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/config/ClusteringServiceConfigurationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/config/ClusteringServiceConfigurationTest.java
@@ -76,18 +76,6 @@ public class ClusteringServiceConfigurationTest {
   }
 
   @Test
-  public void testInvalidURI() {
-
-    URI uri = URI.create("http://localhost:9540");
-    try {
-      new ClusteringServiceConfiguration(uri);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("Cluster Uri is not valid, clusterUri : http://localhost:9540"));
-    }
-  }
-
-  @Test
   public void testValidURI() {
     URI uri = URI.create("terracotta://localhost:9540");
     ClusteringServiceConfiguration serviceConfiguration = new ClusteringServiceConfiguration(uri);

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -23,26 +23,17 @@ dependencies {
   compile project(':api')
   compile project(':core')
   compile project(':impl')
-  compile "org.terracotta.management:management-registry:$parent.terracottaPlatformVersion"
-  compile "org.terracotta.management:management-entity-client:$parent.terracottaPlatformVersion"
+  compile "org.terracotta.management:management-entity-client:$parent.managementVersion"
 
   testCompile project(':xml')
   testCompile project(':clustered:client')
   testCompile project(':clustered:server')
   testCompile "org.terracotta:entity-test-lib:$parent.entityTestLibVersion"
   testCompile "org.terracotta:passthrough-server:$parent.entityTestLibVersion"
-  testCompile "org.terracotta.management:monitoring-service:$parent.terracottaPlatformVersion"
-  testCompile "org.terracotta.management:management-entity-server:$parent.terracottaPlatformVersion"
+  testCompile "org.terracotta.management:monitoring-service:$parent.managementVersion"
+  testCompile "org.terracotta.management:management-entity-server:$parent.managementVersion"
   testCompile "org.terracotta.entities:clustered-map-server:$parent.terracottaPlatformVersion"
   testCompile "com.fasterxml.jackson.core:jackson-databind:2.7.5"
-}
-
-repositories {
-  maven { url "http://snapshots.terracotta.org/" }
-}
-
-def java8 = {
-  JavaVersion.current().isJava8Compatible()
 }
 
 compileTestJava {

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -18,16 +18,41 @@ apply plugin: EhDeploy
 
 dependencies {
   compileOnly project(':xml')
+  compileOnly project(':clustered:client')
 
   compile project(':api')
   compile project(':core')
   compile project(':impl')
-  compile "org.terracotta.management:management-registry:$parent.managementVersion"
+  compile "org.terracotta.management:management-registry:$parent.terracottaPlatformVersion"
+  compile "org.terracotta.management:management-entity-client:$parent.terracottaPlatformVersion"
 
   testCompile project(':xml')
+  testCompile project(':clustered:client')
+  testCompile project(':clustered:server')
+  testCompile "org.terracotta:entity-test-lib:$parent.entityTestLibVersion"
+  testCompile "org.terracotta:passthrough-server:$parent.entityTestLibVersion"
+  testCompile "org.terracotta.management:monitoring-service:$parent.terracottaPlatformVersion"
+  testCompile "org.terracotta.management:management-entity-server:$parent.terracottaPlatformVersion"
+  testCompile "org.terracotta.entities:clustered-map-server:$parent.terracottaPlatformVersion"
   testCompile "com.fasterxml.jackson.core:jackson-databind:2.7.5"
 }
 
 repositories {
   maven { url "http://snapshots.terracotta.org/" }
+}
+
+def java8 = {
+  JavaVersion.current().isJava8Compatible()
+}
+
+compileTestJava {
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+  options.fork = true;
+  options.forkOptions.executable = MavenToolchain.javaExecutable(JavaVersion.VERSION_1_8, 'javac')
+}
+
+test {
+  executable = MavenToolchain.javaExecutable(JavaVersion.VERSION_1_8, 'java')
+  environment 'JAVA_HOME', MavenToolchain.javaHome(JavaVersion.VERSION_1_8)
 }

--- a/management/src/main/java/org/ehcache/management/cluster/Clustering.java
+++ b/management/src/main/java/org/ehcache/management/cluster/Clustering.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceProvider;
+
+/**
+ * Feature-check class that is there only so that the management module can contain some specific classes
+ * depending on clustering, and activated only when clustering is available
+ */
+public class Clustering {
+
+  private static final String ENTITY_SERVICE_FQCN = "org.ehcache.clustered.client.service.EntityService";
+  private static final Class<? extends Service> ENTITY_SERVICE_CLASS;
+
+  static {
+    Class<? extends Service> serviceClass = null;
+    try {
+      serviceClass = Clustering.class.getClassLoader().loadClass(ENTITY_SERVICE_FQCN).asSubclass(Service.class);
+    } catch (ClassNotFoundException ignored) {
+    }
+    ENTITY_SERVICE_CLASS = serviceClass;
+  }
+
+  /**
+   * Check if clustering is active for this cache manager
+   */
+  public static boolean isAvailable(ServiceProvider<Service> serviceProvider) {
+    return ENTITY_SERVICE_CLASS != null && serviceProvider.getService(ENTITY_SERVICE_CLASS) != null;
+  }
+
+  /**
+   * Creates a new ${@link ClusteringManagementService} to handle the management integration with the cluster
+   */
+  public static ClusteringManagementService newClusteringManagementService() {
+    return new DefaultClusteringManagementService();
+  }
+
+}

--- a/management/src/main/java/org/ehcache/management/cluster/ClusteringManagementService.java
+++ b/management/src/main/java/org/ehcache/management/cluster/ClusteringManagementService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.ehcache.spi.service.Service;
+
+/**
+ * Activate the clustering management, which will sends all client-side stats,
+ * notifications and also the client-side management registry through the cluster
+ * connection
+ */
+public interface ClusteringManagementService extends Service {
+}

--- a/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
+++ b/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.ehcache.Cache;
+import org.ehcache.Status;
+import org.ehcache.clustered.client.service.ClientEntityFactory;
+import org.ehcache.clustered.client.service.EntityService;
+import org.ehcache.core.events.CacheManagerListener;
+import org.ehcache.core.spi.service.CacheManagerProviderService;
+import org.ehcache.core.spi.service.ExecutionService;
+import org.ehcache.core.spi.store.InternalCacheManager;
+import org.ehcache.core.spi.time.TimeSourceService;
+import org.ehcache.management.CollectorService;
+import org.ehcache.management.ManagementRegistryService;
+import org.ehcache.management.registry.DefaultCollectorService;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceDependencies;
+import org.ehcache.spi.service.ServiceProvider;
+import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityNotFoundException;
+import org.terracotta.management.entity.ManagementAgentConfig;
+import org.terracotta.management.entity.Version;
+import org.terracotta.management.entity.client.ManagementAgentEntity;
+import org.terracotta.management.entity.client.ManagementAgentService;
+import org.terracotta.management.model.notification.ContextualNotification;
+import org.terracotta.management.model.stats.ContextualStatistics;
+
+import java.util.Collection;
+
+@ServiceDependencies({CacheManagerProviderService.class, ExecutionService.class, TimeSourceService.class, ManagementRegistryService.class, EntityService.class})
+public class DefaultClusteringManagementService implements ClusteringManagementService, CacheManagerListener, CollectorService.Collector {
+
+  private volatile ManagementRegistryService managementRegistryService;
+  private volatile CollectorService collectorService;
+  private volatile ManagementAgentService managementAgentService;
+  private volatile ClientEntityFactory<ManagementAgentEntity, ManagementAgentConfig> managementAgentEntityFactory;
+  private volatile InternalCacheManager cacheManager;
+
+  @Override
+  public void start(ServiceProvider<Service> serviceProvider) {
+    this.managementRegistryService = serviceProvider.getService(ManagementRegistryService.class);
+    this.cacheManager = serviceProvider.getService(CacheManagerProviderService.class).getCacheManager();
+
+    this.collectorService = new DefaultCollectorService(this);
+    this.collectorService.start(serviceProvider);
+
+    EntityService entityService = serviceProvider.getService(EntityService.class);
+    this.managementAgentEntityFactory = entityService.newClientEntityFactory(
+        "ManagementAgent",
+        ManagementAgentEntity.class,
+        Version.LATEST.version(),
+        new ManagementAgentConfig()
+            //TODO: this config is only used once when the management entity is created. It's useless otherwise.
+            // should-we add something in ehcache config to handle the creation case ?
+            .setMaximumUnreadClientNotifications(1024 * 1024)
+            .setMaximumUnreadClientStatistics(1024 * 1024));
+
+    this.cacheManager.registerListener(this);
+  }
+
+  @Override
+  public void stop() {
+    collectorService.stop();
+
+    // nullify so that no further actions are done with them (see null-checks below)
+    managementAgentService.close();
+    managementRegistryService = null;
+    managementAgentService = null;
+  }
+
+  @Override
+  public void cacheAdded(String alias, Cache<?, ?> cache) {
+  }
+
+  @Override
+  public void cacheRemoved(String alias, Cache<?, ?> cache) {
+  }
+
+  @Override
+  public void stateTransition(Status from, Status to) {
+    // we are only interested when cache manager is initializing (but at the end of the initialization)
+    switch (to) {
+
+      case AVAILABLE: {
+        // create / fetch the management entity
+        ManagementAgentEntity managementAgentEntity;
+        try {
+          managementAgentEntity = managementAgentEntityFactory.retrieve();
+        } catch (EntityNotFoundException e) {
+          try {
+            managementAgentEntityFactory.create();
+          } catch (EntityAlreadyExistsException ignored) {
+          }
+          try {
+            managementAgentEntity = managementAgentEntityFactory.retrieve();
+          } catch (EntityNotFoundException bigFailure) {
+            throw (AssertionError) new AssertionError("Entity " + ManagementAgentEntity.class.getSimpleName() + " cannot be retrieved even after being created.").initCause(bigFailure.getCause());
+          }
+        }
+        managementAgentService = new ManagementAgentService(managementAgentEntity);
+        managementAgentService.bridge(managementRegistryService);
+
+        // expose tags
+        managementAgentService.setTags(managementRegistryService.getConfiguration().getTags());
+
+        break;
+      }
+
+
+      case UNINITIALIZED: {
+        this.cacheManager.deregisterListener(this);
+        break;
+      }
+
+      case MAINTENANCE:
+        // in case we need management capabilities in maintenance mode
+        break;
+
+      default:
+        throw new AssertionError("Unsupported state: " + to);
+    }
+  }
+
+  @Override
+  public void onNotification(ContextualNotification notification) {
+    ManagementAgentService service = managementAgentService;
+    if (service != null) {
+      service.pushNotification(notification);
+    }
+  }
+
+  @Override
+  public void onStatistics(Collection<ContextualStatistics> statistics) {
+    ManagementAgentService service = managementAgentService;
+    if (service != null) {
+      service.pushStatistics(statistics);
+    }
+  }
+
+}

--- a/management/src/main/java/org/ehcache/management/registry/DefaultCollectorService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultCollectorService.java
@@ -156,7 +156,7 @@ public class DefaultCollectorService implements CollectorService, CacheManagerLi
         break;
 
       default:
-        throw new AssertionError(to);
+        throw new AssertionError("Unsupported state: " + to);
     }
   }
 

--- a/management/src/main/java/org/ehcache/management/registry/DefaultSharedManagementService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultSharedManagementService.java
@@ -82,7 +82,7 @@ public class DefaultSharedManagementService implements SharedManagementService {
             break;
 
           default:
-            throw new AssertionError(to);
+            throw new AssertionError("Unsupported state: " + to);
         }
       }
     });

--- a/management/src/test/java/org/ehcache/management/cluster/ClusteringManagementServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/cluster/ClusteringManagementServiceTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.Status;
+import org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder;
+import org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder;
+import org.ehcache.clustered.client.internal.EhcacheClientEntityService;
+import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockEntityClientService;
+import org.ehcache.clustered.lock.server.VoltronReadWriteLockServerEntityService;
+import org.ehcache.clustered.server.EhcacheServerEntityService;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.management.config.EhcacheStatisticsProviderConfiguration;
+import org.ehcache.management.registry.DefaultManagementRegistryConfiguration;
+import org.ehcache.xml.XmlConfiguration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.entity.ServiceProviderConfiguration;
+import org.terracotta.entity.map.TerracottaClusteredMapClientService;
+import org.terracotta.entity.map.server.TerracottaClusteredMapService;
+import org.terracotta.management.entity.ManagementAgentConfig;
+import org.terracotta.management.entity.client.ContextualReturnListener;
+import org.terracotta.management.entity.client.ManagementAgentEntityClientService;
+import org.terracotta.management.entity.client.ManagementAgentEntityFactory;
+import org.terracotta.management.entity.client.ManagementAgentService;
+import org.terracotta.management.entity.server.ManagementAgentEntityServerService;
+import org.terracotta.management.model.call.ContextualReturn;
+import org.terracotta.management.model.call.Parameter;
+import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.cluster.ClientIdentifier;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.context.ContextContainer;
+import org.terracotta.management.model.notification.ContextualNotification;
+import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.management.model.stats.primitive.Counter;
+import org.terracotta.management.service.monitoring.IMonitoringConsumer;
+import org.terracotta.management.service.monitoring.MonitoringConsumerConfiguration;
+import org.terracotta.management.service.monitoring.MonitoringServiceConfiguration;
+import org.terracotta.management.service.monitoring.MonitoringServiceProvider;
+import org.terracotta.offheapresource.OffHeapResourcesConfiguration;
+import org.terracotta.offheapresource.OffHeapResourcesProvider;
+import org.terracotta.offheapresource.config.OffheapResourcesType;
+import org.terracotta.offheapresource.config.ResourceType;
+import org.terracotta.passthrough.PassthroughClusterControl;
+import org.terracotta.passthrough.PassthroughServer;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.TreeSet;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Arrays.asList;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class ClusteringManagementServiceTest {
+
+  static IMonitoringConsumer consumer;
+  static PassthroughClusterControl stripeControl;
+
+  CacheManager cacheManager;
+
+  @Test //(timeout = 10000)
+  public void test_programmatic_api() throws Exception {
+    cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+        // cluster config
+        .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("passthrough://server-1:9510/my-server-entity-1"))
+            .autoCreate()
+            .defaultServerResource("primary-server-resource"))
+        // management config
+        .using(new DefaultManagementRegistryConfiguration()
+            .addTags("webapp-1", "server-node-1")
+            .setCacheManagerAlias("my-super-cache-manager")
+            .addConfiguration(new EhcacheStatisticsProviderConfiguration(
+                1, TimeUnit.MINUTES,
+                100, 1, TimeUnit.SECONDS,
+                2, TimeUnit.SECONDS))) // TTD reduce to 2 seconds so that the stat collector run faster
+        // cache config
+        .withCache("cache-1", CacheConfigurationBuilder.newCacheConfigurationBuilder(
+            String.class, String.class,
+            newResourcePoolsBuilder()
+                .heap(10, EntryUnit.ENTRIES)
+                .offheap(1, MemoryUnit.MB)
+                .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+            .build())
+        .build(true);
+
+    runTest();
+  }
+
+  @Test(timeout = 10000)
+  public void test_xml_api() throws Exception {
+
+    cacheManager = CacheManagerBuilder.newCacheManager(new XmlConfiguration(getClass().getResource("/ehcache-management-clustered.xml")));
+    cacheManager.init();
+
+    runTest();
+  }
+
+  private void runTest() throws Exception {
+    // get the queues where notifs and stats are put in the voltron server
+    BlockingQueue<Object[]> statistics = consumer.getValueForNode(new String[]{"management", "statistics"}, BlockingQueue.class).get();
+    BlockingQueue<Object[]> notifications = consumer.getValueForNode(new String[]{"management", "notifications"}, BlockingQueue.class).get();
+
+    // assert management registry has been correctly exposed in voltron
+    String clientIdentifier = consumer.getChildNamesForNode("management", "clients").get().iterator().next();
+    String[] tags = consumer.getValueForNode(new String[]{"management", "clients", clientIdentifier, "tags"}, String[].class).get();
+    assertThat(tags, equalTo(new String[]{"server-node-1", "webapp-1"}));
+    ContextContainer contextContainer = consumer.getValueForNode(new String[]{"management", "clients", clientIdentifier, "registry", "contextContainer"}, ContextContainer.class).get();
+    assertThat(contextContainer.getValue(), equalTo("my-super-cache-manager"));
+    assertThat(contextContainer.getSubContexts(), hasSize(1));
+    assertThat(contextContainer.getSubContexts().iterator().next().getValue(), equalTo("cache-1"));
+    Capability[] capabilities = consumer.getValueForNode(new String[]{"management", "clients", clientIdentifier, "registry", "capabilities"}, Capability[].class).get();
+    assertThat(capabilities.length, equalTo(5));
+
+    remotelyUpdateCollectedStatistics();
+
+    // issue some puts to record some stats
+    Cache<String, String> cache1 = cacheManager.getCache("cache-1", String.class, String.class);
+    cache1.put("key1", "val");
+    cache1.put("key2", "val");
+
+    // create dynamically another cache to get the client-side notif
+    cacheManager.createCache("cache-2", CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+            .heap(10, EntryUnit.ENTRIES)
+            .offheap(1, MemoryUnit.MB)
+            .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+        .build());
+
+    // assert that the management registry exposed in voltron has been updated
+    contextContainer = consumer.getValueForNode(new String[]{"management", "clients", clientIdentifier, "registry", "contextContainer"}, ContextContainer.class).get();
+    assertThat(contextContainer.getValue(), equalTo("my-super-cache-manager"));
+    assertThat(contextContainer.getSubContexts(), hasSize(2));
+    assertThat(contextContainer.getSubContexts().iterator().next().getValue(), equalTo("cache-1"));
+
+    Collection<String> cNames = new TreeSet<String>();
+    Collection<String> expectedCNames = new TreeSet<String>(Arrays.asList("cache-1", "cache-2"));
+    for (ContextContainer container : contextContainer.getSubContexts()) {
+      cNames.add(container.getValue());
+    }
+    assertThat(cNames, equalTo(expectedCNames));
+
+    // verify the notification has been received in voltron
+    ContextualNotification notif = (ContextualNotification) notifications.take()[1];
+    assertThat(notif.getType(), equalTo("CACHE_ADDED"));
+
+    // do some put also
+    Cache<String, String> cache2 = cacheManager.getCache("cache-2", String.class, String.class);
+    cache2.put("key1", "val");
+    cache2.put("key2", "val");
+    cache2.put("key3", "val");
+
+    // verify stats have been received too
+    ContextualStatistics[] stats = (ContextualStatistics[]) statistics.take()[1];
+    assertThat(stats.length, equalTo(2));
+    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
+    assertThat(stats[1].getContext().get("cacheName"), equalTo("cache-2"));
+    assertThat(stats[0].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(2L));
+    assertThat(stats[1].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(3L));
+
+    cache1.put("key1", "val");
+    cache1.put("key2", "val");
+    cache2.put("key1", "val");
+    cache2.put("key2", "val");
+    cache2.put("key3", "val");
+
+    // wait for next stats and verify
+    stats = (ContextualStatistics[]) statistics.take()[1];
+    assertThat(stats.length, equalTo(2));
+    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
+    assertThat(stats[1].getContext().get("cacheName"), equalTo("cache-2"));
+    assertThat(stats[0].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(4L));
+    assertThat(stats[1].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(6L));
+
+    // remove a cache
+    cacheManager.removeCache("cache-2");
+
+    // ensure we got the notification server-side
+    notif = (ContextualNotification) notifications.take()[1];
+    assertThat(notif.getType(), equalTo("CACHE_REMOVED"));
+  }
+
+  private void remotelyUpdateCollectedStatistics() throws Exception {
+    try (Connection managementConsole = ConnectionFactory.connect(URI.create("passthrough://server-1:9510/"), new Properties())) {
+      ManagementAgentService agent = new ManagementAgentService(new ManagementAgentEntityFactory(managementConsole).retrieveOrCreate(new ManagementAgentConfig()));
+
+      assertThat(agent.getManageableClients().size(), equalTo(2));
+
+      // find Ehcache client
+      ClientIdentifier me = agent.getClientIdentifier();
+      ClientIdentifier client = null;
+      for (ClientIdentifier clientIdentifier : agent.getManageableClients()) {
+        if (!clientIdentifier.equals(me)) {
+          client = clientIdentifier;
+          break;
+        }
+      }
+
+      assertThat(client, is(notNullValue()));
+      final ClientIdentifier ehcacheClientIdentifier = client;
+
+      AtomicReference<String> managementCallId = new AtomicReference<>();
+      BlockingQueue<ContextualReturn<?>> returns = new LinkedBlockingQueue<>();
+
+      agent.setContextualReturnListener(new ContextualReturnListener() {
+        @Override
+        public void onContextualReturn(ClientIdentifier from, String id, ContextualReturn<?> aReturn) {
+          assertEquals(ehcacheClientIdentifier, from);
+          assertEquals(managementCallId.get(), id);
+          returns.offer(aReturn);
+        }
+      });
+
+      managementCallId.set(agent.call(
+          ehcacheClientIdentifier,
+          Context.create("cacheManagerName", "my-super-cache-manager"),
+          "StatisticCollectorCapability",
+          "updateCollectedStatistics",
+          Collection.class,
+          new Parameter("StatisticsCapability"),
+          new Parameter(asList("PutCounter", "InexistingRate"), Collection.class.getName())));
+
+      // ensure the call is made
+      returns.take();
+    }
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    PassthroughServer activeServer = new PassthroughServer();
+    activeServer.setServerName("server-1");
+    activeServer.setBindPort(9510);
+    activeServer.setGroupPort(9610);
+
+    // management agent entity
+    activeServer.registerServerEntityService(new ManagementAgentEntityServerService());
+    activeServer.registerClientEntityService(new ManagementAgentEntityClientService());
+
+    // ehcache entity
+    activeServer.registerServerEntityService(new EhcacheServerEntityService());
+    activeServer.registerClientEntityService(new EhcacheClientEntityService());
+
+    // RW lock entity (required by ehcache)
+    activeServer.registerServerEntityService(new VoltronReadWriteLockServerEntityService());
+    activeServer.registerClientEntityService(new VoltronReadWriteLockEntityClientService());
+
+    // clustered map (required by ehcache)
+    activeServer.registerClientEntityService(new TerracottaClusteredMapClientService());
+    activeServer.registerServerEntityService(new TerracottaClusteredMapService());
+
+    // monitoring service
+    activeServer.registerServiceProvider(new HackedMonitoringServiceProvider(), new MonitoringServiceConfiguration().setDebug(false));
+
+    // off-heap service
+    OffheapResourcesType offheapResourcesType = new OffheapResourcesType();
+    ResourceType resourceType = new ResourceType();
+    resourceType.setName("primary-server-resource");
+    resourceType.setUnit(org.terracotta.offheapresource.config.MemoryUnit.MB);
+    resourceType.setValue(BigInteger.TEN);
+    offheapResourcesType.getResource().add(resourceType);
+    activeServer.registerServiceProvider(new OffHeapResourcesProvider(), new OffHeapResourcesConfiguration(offheapResourcesType));
+
+    stripeControl = new PassthroughClusterControl("server-1", activeServer);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    stripeControl.tearDown();
+  }
+
+  @After
+  public void after() throws Exception {
+    if (cacheManager != null && cacheManager.getStatus() == Status.AVAILABLE) {
+      cacheManager.close();
+    }
+  }
+
+  // hack to be able to access the IMonitoringConsumer interface outside of Voltron
+  public static class HackedMonitoringServiceProvider extends MonitoringServiceProvider {
+    @Override
+    public boolean initialize(ServiceProviderConfiguration configuration) {
+      super.initialize(configuration);
+      consumer = getService(0, new MonitoringConsumerConfiguration());
+      return true;
+    }
+  }
+
+}

--- a/management/src/test/resources/META-INF/services/org.terracotta.connection.ConnectionService
+++ b/management/src/test/resources/META-INF/services/org.terracotta.connection.ConnectionService
@@ -1,0 +1,1 @@
+org.terracotta.passthrough.PassthroughConnectionService

--- a/management/src/test/resources/ehcache-management-clustered.xml
+++ b/management/src/test/resources/ehcache-management-clustered.xml
@@ -1,0 +1,46 @@
+<config
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns='http://www.ehcache.org/v3'
+    xmlns:mnm='http://www.ehcache.org/v3/management'
+    xmlns:c="http://www.ehcache.org/v3/clustered"
+    xsi:schemaLocation="http://www.ehcache.org/v3 ../../../../xml/src/main/resources/ehcache-core.xsd
+                        http://www.ehcache.org/v3/management ../../main/resources/ehcache-management-ext.xsd
+                        http://www.ehcache.org/v3/clustered ../../../../clustered/client/src/main/resources/ehcache-clustered-ext.xsd">
+
+  <service>
+    <c:cluster>
+      <c:connection url="passthrough://server-1:9510/my-server-entity-2"/>
+      <c:server-side-config auto-create="true">
+        <c:default-resource from="primary-server-resource"/>
+      </c:server-side-config>
+    </c:cluster>
+  </service>
+
+  <service>
+    <mnm:management cache-manager-alias="my-super-cache-manager">
+      <mnm:tags>
+        <mnm:tag>webapp-1</mnm:tag>
+        <mnm:tag>server-node-1</mnm:tag>
+      </mnm:tags>
+      <mnm:statistics-configurations>
+        <mnm:statistics-configuration>
+          <mnm:average-window unit="minutes">1</mnm:average-window>
+          <mnm:history-interval unit="seconds">1</mnm:history-interval>
+          <mnm:history-size>100</mnm:history-size>
+          <mnm:time-to-disable unit="seconds">2</mnm:time-to-disable>
+        </mnm:statistics-configuration>
+      </mnm:statistics-configurations>
+    </mnm:management>
+  </service>
+
+  <cache alias="cache-1">
+    <key-type>java.lang.String</key-type>
+    <value-type>java.lang.String</value-type>
+    <resources>
+      <heap unit="entries">10</heap>
+      <offheap unit="MB">1</offheap>
+      <c:clustered-dedicated from="primary-server-resource" unit="MB">1</c:clustered-dedicated>
+    </resources>
+  </cache>
+
+</config>


### PR DESCRIPTION
# rebases and replaces PR #1307 
In a nutshell, we "just" need to figure out what to do with the "passthrough" scheme

Closes #1004. 

Adds support for clustering in management module.

Several notes:

 __1.__ I moved several versions from `clustered` to the top build file because some versions are common from management and clustered and management depends on clustered (provided)

=> Confirmed with @chrisdennis and @cljohnso : OK (only impact on clustered is the dependency on tc-platform, which still compile fine and pass the IT tests)

 __2.__ To avoid creating another module depending on both management AND clustered, I put the clustering work in an isolated package which won't impact the standalone usage. Thus, the clustering management service is started by the Management registry service ONLY if the `EntityService` is found in the classpath AND in the service locator.

=> @ljacomet : the little trick is 3 lines added to the `DefaultManagementRegistryService` to load the clustered management service if needed. This avoids creating the new module.

 __3.__ The `passthrough` scheme needs to be supported in Ehcache so that we can Ehcache test with the OSS passthrough system from another module.

=> @ljacomet : this is something I discussed with @chrisdennis on Friday. I think it's a valid use case to be able to test Ehcache. And I cannot access the `UnitTestConnectionService` from management tests.

__DO NOT MERGE BEFORE @ljacomet's APPROVAL__