### PR TITLE
Fix #1275 Improve error message for destroyCache

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
@@ -27,6 +27,7 @@ import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.exceptions.ClusterException;
+import org.ehcache.clustered.common.internal.exceptions.ResourceBusyException;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse.Failure;
@@ -202,6 +203,8 @@ public class EhcacheClientEntity implements Entity {
   public void destroyCache(String name) throws ClusteredTierDestructionException, TimeoutException {
     try {
       invokeInternal(timeouts.getLifecycleOperationTimeout(), messageFactory.destroyServerStore(name), true);
+    } catch (ResourceBusyException e) {
+      throw new ClusteredTierDestructionException(e.getMessage(), e);
     } catch (ClusterException e) {
       throw new ClusteredTierDestructionException("Error destroying clustered tier '" + name + "'", e);
     }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
@@ -310,7 +310,7 @@ class DefaultClusteringService implements ClusteringService, EntityService {
     try {
       entity.destroyCache(name);
     } catch (ClusteredTierDestructionException e) {
-      throw new CachePersistenceException("Cannot destroy clustered tier '" + name + "' on " + clusterUri, e);
+      throw new CachePersistenceException(e.getMessage() + " (on " + clusterUri + ")", e);
     } catch (TimeoutException e) {
       throw new CachePersistenceException("Could not destroy clustered tier '" + name + "' on " + clusterUri
           + "; destroy operation timed out" + clusterUri, e);

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/CacheManagerDestroyTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/CacheManagerDestroyTest.java
@@ -36,7 +36,6 @@ import java.net.URI;
 import static org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder.cluster;
 import static org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -168,38 +167,6 @@ public class CacheManagerDestroyTest {
     Cache<Long, String> cache2 = persistentCacheManager2.getCache("test", Long.class, String.class);
 
     assertThat(cache2.get(1L), is("One"));
-
-  }
-
-  @Test
-  public void testDestroyUnKnownCacheAlias() throws CachePersistenceException {
-    CacheManagerBuilder<PersistentCacheManager> cacheManagerBuilder = clusteredCacheManagerBuilder
-        .withCache("test", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
-            ResourcePoolsBuilder.newResourcePoolsBuilder()
-                .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 32, MemoryUnit.MB))));
-
-    PersistentCacheManager persistentCacheManager1 = cacheManagerBuilder.build(true);
-
-    PersistentCacheManager anotherPersistentCacheManager = clusteredCacheManagerBuilder.build(true);
-
-    try {
-      anotherPersistentCacheManager.destroyCache("test");
-      fail("CachePersistenceException Expected");
-    } catch (CachePersistenceException e) {
-      assertThat(e.getMessage(), is("Cannot destroy clustered tier 'test' on terracotta://example.com:9540"));
-    }
-
-    persistentCacheManager1.close();
-
-    anotherPersistentCacheManager.destroyCache("test");
-
-    //Proves that the resource cache is destroyed.
-
-    Cache<Long, String> cache1 = anotherPersistentCacheManager.createCache("test", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
-        ResourcePoolsBuilder.newResourcePoolsBuilder()
-            .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 40, MemoryUnit.MB))));
-
-    assertNotNull(cache1);
 
   }
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -691,7 +691,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
 
     final Set<ClientDescriptor> clients = storeClientMap.get(name);
     if (clients != null && !clients.isEmpty()) {
-      throw new ResourceBusyException("Can not destroy clustered tier '" + name + "': in use by " + clients.size() + " clients");
+      throw new ResourceBusyException("Cannot destroy clustered tier '" + name + "': in use by " + clients.size() + " other client(s)");
     }
 
     LOGGER.info("Client {} destroying clustered tier '{}'", clientDescriptor, name);


### PR DESCRIPTION
When a cache cannot be destroyed because it is still in use, the
message was limited to the bottom cause. This makes it apparent from
the top of the exception hierarchy.
Also cleaned up tests related to destroyCache