### PR TITLE
Closes #1343 On-demand encode/decode of Operation values during chain resolution

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/LazyValueHolder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/LazyValueHolder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations;
+
+import org.ehcache.clustered.client.internal.store.operations.codecs.CodecException;
+import org.ehcache.spi.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+
+class LazyValueHolder<V> {
+
+  private V value;
+  private ByteBuffer encodedValue;
+  private final Serializer<V> valueSerializer;
+
+  LazyValueHolder(final V value) {
+    if(value == null) {
+      throw new NullPointerException("Value can not be null");
+    }
+    this.value = value;
+    this.encodedValue = null;
+    this.valueSerializer = null;
+  }
+
+  LazyValueHolder(final ByteBuffer encodedValue, final Serializer<V> valueSerializer) {
+    this.encodedValue = encodedValue;
+    this.valueSerializer = valueSerializer;
+    this.value = null;
+  }
+
+  public V getValue() {
+    if(value == null) {
+      try {
+        value = this.valueSerializer.read(encodedValue);
+      } catch (ClassNotFoundException e) {
+        throw new CodecException(e);
+      }
+    }
+    return value;
+  }
+
+  public ByteBuffer encode(Serializer<V> valueSerializer) {
+    if(encodedValue == null) {
+      this.encodedValue = valueSerializer.serialize(value);
+    }
+    return encodedValue;
+  }
+}

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/LazyValueHolderTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/LazyValueHolderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.client.internal.store.operations;
+
+import org.ehcache.spi.serialization.Serializer;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class LazyValueHolderTest {
+
+  @Test
+  public void testGetValueDecodeOnlyOnce() throws Exception {
+    Date date = mock(Date.class);
+    ByteBuffer buffer = mock(ByteBuffer.class);
+    Serializer<Date> serializer = mock(Serializer.class);
+    doReturn(date).when(serializer).read(buffer);
+
+    LazyValueHolder<Date> valueHolder = new LazyValueHolder<Date>(buffer, serializer);
+    verify(serializer, never()).read(buffer); //Encoded value not deserialized on creation itself
+    valueHolder.getValue();
+    verify(serializer).read(buffer);  //Deserialization happens on the first invocation of getValue()
+    valueHolder.getValue();
+    verify(serializer).read(buffer);  //Deserialization does not repeat on subsequent getValue() calls
+  }
+
+  @Test
+  public void testEncodeEncodesOnlyOnce() throws Exception {
+    Date date = mock(Date.class);
+    ByteBuffer buffer = mock(ByteBuffer.class);
+    Serializer<Date> serializer = mock(Serializer.class);
+    doReturn(buffer).when(serializer).serialize(date);
+
+    LazyValueHolder<Date> valueHolder = new LazyValueHolder<Date>(date);
+    verify(serializer, never()).serialize(date); //Value not serialized on creation itself
+    valueHolder.encode(serializer);
+    verify(serializer).serialize(date); //Serialization happens on the first invocation of encode()
+    valueHolder.encode(serializer);
+    verify(serializer).serialize(date); //Serialization does not repeat on subsequent encode() calls
+  }
+
+  @Test
+  public void testEncodeDoesNotEncodeAlreadyEncodedValue() throws Exception {
+    ByteBuffer buffer = mock(ByteBuffer.class);
+    Serializer<Date> serializer = mock(Serializer.class);
+
+    LazyValueHolder<Date> valueHolder = new LazyValueHolder<Date>(buffer, serializer);
+    ByteBuffer encoded = valueHolder.encode(serializer);
+    assertThat(encoded, sameInstance(buffer));
+    verify(serializer, never()).serialize(any(Date.class)); //Value not serialized as the serialized form was available on creation itself
+  }
+}


### PR DESCRIPTION
The chain resolution now handles the following cases:

1. Decode value of target operations only when required
2. Avoid decoding values of non-target operations
3. No expiry calculations and expiryTime updates when expiry is not configured
4. Avoid rebuilding the chain after resolution if no compaction has happened