### PR TITLE
Fix #1393 Proper task dependencies for distribution creation

### DIFF
--- a/clustered/clustered-dist/build.gradle
+++ b/clustered/clustered-dist/build.gradle
@@ -117,5 +117,4 @@ distZip {
   classifier = 'kit'
 }
 
-distTar.dependsOn copyDocs, javadocJar, project(':dist').javadocJar
-distZip.dependsOn copyDocs, javadocJar, project(':dist').javadocJar
+[distTar, distZip, installDist]*.dependsOn copyDocs, javadocJar, project(':dist').jar, project(':dist').javadocJar


### PR DESCRIPTION
The dependency on :dist:jar was missing and code has been refactored
to be more compact. The installDist task is now properly configured
as well.