### PR TITLE
Fix #1344 Default timeout in configuration

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteringServiceConfiguration.java
@@ -28,6 +28,8 @@ import java.net.URI;
 
 import org.ehcache.clustered.common.ServerSideConfiguration;
 
+import static org.ehcache.clustered.client.internal.EhcacheClientEntity.Timeouts.DEFAULT_READ_OPERATION_TIMEOUT;
+
 /**
  * Specifies the configuration for a {@link ClusteringService}.
  */
@@ -56,7 +58,7 @@ public class ClusteringServiceConfiguration
     this.clusterUri = clusterUri;
     this.autoCreate = false;
     this.serverConfiguration = null;
-    this.readOperationTimeout = null;
+    this.readOperationTimeout = DEFAULT_READ_OPERATION_TIMEOUT;
   }
 
   /**
@@ -71,10 +73,31 @@ public class ClusteringServiceConfiguration
    */
   public ClusteringServiceConfiguration(final URI clusterUri, final TimeoutDuration readOperationTimeout) {
     validateClusterUri(clusterUri);
+    validateReadOperationTimeout(readOperationTimeout);
     this.clusterUri = clusterUri;
     this.autoCreate = false;
     this.serverConfiguration = null;
     this.readOperationTimeout = readOperationTimeout;
+  }
+
+  /**
+   * Creates a {@code ClusteringServiceConfiguration} from the properties provided.
+   *
+   * @param clusterUri the non-{@code null} URI identifying the cluster server
+   * @param serverConfig  the server side entity configuration required
+   *
+   * @throws NullPointerException if {@code clusterUri} or {@code serverConfig} is {@code null}
+   * @throws IllegalArgumentException if {@code clusterUri} is not URI valid for cluster operations
+   */
+  public ClusteringServiceConfiguration(final URI clusterUri, final ServerSideConfiguration serverConfig) {
+    validateClusterUri(clusterUri);
+    if (serverConfig == null) {
+      throw new NullPointerException("Server configuration cannot be null");
+    }
+    this.clusterUri = clusterUri;
+    this.autoCreate = false;
+    this.serverConfiguration = serverConfig;
+    this.readOperationTimeout = DEFAULT_READ_OPERATION_TIMEOUT;
   }
 
   /**
@@ -90,6 +113,7 @@ public class ClusteringServiceConfiguration
    */
   public ClusteringServiceConfiguration(final URI clusterUri, final TimeoutDuration readOperationTimeout, ServerSideConfiguration serverConfig) {
     validateClusterUri(clusterUri);
+    validateReadOperationTimeout(readOperationTimeout);
     if (serverConfig == null) {
       throw new NullPointerException("Server configuration cannot be null");
     }
@@ -117,7 +141,7 @@ public class ClusteringServiceConfiguration
     this.clusterUri = clusterUri;
     this.autoCreate = autoCreate;
     this.serverConfiguration = serverConfig;
-    this.readOperationTimeout = null;
+    this.readOperationTimeout = DEFAULT_READ_OPERATION_TIMEOUT;
   }
 
   /**
@@ -134,6 +158,7 @@ public class ClusteringServiceConfiguration
    */
   public ClusteringServiceConfiguration(final URI clusterUri, final TimeoutDuration readOperationTimeout, boolean autoCreate, ServerSideConfiguration serverConfig) {
     validateClusterUri(clusterUri);
+    validateReadOperationTimeout(readOperationTimeout);
     if (serverConfig == null) {
       throw new NullPointerException("Server configuration cannot be null");
     }
@@ -157,6 +182,12 @@ public class ClusteringServiceConfiguration
   private static void validateClusterUri(URI clusterUri) {
     if (clusterUri == null) {
       throw new NullPointerException("Cluster URI cannot be null.");
+    }
+  }
+
+  private void validateReadOperationTimeout(TimeoutDuration readOperationTimeout) {
+    if (readOperationTimeout == null) {
+      throw new NullPointerException("readOperationTimeout cannot be null");
     }
   }
 

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/builders/ClusteringServiceConfigurationBuilder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/builders/ClusteringServiceConfigurationBuilder.java
@@ -97,7 +97,11 @@ public final class ClusteringServiceConfigurationBuilder implements Builder<Clus
 
   @Override
   public ClusteringServiceConfiguration build() {
-    return new ClusteringServiceConfiguration(clusterUri, readOperationTimeout);
+    if (readOperationTimeout == null) {
+      return new ClusteringServiceConfiguration(clusterUri);
+    } else {
+      return new ClusteringServiceConfiguration(clusterUri, readOperationTimeout);
+    }
   }
 
   /**
@@ -111,9 +115,17 @@ public final class ClusteringServiceConfigurationBuilder implements Builder<Clus
   ClusteringServiceConfiguration build(ServerSideConfiguration serverSideConfiguration) {
     ClusteringServiceConfiguration configuration;
     if (autoCreate != null) {
-      configuration = new ClusteringServiceConfiguration(clusterUri, readOperationTimeout, autoCreate, serverSideConfiguration);
+      if (readOperationTimeout != null) {
+        configuration = new ClusteringServiceConfiguration(clusterUri, readOperationTimeout, autoCreate, serverSideConfiguration);
+      } else {
+        configuration = new ClusteringServiceConfiguration(clusterUri, autoCreate, serverSideConfiguration);
+      }
     } else {
-      configuration = new ClusteringServiceConfiguration(clusterUri, readOperationTimeout, serverSideConfiguration);
+      if (readOperationTimeout != null) {
+        configuration = new ClusteringServiceConfiguration(clusterUri, readOperationTimeout, serverSideConfiguration);
+      } else {
+        configuration = new ClusteringServiceConfiguration(clusterUri, serverSideConfiguration);
+      }
     }
     return configuration;
   }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
@@ -312,6 +312,9 @@ public class EhcacheClientEntity implements Entity {
    * {@link #builder()} to construct an instance.
    */
   public static final class Timeouts {
+
+    public static final TimeoutDuration DEFAULT_READ_OPERATION_TIMEOUT = TimeoutDuration.of(5, TimeUnit.SECONDS);
+
     private final TimeoutDuration readOperationTimeout;
     private final TimeoutDuration mutativeOperationTimeout;
     private final TimeoutDuration lifecycleOperationTimeout;
@@ -352,7 +355,7 @@ public class EhcacheClientEntity implements Entity {
      * {@link Timeouts#builder()}, the default values are pre-set.
      */
     public static final class Builder {
-      private TimeoutDuration readOperationTimeout = TimeoutDuration.of(5, TimeUnit.SECONDS);
+      private TimeoutDuration readOperationTimeout = DEFAULT_READ_OPERATION_TIMEOUT;
       private TimeoutDuration mutativeOperationTimeout = TimeoutDuration.of(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
       private TimeoutDuration lifecycleOperationTimeout = TimeoutDuration.of(10, TimeUnit.SECONDS);
 

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java
@@ -142,7 +142,11 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
 
       try {
         if (serverConfig == null) {
-          return new ClusteringServiceConfiguration(connectionUri, getTimeout);
+          if (getTimeout == null) {
+            return new ClusteringServiceConfiguration(connectionUri);
+          } else {
+            return new ClusteringServiceConfiguration(connectionUri, getTimeout);
+          }
         } else {
           ServerSideConfiguration serverSideConfiguration;
           if (serverConfig.defaultServerResource == null) {
@@ -150,8 +154,12 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
           } else {
             serverSideConfiguration = new ServerSideConfiguration(serverConfig.defaultServerResource, serverConfig.pools);
           }
-          return new ClusteringServiceConfiguration(
-              connectionUri, getTimeout, serverConfig.autoCreate, serverSideConfiguration);
+          if (getTimeout == null) {
+            return new ClusteringServiceConfiguration(connectionUri, serverConfig.autoCreate, serverSideConfiguration);
+          } else {
+            return new ClusteringServiceConfiguration(
+                connectionUri, getTimeout, serverConfig.autoCreate, serverSideConfiguration);
+          }
         }
       } catch (IllegalArgumentException e) {
         throw new XmlConfigurationException(e);

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
@@ -99,9 +99,7 @@ class DefaultClusteringService implements ClusteringService, EntityService {
     this.entityIdentifier = clusterUri.relativize(ehcacheUri).getPath();
 
     EhcacheClientEntity.Timeouts.Builder timeoutsBuilder = EhcacheClientEntity.Timeouts.builder();
-    if (configuration.getReadOperationTimeout() != null) {
-      timeoutsBuilder.setReadOperationTimeout(configuration.getReadOperationTimeout());
-    }
+    timeoutsBuilder.setReadOperationTimeout(configuration.getReadOperationTimeout());
     if (configuration instanceof ExperimentalClusteringServiceConfiguration) {
       ExperimentalClusteringServiceConfiguration experimentalConfiguration = (ExperimentalClusteringServiceConfiguration)configuration;
       if (experimentalConfiguration.getMutativeOperationTimeout() != null) {

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/config/ClusteringServiceConfigurationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/config/ClusteringServiceConfigurationTest.java
@@ -35,6 +35,8 @@ import static org.junit.Assert.fail;
 
 public class ClusteringServiceConfigurationTest {
 
+  private URI DEFAULT_URI = URI.create("terracotta://localhost:9450");
+
   @Test(expected = NullPointerException.class)
   public void testGetConnectionUrlNull() throws Exception {
     new ClusteringServiceConfiguration((URI)null);
@@ -42,44 +44,52 @@ public class ClusteringServiceConfigurationTest {
 
   @Test
   public void testGetConnectionUrl() throws Exception {
-    final URI connectionUrl = URI.create("terracotta://localhost:9450");
-    assertThat(new ClusteringServiceConfiguration(connectionUrl).getClusterUri(), is(connectionUrl));
+    assertThat(new ClusteringServiceConfiguration(DEFAULT_URI).getClusterUri(), is(DEFAULT_URI));
   }
 
   @Test
-  public void testGetGetTimeout() throws Exception {
-    final URI connectionUrl = URI.create("terracotta://localhost:9450");
+  public void testGetReadOperationTimeout() throws Exception {
     final TimeoutDuration getTimeout = TimeoutDuration.of(15, TimeUnit.SECONDS);
-    assertThat(new ClusteringServiceConfiguration(connectionUrl, getTimeout).getReadOperationTimeout(), is(getTimeout));
+    assertThat(new ClusteringServiceConfiguration(DEFAULT_URI, getTimeout).getReadOperationTimeout(), is(getTimeout));
+  }
 
-    assertThat(new ClusteringServiceConfiguration(connectionUrl).getReadOperationTimeout(), is(nullValue()));
-    assertThat(new ClusteringServiceConfiguration(connectionUrl, null).getReadOperationTimeout(), is(nullValue()));
+  @Test
+  public void testDefaultReadOperationTimeout() throws Exception {
+
+    assertThat(new ClusteringServiceConfiguration(DEFAULT_URI).getReadOperationTimeout(), is(TimeoutDuration.of(5, TimeUnit.SECONDS)));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReadOperationTimeoutCannotBeNull2Args() throws Exception {
+    new ClusteringServiceConfiguration(DEFAULT_URI, (TimeoutDuration) null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReadOperationTimeoutCannotBeNull3Args() throws Exception {
+    new ClusteringServiceConfiguration(DEFAULT_URI, null, new ServerSideConfiguration(Collections.<String, Pool>emptyMap()));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testReadOperationTimeoutCannotBeNull4Args() throws Exception {
+    new ClusteringServiceConfiguration(DEFAULT_URI, null, true, new ServerSideConfiguration(Collections.<String, Pool>emptyMap()));
   }
 
   @Test
   public void testGetServiceType() throws Exception {
-    assertThat(new ClusteringServiceConfiguration(URI.create("terracotta://localhost:9450")).getServiceType(),
+    assertThat(new ClusteringServiceConfiguration(DEFAULT_URI).getServiceType(),
         is(equalTo(ClusteringService.class)));
   }
 
   @Test
   public void testGetAutoCreate() throws Exception {
-    assertThat(new ClusteringServiceConfiguration(URI.create("terracotta://localhost:9450"), true,
+    assertThat(new ClusteringServiceConfiguration(DEFAULT_URI, true,
             new ServerSideConfiguration(Collections.<String, Pool>emptyMap())).isAutoCreate(),
         is(true));
   }
 
   @Test
   public void testBuilder() throws Exception {
-    assertThat(new ClusteringServiceConfiguration(URI.create("terracotta://localhost:9450"))
+    assertThat(new ClusteringServiceConfiguration(DEFAULT_URI)
         .builder(CacheManagerBuilder.newCacheManagerBuilder()), is(instanceOf(CacheManagerBuilder.class)));
-  }
-
-  @Test
-  public void testValidURI() {
-    URI uri = URI.create("terracotta://localhost:9540");
-    ClusteringServiceConfiguration serviceConfiguration = new ClusteringServiceConfiguration(uri);
-
-    assertThat(serviceConfiguration.getClusterUri(), is(uri));
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParserTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParserTest.java
@@ -170,7 +170,7 @@ public class ClusteringServiceConfigurationParserTest {
         ServiceLocator.findSingletonAmongst(ClusteringServiceConfiguration.class, serviceCreationConfigurations);
     assertThat(clusteringServiceConfiguration, is(notNullValue()));
 
-    assertThat(clusteringServiceConfiguration.getReadOperationTimeout(), is(nullValue()));
+    assertThat(clusteringServiceConfiguration.getReadOperationTimeout(), is(TimeoutDuration.of(5, TimeUnit.SECONDS)));
   }
 
   @Test

--- a/management/src/test/resources/clusteredConfiguration.txt
+++ b/management/src/test/resources/clusteredConfiguration.txt
@@ -19,6 +19,6 @@ caches:
 services:
     - org.ehcache.clustered.client.config.ClusteringServiceConfiguration:
         clusterUri: passthrough://server-1:9510/my-server-entity-1
-        readOperationTimeout: null
+        readOperationTimeout: TimeoutDuration{5 SECONDS}
         autoCreate: true
     - org.ehcache.management.registry.DefaultManagementRegistryConfiguration


### PR DESCRIPTION
Previously the ClusteringServiceConfiguration could have a null field
. This commit changes that by making sure to use the defined default.
 This simplifies configuration handling by not having to perform null
  checks.