### PR TITLE
Compat' with new tc-platform and tc-apis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,16 +26,16 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.3.beta2'
+  terracottaPlatformVersion = '5.0.4.beta'
   managementVersion = terracottaPlatformVersion
-  terracottaApisVersion = '1.0.3.beta'
-  terracottaCoreVersion = '5.0.3-beta'
+  terracottaApisVersion = '1.0.4.beta'
+  terracottaCoreVersion = '5.0.4-beta'
   clusteredMapVersion = terracottaPlatformVersion
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
-  terracottaPassthroughTestingVersion = '1.0.3.beta'
+  terracottaPassthroughTestingVersion = '1.0.4.beta'
   entityTestLibVersion = terracottaPassthroughTestingVersion
-  galvanVersion = '1.0.3-beta'
+  galvanVersion = '1.0.4-beta'
 
   utils = new Utils(baseVersion, logger)
   isReleaseVersion = !baseVersion.endsWith('SNAPSHOT')

--- a/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
+++ b/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.management.entity.ManagementAgentConfig;
-import org.terracotta.management.entity.Version;
+import org.terracotta.management.entity.ManagementAgentVersion;
 import org.terracotta.management.entity.client.ManagementAgentEntity;
 import org.terracotta.management.entity.client.ManagementAgentService;
 import org.terracotta.management.model.notification.ContextualNotification;
@@ -83,12 +83,8 @@ public class DefaultClusteringManagementService implements ClusteringManagementS
     this.managementAgentEntityFactory = entityService.newClientEntityFactory(
         "ManagementAgent",
         ManagementAgentEntity.class,
-        Version.LATEST.version(),
-        new ManagementAgentConfig()
-            //TODO: this config is only used once when the management entity is created. It's useless otherwise.
-            // should-we add something in ehcache config to handle the creation case ?
-            .setMaximumUnreadClientNotifications(1024 * 1024)
-            .setMaximumUnreadClientStatistics(1024 * 1024));
+        ManagementAgentVersion.LATEST.version(),
+        new ManagementAgentConfig());
 
     this.cacheManager.registerListener(this);
   }


### PR DESCRIPTION
Updates:

- apis - 1.0.4.beta
- passthrough-testing - 1.0.4.beta
- config - 10.0.4.beta
- core - 5.0.4-beta
- galvan - 1.0.4-beta
- tc-platform - 5.0.4.beta

Compat' with Terracotta-OSS/terracotta-platform#129
(new tc-platform snapshot)

@anthonydahanne : this can be merged when Terracotta-OSS/terracotta-platform#129 will be merged AND tc-platform __5.0.4.beta__ will be released.

This is part of the work for #1008 