### PR TITLE
clustered management - fix missing thread delegation when receiving management call requests

### DIFF
--- a/management/src/main/java/org/ehcache/management/cluster/Clustering.java
+++ b/management/src/main/java/org/ehcache/management/cluster/Clustering.java
@@ -46,8 +46,8 @@ public class Clustering {
   /**
    * Creates a new ${@link ClusteringManagementService} to handle the management integration with the cluster
    */
-  public static ClusteringManagementService newClusteringManagementService() {
-    return new DefaultClusteringManagementService();
+  public static ClusteringManagementService newClusteringManagementService(ClusteringManagementServiceConfiguration configuration) {
+    return new DefaultClusteringManagementService(configuration);
   }
 
 }

--- a/management/src/main/java/org/ehcache/management/cluster/ClusteringManagementServiceConfiguration.java
+++ b/management/src/main/java/org/ehcache/management/cluster/ClusteringManagementServiceConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+/**
+ * Configuration interface for a  {@link ClusteringManagementService}.
+ */
+public interface ClusteringManagementServiceConfiguration extends ServiceCreationConfiguration<ClusteringManagementService> {
+
+  /**
+   * @return The alias of the executor used to run management call queries.
+   */
+  String getManagementCallExecutorAlias();
+
+  /**
+   * @return The maximum size of the bounded queue used to stock management call requests before executing them
+   */
+  int getManagementCallQueueSize();
+}

--- a/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementServiceConfiguration.java
+++ b/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementServiceConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+public class DefaultClusteringManagementServiceConfiguration implements ClusteringManagementServiceConfiguration {
+
+  private String managementCallExecutorAlias;
+  private int managementCallQueueSize = 1024;
+
+  @Override
+  public String getManagementCallExecutorAlias() {
+    return managementCallExecutorAlias;
+  }
+
+  public DefaultClusteringManagementServiceConfiguration setManagementCallExecutorAlias(String managementCallExecutorAlias) {
+    this.managementCallExecutorAlias = managementCallExecutorAlias;
+    return this;
+  }
+
+  @Override
+  public int getManagementCallQueueSize() {
+    return managementCallQueueSize;
+  }
+
+  public DefaultClusteringManagementServiceConfiguration setManagementCallQueueSize(int managementCallQueueSize) {
+    this.managementCallQueueSize = managementCallQueueSize;
+    return this;
+  }
+
+  @Override
+  public Class<ClusteringManagementService> getServiceType() {
+    return ClusteringManagementService.class;
+  }
+}

--- a/management/src/main/java/org/ehcache/management/cluster/LoggingExecutor.java
+++ b/management/src/main/java/org/ehcache/management/cluster/LoggingExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.Executor;
+
+class LoggingExecutor implements Executor {
+
+  private final Logger logger;
+  private final Executor delegate;
+
+  public LoggingExecutor(Executor delegate, Logger logger) {
+    this.delegate = delegate;
+    this.logger = logger;
+  }
+
+  @Override
+  public void execute(final Runnable command) {
+    delegate.execute(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          command.run();
+        } catch (RuntimeException e) {
+          logger.error("ERR: " + e.getMessage(), e);
+        }
+      }
+    });
+  }
+
+}

--- a/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistryService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistryService.java
@@ -27,6 +27,7 @@ import org.ehcache.management.ManagementRegistryService;
 import org.ehcache.management.ManagementRegistryServiceConfiguration;
 import org.ehcache.management.cluster.Clustering;
 import org.ehcache.management.cluster.ClusteringManagementService;
+import org.ehcache.management.cluster.DefaultClusteringManagementServiceConfiguration;
 import org.ehcache.management.providers.CacheBinding;
 import org.ehcache.management.providers.EhcacheStatisticCollectorProvider;
 import org.ehcache.management.providers.actions.EhcacheActionProvider;
@@ -80,7 +81,7 @@ public class DefaultManagementRegistryService extends AbstractManagementRegistry
     // this feature detection is done to avoid having another "cluster-management" module that would depend on both management and clustering
     this.clusteringManagementService = serviceProvider.getService(ClusteringManagementService.class);
     if (this.clusteringManagementService == null && Clustering.isAvailable(serviceProvider)) {
-      this.clusteringManagementService = Clustering.newClusteringManagementService();
+      this.clusteringManagementService = Clustering.newClusteringManagementService(new DefaultClusteringManagementServiceConfiguration());
       this.clusteringManagementService.start(serviceProvider);
     }
   }


### PR DESCRIPTION
When using the client communicator, the execution should be delegated to another thread.

So this PR is to use the ehcache execution service to create an executor specialized in executing the management call requests in another thread.