### PR TITLE
Switching to next releases (1.0.6 and 5.0.6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,16 +26,16 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.4.beta'
+  terracottaPlatformVersion = '5.0.6.beta'
   managementVersion = terracottaPlatformVersion
-  terracottaApisVersion = '1.0.4.beta'
-  terracottaCoreVersion = '5.0.4-beta'
+  terracottaApisVersion = '1.0.6.beta'
+  terracottaCoreVersion = '5.0.6-beta'
   clusteredMapVersion = terracottaPlatformVersion
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
-  terracottaPassthroughTestingVersion = '1.0.4.beta'
+  terracottaPassthroughTestingVersion = '1.0.6.beta'
   entityTestLibVersion = terracottaPassthroughTestingVersion
-  galvanVersion = '1.0.4-beta'
+  galvanVersion = '1.0.6-beta'
 
   utils = new Utils(baseVersion, logger)
   isReleaseVersion = !baseVersion.endsWith('SNAPSHOT')

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactory.java
@@ -117,7 +117,7 @@ public class EhcacheClientEntityFactory {
               }
             } catch (ClusteredTierManagerConfigurationException e) {
               try {
-                ref.tryDestroy();
+                ref.destroy();
               } catch (EntityNotFoundException f) {
                 //ignore
               }
@@ -197,7 +197,7 @@ public class EhcacheClientEntityFactory {
       try {
         EntityRef<EhcacheClientEntity, UUID> ref = getEntityRef(identifier);
         try {
-          if (!ref.tryDestroy()) {
+          if (!ref.destroy()) {
             throw new EntityBusyException("Destroy operation failed; " + identifier + " clustered tier in use by other clients");
           }
         } catch (EntityNotProvidedException e) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLock.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLock.java
@@ -73,7 +73,7 @@ public class VoltronReadWriteLock {
 
   private boolean tryDestroy() {
     try {
-      return reference.tryDestroy();
+      return reference.destroy();
     } catch (EntityNotProvidedException e) {
       throw new AssertionError(e);
     } catch (EntityNotFoundException e) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/AbstractClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/AbstractClientEntityFactory.java
@@ -103,7 +103,7 @@ abstract class AbstractClientEntityFactory<E extends Entity, C> implements Clien
   public void destroy() throws EntityNotFoundException, EntityBusyException {
     EntityRef<E, C> ref = getEntityRef();
     try {
-      if (!ref.tryDestroy()) {
+      if (!ref.destroy()) {
         throw new EntityBusyException("Destroy operation failed; " + entityIdentifier + " clustered tier in use by other clients");
       }
     } catch (EntityNotProvidedException e) {

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactoryTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactoryTest.java
@@ -82,7 +82,7 @@ public class EhcacheClientEntityFactoryTest {
     verify(entityRef).create(any(UUID.class));
     verify(entity).configure(any(ServerSideConfiguration.class));
     verify(entity).close();
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
@@ -163,7 +163,7 @@ public class EhcacheClientEntityFactoryTest {
   @Test
   public void testDestroy() throws Exception {
     EntityRef<EhcacheClientEntity, Object> entityRef = mock(EntityRef.class);
-    doReturn(Boolean.TRUE).when(entityRef).tryDestroy();
+    doReturn(Boolean.TRUE).when(entityRef).destroy();
     Connection connection = mock(Connection.class);
     when(connection.getEntityRef(eq(EhcacheClientEntity.class), anyInt(), anyString())).thenReturn(entityRef);
 
@@ -171,13 +171,13 @@ public class EhcacheClientEntityFactoryTest {
 
     EhcacheClientEntityFactory factory = new EhcacheClientEntityFactory(connection);
     factory.destroy("test");
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
   public void testDestroyWhenNotExisting() throws Exception {
     EntityRef<EhcacheClientEntity, Object> entityRef = mock(EntityRef.class);
-    doThrow(EntityNotFoundException.class).when(entityRef).tryDestroy();
+    doThrow(EntityNotFoundException.class).when(entityRef).destroy();
     Connection connection = mock(Connection.class);
     when(connection.getEntityRef(eq(EhcacheClientEntity.class), anyInt(), anyString())).thenReturn(entityRef);
 

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLockClientTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLockClientTest.java
@@ -66,7 +66,7 @@ public class VoltronReadWriteLockClientTest {
     try {
       EntityRef<VoltronReadWriteLockClient, Void> ref = getEntityReference(connection);
       try {
-        assertThat(ref.tryDestroy(), is(true));
+        assertThat(ref.destroy(), is(true));
       } catch (EntityNotFoundException e) {
         //expected
       }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLockTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLockTest.java
@@ -174,7 +174,7 @@ public class VoltronReadWriteLockTest {
 
     lock.writeLock().unlock();
 
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
@@ -190,7 +190,7 @@ public class VoltronReadWriteLockTest {
 
     lock.readLock().unlock();
 
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
@@ -307,7 +307,7 @@ public class VoltronReadWriteLockTest {
 
     lock.tryWriteLock().unlock();
 
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
@@ -324,7 +324,7 @@ public class VoltronReadWriteLockTest {
 
     lock.tryReadLock().unlock();
 
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
@@ -372,7 +372,7 @@ public class VoltronReadWriteLockTest {
     VoltronReadWriteLock lock = new VoltronReadWriteLock(connection, "TestLock");
 
     assertThat(lock.tryWriteLock(), nullValue());
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 
   @Test
@@ -388,6 +388,6 @@ public class VoltronReadWriteLockTest {
     VoltronReadWriteLock lock = new VoltronReadWriteLock(connection, "TestLock");
 
     assertThat(lock.tryReadLock(), nullValue());
-    verify(entityRef).tryDestroy();
+    verify(entityRef).destroy();
   }
 }

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   testCompile "org.terracotta:entity-test-lib:$parent.entityTestLibVersion"
   testCompile "org.terracotta:passthrough-server:$parent.entityTestLibVersion"
   testCompile "org.terracotta.management:monitoring-service:$parent.managementVersion"
+  testCompile "org.terracotta.management:monitoring-service-entity:$parent.managementVersion"
   testCompile "org.terracotta.management:management-entity-server:$parent.managementVersion"
   testCompile "org.terracotta.entities:clustered-map-server:$parent.terracottaPlatformVersion"
   testCompile "com.fasterxml.jackson.core:jackson-databind:2.7.5"

--- a/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
+++ b/management/src/main/java/org/ehcache/management/cluster/DefaultClusteringManagementService.java
@@ -33,10 +33,10 @@ import org.ehcache.spi.service.ServiceProvider;
 import org.slf4j.LoggerFactory;
 import org.terracotta.exception.EntityAlreadyExistsException;
 import org.terracotta.exception.EntityNotFoundException;
-import org.terracotta.management.entity.ManagementAgentConfig;
-import org.terracotta.management.entity.ManagementAgentVersion;
-import org.terracotta.management.entity.client.ManagementAgentEntity;
-import org.terracotta.management.entity.client.ManagementAgentService;
+import org.terracotta.management.entity.management.ManagementAgentConfig;
+import org.terracotta.management.entity.management.ManagementAgentVersion;
+import org.terracotta.management.entity.management.client.ManagementAgentEntity;
+import org.terracotta.management.entity.management.client.ManagementAgentService;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
 

--- a/management/src/test/java/org/ehcache/core/EhcacheManagerToStringTest.java
+++ b/management/src/test/java/org/ehcache/core/EhcacheManagerToStringTest.java
@@ -31,7 +31,6 @@ import org.ehcache.config.builders.WriteBehindConfigurationBuilder;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration;
-import org.ehcache.management.cluster.ClusteringManagementServiceTest;
 import org.ehcache.management.config.EhcacheStatisticsProviderConfiguration;
 import org.ehcache.management.registry.DefaultManagementRegistryConfiguration;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
@@ -41,10 +40,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.terracotta.entity.map.TerracottaClusteredMapClientService;
 import org.terracotta.entity.map.server.TerracottaClusteredMapService;
-import org.terracotta.management.entity.client.ManagementAgentEntityClientService;
-import org.terracotta.management.entity.server.ManagementAgentEntityServerService;
+import org.terracotta.management.entity.management.client.ManagementAgentEntityClientService;
+import org.terracotta.management.entity.management.server.ManagementAgentEntityServerService;
 import org.terracotta.management.service.monitoring.IMonitoringConsumer;
-import org.terracotta.management.service.monitoring.MonitoringServiceConfiguration;
 import org.terracotta.offheapresource.OffHeapResourcesConfiguration;
 import org.terracotta.offheapresource.OffHeapResourcesProvider;
 import org.terracotta.offheapresource.config.OffheapResourcesType;
@@ -63,7 +61,6 @@ import java.util.concurrent.TimeUnit;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class EhcacheManagerToStringTest {
 
@@ -179,9 +176,6 @@ public class EhcacheManagerToStringTest {
     // clustered map (required by ehcache)
     activeServer.registerClientEntityService(new TerracottaClusteredMapClientService());
     activeServer.registerServerEntityService(new TerracottaClusteredMapService());
-
-    // monitoring service
-    activeServer.registerServiceProvider(new ClusteringManagementServiceTest.HackedMonitoringServiceProvider(), new MonitoringServiceConfiguration().setDebug(false));
 
     // off-heap service
     OffheapResourcesType offheapResourcesType = new OffheapResourcesType();


### PR DESCRIPTION
__Updates:__

- apis - 1.0.6.beta
- passthrough-testing - 1.0.6.beta
- config - 10.0.6.beta
- core - 5.0.6-beta
- galvan - 1.0.6-beta

Before merging this PR, tc-platform __5.0.5.beta__ needs to be released.

Notes:

- Needed to adapt to changes from Terracotta-OSS/terracotta-platform#132
- Using new test entity to test the state of the monitoring tree
- monitoring service is now a builtin service
- management packages have been "normalized"

![http://i.imgur.com/k4fViTh.png](http://i.imgur.com/k4fViTh.png)