### PR TITLE
do not call cacheManager.getStatus() into a scheduled task because it would block the shutdown of the executor

### DIFF
--- a/management/src/main/java/org/ehcache/management/cluster/ClusteringManagementServiceConfiguration.java
+++ b/management/src/main/java/org/ehcache/management/cluster/ClusteringManagementServiceConfiguration.java
@@ -31,4 +31,9 @@ public interface ClusteringManagementServiceConfiguration extends ServiceCreatio
    * @return The maximum size of the bounded queue used to stock management call requests before executing them
    */
   int getManagementCallQueueSize();
+
+  /**
+   * @return The timeout in seconds for management call operations
+   */
+  long getManagementCallTimeoutSec();
 }

--- a/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
+++ b/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
@@ -43,6 +43,7 @@ import org.terracotta.management.model.stats.ContextualStatistics;
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.ehcache.impl.internal.executor.ExecutorUtil.shutdownNow;
 
@@ -134,6 +135,7 @@ public class DefaultClusteringManagementService implements ClusteringManagementS
           }
         }
         managementAgentService = new ManagementAgentService(managementAgentEntity);
+        managementAgentService.setOperationTimeout(configuration.getManagementCallTimeoutSec(), TimeUnit.SECONDS);
         // setup the executor that will handle the management call requests received from the server. We log failures.
         managementAgentService.setManagementCallExecutor(new LoggingExecutor(
             managementCallExecutor,

--- a/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementServiceConfiguration.java
+++ b/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementServiceConfiguration.java
@@ -19,6 +19,7 @@ public class DefaultClusteringManagementServiceConfiguration implements Clusteri
 
   private String managementCallExecutorAlias;
   private int managementCallQueueSize = 1024;
+  private long managementCallTimeoutSec = 5;
 
   @Override
   public String getManagementCallExecutorAlias() {
@@ -37,6 +38,16 @@ public class DefaultClusteringManagementServiceConfiguration implements Clusteri
 
   public DefaultClusteringManagementServiceConfiguration setManagementCallQueueSize(int managementCallQueueSize) {
     this.managementCallQueueSize = managementCallQueueSize;
+    return this;
+  }
+
+  @Override
+  public long getManagementCallTimeoutSec() {
+    return managementCallTimeoutSec;
+  }
+
+  public DefaultClusteringManagementServiceConfiguration setManagementCallTimeoutSec(long managementCallTimeoutSec) {
+    this.managementCallTimeoutSec = managementCallTimeoutSec;
     return this;
   }
 

--- a/management/src/main/java/org/ehcache/management/registry/DefaultCollectorService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultCollectorService.java
@@ -175,7 +175,7 @@ public class DefaultCollectorService implements CollectorService, CacheManagerLi
         public void run() {
           try {
             // always check if the cache manager is still available
-            if (cacheManager.getStatus() == Status.AVAILABLE && !selectedStatsPerCapability.isEmpty()) {
+            if (!selectedStatsPerCapability.isEmpty()) {
 
               // create the full context list from current caches
               Collection<Context> cacheContexts = new ArrayList<Context>();


### PR DESCRIPTION
do not call cacheManager.getStatus() into a scheduled task
because it would block the shutdown of the executor