### PR TITLE
Issue #1196 Single queue for event ordering

### DIFF
--- a/core/src/main/java/org/ehcache/core/config/store/StoreEventSourceConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/config/store/StoreEventSourceConfiguration.java
@@ -29,7 +29,7 @@ public interface StoreEventSourceConfiguration extends ServiceConfiguration<Stor
   /**
    * Default dispatcher concurrency
    */
-  int DEFAULT_DISPATCHER_CONCURRENCY = 8;
+  int DEFAULT_DISPATCHER_CONCURRENCY = 1;
 
   /**
    * Indicates over how many buckets should ordered events be spread


### PR DESCRIPTION
Since this change has no major impact on load tests that are effectively using ordered events - let's go with it.