### PR TITLE
Rewriting ClusteredManagementServiceTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.6.beta2'
+  terracottaPlatformVersion = '5.0.6.beta3'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.0.6.beta'
   terracottaCoreVersion = '5.0.6-beta'

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatistics.java
@@ -74,7 +74,6 @@ class EhcacheStatistics extends ExposedCacheBinding {
   private static final Set<CacheOperationOutcomes.RemoveOutcome> ALL_CACHE_REMOVE_OUTCOMES = EnumSet.allOf(CacheOperationOutcomes.RemoveOutcome.class);
   private static final Set<CacheOperationOutcomes.GetOutcome> GET_WITH_LOADER_OUTCOMES = EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER, CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER);
   private static final Set<CacheOperationOutcomes.GetOutcome> GET_NO_LOADER_OUTCOMES = EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER, CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER);
-  private static final Set<CacheOperationOutcomes.CacheLoadingOutcome> ALL_CACHE_LOADER_OUTCOMES = EnumSet.allOf(CacheOperationOutcomes.CacheLoadingOutcome.class);
 
   private final StatisticsRegistry statisticsRegistry;
   private final Map<String, OperationStatistic<?>> countStatistics;

--- a/management/src/test/java/org/ehcache/management/cluster/AbstractClusteringManagementTest.java
+++ b/management/src/test/java/org/ehcache/management/cluster/AbstractClusteringManagementTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.management.cluster;
+
+import org.ehcache.clustered.client.internal.EhcacheClientEntityService;
+import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockEntityClientService;
+import org.ehcache.clustered.lock.server.VoltronReadWriteLockServerEntityService;
+import org.ehcache.clustered.server.EhcacheServerEntityService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.management.entity.management.ManagementAgentConfig;
+import org.terracotta.management.entity.management.client.ContextualReturnListener;
+import org.terracotta.management.entity.management.client.ManagementAgentEntityClientService;
+import org.terracotta.management.entity.management.client.ManagementAgentEntityFactory;
+import org.terracotta.management.entity.management.client.ManagementAgentService;
+import org.terracotta.management.entity.management.server.ManagementAgentEntityServerService;
+import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntity;
+import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntityClientService;
+import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntityFactory;
+import org.terracotta.management.entity.monitoring.server.MonitoringServiceEntityServerService;
+import org.terracotta.management.model.call.ContextualReturn;
+import org.terracotta.management.model.call.Parameter;
+import org.terracotta.management.model.cluster.ClientIdentifier;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.offheapresource.OffHeapResourcesConfiguration;
+import org.terracotta.offheapresource.OffHeapResourcesProvider;
+import org.terracotta.offheapresource.config.OffheapResourcesType;
+import org.terracotta.offheapresource.config.ResourceType;
+import org.terracotta.passthrough.PassthroughClusterControl;
+import org.terracotta.passthrough.PassthroughServer;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public abstract class AbstractClusteringManagementTest {
+
+  protected static MonitoringServiceEntity consumer;
+
+  private static PassthroughClusterControl stripeControl;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    PassthroughServer activeServer = new PassthroughServer();
+    activeServer.setServerName("server-1");
+    activeServer.setBindPort(9510);
+    activeServer.setGroupPort(9610);
+
+    // management agent entity
+    activeServer.registerServerEntityService(new ManagementAgentEntityServerService());
+    activeServer.registerClientEntityService(new ManagementAgentEntityClientService());
+
+    // ehcache entity
+    activeServer.registerServerEntityService(new EhcacheServerEntityService());
+    activeServer.registerClientEntityService(new EhcacheClientEntityService());
+
+    // RW lock entity (required by ehcache)
+    activeServer.registerServerEntityService(new VoltronReadWriteLockServerEntityService());
+    activeServer.registerClientEntityService(new VoltronReadWriteLockEntityClientService());
+
+    activeServer.registerServerEntityService(new MonitoringServiceEntityServerService());
+    activeServer.registerClientEntityService(new MonitoringServiceEntityClientService());
+
+    // off-heap service
+    OffheapResourcesType offheapResourcesType = new OffheapResourcesType();
+    ResourceType resourceType = new ResourceType();
+    resourceType.setName("primary-server-resource");
+    resourceType.setUnit(org.terracotta.offheapresource.config.MemoryUnit.MB);
+    resourceType.setValue(BigInteger.TEN);
+    offheapResourcesType.getResource().add(resourceType);
+    activeServer.registerServiceProvider(new OffHeapResourcesProvider(), new OffHeapResourcesConfiguration(offheapResourcesType));
+
+    stripeControl = new PassthroughClusterControl("server-1", activeServer);
+
+    consumer = new MonitoringServiceEntityFactory(ConnectionFactory.connect(URI.create("passthrough://server-1:9510/cluster-1"), new Properties())).retrieveOrCreate("MonitoringConsumerEntity");
+    consumer.createBestEffortBuffer("client-notifications", 1024, Serializable[].class);
+    consumer.createBestEffortBuffer("client-statistics", 1024, Serializable[].class);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    if (stripeControl != null) {
+      stripeControl.tearDown();
+    }
+  }
+
+  @After
+  public final void clearBuffers() throws Exception {
+    clear();
+  }
+
+  protected final void clear() {
+    while (consumer.readBuffer("client-notifications", Serializable[].class) != null) ;
+    while (consumer.readBuffer("client-statistics", Serializable[].class) != null) ;
+  }
+
+  protected static void sendManagementCallToCollectStats(String... statNames) throws Exception {
+    try (Connection managementConsole = ConnectionFactory.connect(URI.create("passthrough://server-1:9510/"), new Properties())) {
+      ManagementAgentService agent = new ManagementAgentService(new ManagementAgentEntityFactory(managementConsole).retrieveOrCreate(new ManagementAgentConfig()));
+
+      assertThat(agent.getManageableClients().size(), equalTo(2));
+
+      // find Ehcache client
+      ClientIdentifier me = agent.getClientIdentifier();
+      ClientIdentifier client = null;
+      for (ClientIdentifier clientIdentifier : agent.getManageableClients()) {
+        if (!clientIdentifier.equals(me)) {
+          client = clientIdentifier;
+          break;
+        }
+      }
+      assertThat(client, is(notNullValue()));
+      final ClientIdentifier ehcacheClientIdentifier = client;
+
+      CountDownLatch callCompleted = new CountDownLatch(1);
+      AtomicReference<String> managementCallId = new AtomicReference<>();
+      BlockingQueue<ContextualReturn<?>> returns = new LinkedBlockingQueue<>();
+
+      agent.setContextualReturnListener(new ContextualReturnListener() {
+        @Override
+        public void onContextualReturn(ClientIdentifier from, String id, ContextualReturn<?> aReturn) {
+          try {
+            assertEquals(ehcacheClientIdentifier, from);
+            // make sure the call completed
+            callCompleted.await(10, TimeUnit.SECONDS);
+            assertEquals(managementCallId.get(), id);
+            returns.offer(aReturn);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+
+      managementCallId.set(agent.call(
+        ehcacheClientIdentifier,
+        Context.create("cacheManagerName", "my-super-cache-manager"),
+        "StatisticCollectorCapability",
+        "updateCollectedStatistics",
+        Collection.class,
+        new Parameter("StatisticsCapability"),
+        new Parameter(asList(statNames), Collection.class.getName())));
+
+      // now we're sure the call completed
+      callCompleted.countDown();
+
+      // ensure the call is made
+      returns.take();
+    }
+  }
+
+  protected static ContextualStatistics[] waitForNextStats() {
+    // uses the monitoring consumre entity to get the content of the stat buffer when some stats are collected
+    Serializable[] serializables;
+    while ((serializables = consumer.readBuffer("client-statistics", Serializable[].class)) == null) { Thread.yield(); }
+    return (ContextualStatistics[]) serializables[1];
+  }
+
+}

--- a/management/src/test/java/org/ehcache/management/cluster/ClusteringManagementServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/cluster/ClusteringManagementServiceTest.java
@@ -18,12 +18,9 @@ package org.ehcache.management.cluster;
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
 import org.ehcache.Status;
+import org.ehcache.ValueSupplier;
 import org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder;
 import org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder;
-import org.ehcache.clustered.client.internal.EhcacheClientEntityService;
-import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockEntityClientService;
-import org.ehcache.clustered.lock.server.VoltronReadWriteLockServerEntityService;
-import org.ehcache.clustered.server.EhcacheServerEntityService;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.units.EntryUnit;
@@ -32,299 +29,220 @@ import org.ehcache.management.config.EhcacheStatisticsProviderConfiguration;
 import org.ehcache.management.registry.DefaultManagementRegistryConfiguration;
 import org.ehcache.xml.XmlConfiguration;
 import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.terracotta.connection.Connection;
-import org.terracotta.connection.ConnectionFactory;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.terracotta.management.entity.management.ManagementAgentConfig;
-import org.terracotta.management.entity.management.client.ContextualReturnListener;
-import org.terracotta.management.entity.management.client.ManagementAgentEntityClientService;
 import org.terracotta.management.entity.management.client.ManagementAgentEntityFactory;
-import org.terracotta.management.entity.management.client.ManagementAgentService;
-import org.terracotta.management.entity.management.server.ManagementAgentEntityServerService;
-import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntity;
-import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntityClientService;
-import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntityFactory;
-import org.terracotta.management.entity.monitoring.server.MonitoringServiceEntityServerService;
-import org.terracotta.management.model.call.ContextualReturn;
-import org.terracotta.management.model.call.Parameter;
 import org.terracotta.management.model.capabilities.Capability;
-import org.terracotta.management.model.cluster.ClientIdentifier;
-import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.management.model.stats.history.CounterHistory;
 import org.terracotta.management.model.stats.primitive.Counter;
-import org.terracotta.offheapresource.OffHeapResourcesConfiguration;
-import org.terracotta.offheapresource.OffHeapResourcesProvider;
-import org.terracotta.offheapresource.config.OffheapResourcesType;
-import org.terracotta.offheapresource.config.ResourceType;
-import org.terracotta.passthrough.PassthroughClusterControl;
-import org.terracotta.passthrough.PassthroughServer;
 
 import java.io.Serializable;
-import java.math.BigInteger;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Properties;
 import java.util.TreeSet;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Arrays.asList;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-public class ClusteringManagementServiceTest {
+@RunWith(Parameterized.class)
+public class ClusteringManagementServiceTest extends AbstractClusteringManagementTest {
 
-  static MonitoringServiceEntity consumer;
-  static PassthroughClusterControl stripeControl;
-
-  CacheManager cacheManager;
-
-  @Test //(timeout = 10000)
-  public void test_programmatic_api() throws Exception {
-    cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-        // cluster config
-        .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("passthrough://server-1:9510/my-server-entity-1"))
-            .autoCreate()
-            .defaultServerResource("primary-server-resource"))
-        // management config
-        .using(new DefaultManagementRegistryConfiguration()
-            .addTags("webapp-1", "server-node-1")
-            .setCacheManagerAlias("my-super-cache-manager")
-            .addConfiguration(new EhcacheStatisticsProviderConfiguration(
-                1, TimeUnit.MINUTES,
-                100, 1, TimeUnit.SECONDS,
-                2, TimeUnit.SECONDS))) // TTD reduce to 2 seconds so that the stat collector run faster
-        // cache config
-        .withCache("cache-1", CacheConfigurationBuilder.newCacheConfigurationBuilder(
-            String.class, String.class,
-            newResourcePoolsBuilder()
-                .heap(10, EntryUnit.ENTRIES)
-                .offheap(1, MemoryUnit.MB)
-                .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
-            .build())
-        .build(true);
-
-    runTest();
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+      {
+        new ValueSupplier<CacheManager>() {
+          @Override
+          public CacheManager value() {
+            return CacheManagerBuilder.newCacheManagerBuilder()
+              // cluster config
+              .with(ClusteringServiceConfigurationBuilder.cluster(URI.create("passthrough://server-1:9510/my-server-entity-1"))
+                .autoCreate()
+                .defaultServerResource("primary-server-resource"))
+              // management config
+              .using(new DefaultManagementRegistryConfiguration()
+                .addTags("webapp-1", "server-node-1")
+                .setCacheManagerAlias("my-super-cache-manager")
+                .addConfiguration(new EhcacheStatisticsProviderConfiguration(
+                  1, TimeUnit.MINUTES,
+                  100, 1, TimeUnit.SECONDS,
+                  2, TimeUnit.SECONDS))) // TTD reduce to 2 seconds so that the stat collector runs faster
+              // cache config
+              .withCache("cache-1", CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                String.class, String.class,
+                newResourcePoolsBuilder()
+                  .heap(10, EntryUnit.ENTRIES)
+                  .offheap(1, MemoryUnit.MB)
+                  .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+                .build())
+              .build(true);
+          }
+        }
+      }, {
+      new ValueSupplier<CacheManager>() {
+        @Override
+        public CacheManager value() {
+          CacheManager cacheManager = CacheManagerBuilder.newCacheManager(new XmlConfiguration(getClass().getResource("/ehcache-management-clustered.xml")));
+          cacheManager.init();
+          return cacheManager;
+        }
+      }
+    }});
   }
 
-  @Test(timeout = 10000)
-  public void test_xml_api() throws Exception {
+  @Rule
+  public final Timeout globalTimeout = new Timeout(10000);
 
-    cacheManager = CacheManagerBuilder.newCacheManager(new XmlConfiguration(getClass().getResource("/ehcache-management-clustered.xml")));
-    cacheManager.init();
+  private final ValueSupplier<CacheManager> cacheManagerValueSupplier;
 
-    runTest();
+  private CacheManager cacheManager;
+  private String clientIdentifier;
+  private long consumerId;
+
+  public ClusteringManagementServiceTest(ValueSupplier<CacheManager> cacheManagerValueSupplier) {
+    this.cacheManagerValueSupplier = cacheManagerValueSupplier;
   }
 
-  private void runTest() throws Exception {
-    // assert management registry has been correctly exposed in voltron
-    long consumerId = consumer.getConsumerId(ManagementAgentConfig.ENTITY_TYPE, ManagementAgentEntityFactory.ENTITYNAME);
-    String clientIdentifier = consumer.getChildNamesForNode(consumerId, "management", "clients").iterator().next();
+  @Before
+  public void init() throws Exception {
+    this.cacheManager = cacheManagerValueSupplier.value();
+
+    // ensure the CM is running and get its client id
+    assertThat(cacheManager.getStatus(), equalTo(Status.AVAILABLE));
+    consumerId = consumer.getConsumerId(ManagementAgentConfig.ENTITY_TYPE, ManagementAgentEntityFactory.ENTITYNAME);
+    clientIdentifier = consumer.getChildNamesForNode(consumerId, "management", "clients").iterator().next();
+  }
+
+  @After
+  public void close() throws Exception {
+    if (cacheManager != null && cacheManager.getStatus() == Status.AVAILABLE) {
+      cacheManager.close();
+    }
+  }
+
+  @Test
+  public void test_tags_exposed() throws Exception {
     String[] tags = consumer.getValueForNode(consumerId, new String[]{"management", "clients", clientIdentifier, "tags"}, String[].class);
     assertThat(tags, equalTo(new String[]{"server-node-1", "webapp-1"}));
+  }
+
+  @Test
+  public void test_contextContainer_exposed() throws Exception {
     ContextContainer contextContainer = consumer.getValueForNode(consumerId, new String[]{"management", "clients", clientIdentifier, "registry", "contextContainer"}, ContextContainer.class);
     assertThat(contextContainer.getValue(), equalTo("my-super-cache-manager"));
     assertThat(contextContainer.getSubContexts(), hasSize(1));
     assertThat(contextContainer.getSubContexts().iterator().next().getValue(), equalTo("cache-1"));
+  }
+
+  @Test
+  public void test_capabilities_exposed() throws Exception {
     Capability[] capabilities = consumer.getValueForNode(consumerId, new String[]{"management", "clients", clientIdentifier, "registry", "capabilities"}, Capability[].class);
     assertThat(capabilities.length, equalTo(5));
+    assertThat(capabilities[0].getName(), equalTo("ActionsCapability"));
+    assertThat(capabilities[1].getName(), equalTo("StatisticsCapability"));
+    assertThat(capabilities[2].getName(), equalTo("StatisticCollectorCapability"));
+    assertThat(capabilities[3].getName(), equalTo("SettingsCapability"));
+    assertThat(capabilities[4].getName(), equalTo("ManagementAgentService"));
+    assertThat(capabilities[0].getDescriptors(), hasSize(4));
+    assertThat(capabilities[1].getDescriptors(), hasSize(13));
+  }
 
-    remotelyUpdateCollectedStatistics();
+  @Test
+  public void test_notifs_sent_at_CM_init() throws Exception {
+    assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_REGISTRY_UPDATED"));
+    assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_TAGS_UPDATED"));
+    assertThat(consumer.readBuffer("client-notifications", Serializable[].class), is(nullValue()));
+  }
 
-    // issue some puts to record some stats
-    Cache<String, String> cache1 = cacheManager.getCache("cache-1", String.class, String.class);
-    cache1.put("key1", "val");
-    cache1.put("key2", "val");
+  @Test
+  public void test_notifs_on_add_cache() throws Exception {
+    clear();
 
-    // create dynamically another cache to get the client-side notif
     cacheManager.createCache("cache-2", CacheConfigurationBuilder.newCacheConfigurationBuilder(
-        String.class, String.class,
-        newResourcePoolsBuilder()
-            .heap(10, EntryUnit.ENTRIES)
-            .offheap(1, MemoryUnit.MB)
-            .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
-        .build());
+      String.class, String.class,
+      newResourcePoolsBuilder()
+        .heap(10, EntryUnit.ENTRIES)
+        .offheap(1, MemoryUnit.MB)
+        .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+      .build());
 
-    // assert that the management registry exposed in voltron has been updated
-    contextContainer = consumer.getValueForNode(consumerId, new String[]{"management", "clients", clientIdentifier, "registry", "contextContainer"}, ContextContainer.class);
-    assertThat(contextContainer.getValue(), equalTo("my-super-cache-manager"));
+    ContextContainer contextContainer = consumer.getValueForNode(consumerId, new String[]{"management", "clients", clientIdentifier, "registry", "contextContainer"}, ContextContainer.class);
     assertThat(contextContainer.getSubContexts(), hasSize(2));
-    assertThat(contextContainer.getSubContexts().iterator().next().getValue(), equalTo("cache-1"));
 
     Collection<String> cNames = new TreeSet<String>();
-    Collection<String> expectedCNames = new TreeSet<String>(Arrays.asList("cache-1", "cache-2"));
     for (ContextContainer container : contextContainer.getSubContexts()) {
       cNames.add(container.getValue());
     }
-    assertThat(cNames, equalTo(expectedCNames));
+    assertThat(cNames, equalTo(new TreeSet<String>(Arrays.asList("cache-1", "cache-2"))));
 
-    // verify the notification has been received in voltron
-    assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_REGISTRY_UPDATED"));
-    assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_TAGS_UPDATED"));
     assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_REGISTRY_UPDATED"));
     assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_REGISTRY_UPDATED"));
     assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CACHE_ADDED"));
     assertThat(consumer.readBuffer("client-notifications", Serializable[].class), is(nullValue()));
+  }
 
-    // do some put also
-    Cache<String, String> cache2 = cacheManager.getCache("cache-2", String.class, String.class);
-    cache2.put("key1", "val");
-    cache2.put("key2", "val");
-    cache2.put("key3", "val");
+  @Test
+  public void test_notifs_on_remove_cache() throws Exception {
+    test_notifs_on_add_cache();
 
-    // verify stats have been received too
-    ContextualStatistics[] stats;
-    Serializable[] serializables;
-    while ((serializables = consumer.readBuffer("client-statistics", Serializable[].class)) == null) { Thread.sleep(500); }
-    stats = (ContextualStatistics[]) serializables[1];
-    assertThat(stats.length, equalTo(2));
-    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
-    assertThat(stats[1].getContext().get("cacheName"), equalTo("cache-2"));
-    assertThat(stats[0].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(2L));
-    assertThat(stats[1].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(3L));
-
-    cache1.put("key1", "val");
-    cache1.put("key2", "val");
-    cache2.put("key1", "val");
-    cache2.put("key2", "val");
-    cache2.put("key3", "val");
-
-    // wait for next stats and verify
-    while ((serializables = consumer.readBuffer("client-statistics", Serializable[].class)) == null) { Thread.sleep(500); }
-    stats = (ContextualStatistics[]) serializables[1];
-    assertThat(stats.length, equalTo(2));
-    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
-    assertThat(stats[1].getContext().get("cacheName"), equalTo("cache-2"));
-    assertThat(stats[0].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(4L));
-    assertThat(stats[1].getStatistic(Counter.class, "PutCounter").getValue(), equalTo(6L));
-
-    // remove a cache
     cacheManager.removeCache("cache-2");
 
-    // ensure we got the notification server-side
     assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_REGISTRY_UPDATED"));
     assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CLIENT_REGISTRY_UPDATED"));
     assertThat(((ContextualNotification) consumer.readBuffer("client-notifications", Serializable[].class)[1]).getType(), equalTo("CACHE_REMOVED"));
     assertThat(consumer.readBuffer("client-notifications", Serializable[].class), is(nullValue()));
   }
 
-  private void remotelyUpdateCollectedStatistics() throws Exception {
-    try (Connection managementConsole = ConnectionFactory.connect(URI.create("passthrough://server-1:9510/"), new Properties())) {
-      ManagementAgentService agent = new ManagementAgentService(new ManagementAgentEntityFactory(managementConsole).retrieveOrCreate(new ManagementAgentConfig()));
+  @Test
+  public void test_stats_collection() throws Exception {
 
-      assertThat(agent.getManageableClients().size(), equalTo(2));
+    sendManagementCallToCollectStats("GetCounter", "InexistingRate", "AllCacheGetCount");
 
-      // find Ehcache client
-      ClientIdentifier me = agent.getClientIdentifier();
-      ClientIdentifier client = null;
-      for (ClientIdentifier clientIdentifier : agent.getManageableClients()) {
-        if (!clientIdentifier.equals(me)) {
-          client = clientIdentifier;
-          break;
-        }
-      }
+    Cache<String, String> cache1 = cacheManager.getCache("cache-1", String.class, String.class);
+    cache1.put("key1", "val");
+    cache1.put("key2", "val");
 
-      assertThat(client, is(notNullValue()));
-      final ClientIdentifier ehcacheClientIdentifier = client;
+    cache1.get("key1");
+    cache1.get("key2");
 
-      CountDownLatch callCompleted = new CountDownLatch(1);
-      AtomicReference<String> managementCallId = new AtomicReference<>();
-      BlockingQueue<ContextualReturn<?>> returns = new LinkedBlockingQueue<>();
+    // get the stats (we are getting the primitive counter, not the sample history)
+    ContextualStatistics[] stats = waitForNextStats();
 
-      agent.setContextualReturnListener(new ContextualReturnListener() {
-        @Override
-        public void onContextualReturn(ClientIdentifier from, String id, ContextualReturn<?> aReturn) {
-          try {
-            assertEquals(ehcacheClientIdentifier, from);
-            // make sure the call completed
-            callCompleted.await(10, TimeUnit.SECONDS);
-            assertEquals(managementCallId.get(), id);
-            returns.offer(aReturn);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
+    assertThat(stats.length, equalTo(1));
+    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
+    assertThat(stats[0].getStatistic(Counter.class, "GetCounter").getValue(), equalTo(2L));
 
-      managementCallId.set(agent.call(
-          ehcacheClientIdentifier,
-          Context.create("cacheManagerName", "my-super-cache-manager"),
-          "StatisticCollectorCapability",
-          "updateCollectedStatistics",
-          Collection.class,
-          new Parameter("StatisticsCapability"),
-          new Parameter(asList("PutCounter", "InexistingRate"), Collection.class.getName())));
+    // first collect of a sample gives no value because it "triggers" the stat computation
+    // this is how the internal ehcache's stat framework works: first call to a sample activates it.
+    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
+    assertThat(stats[0].getStatistic(CounterHistory.class, "AllCacheGetCount").getValue().length, equalTo(0));
 
-      // now we're sure the call completed
-      callCompleted.countDown();
+    // do some other operations
+    cache1.get("key1");
+    cache1.get("key2");
 
-      // ensure the call is made
-      returns.take();
-    }
-  }
+    stats = waitForNextStats();
 
-  @BeforeClass
-  public static void beforeClass() throws Exception {
-    PassthroughServer activeServer = new PassthroughServer();
-    activeServer.setServerName("server-1");
-    activeServer.setBindPort(9510);
-    activeServer.setGroupPort(9610);
-
-    // management agent entity
-    activeServer.registerServerEntityService(new ManagementAgentEntityServerService());
-    activeServer.registerClientEntityService(new ManagementAgentEntityClientService());
-
-    // ehcache entity
-    activeServer.registerServerEntityService(new EhcacheServerEntityService());
-    activeServer.registerClientEntityService(new EhcacheClientEntityService());
-
-    // RW lock entity (required by ehcache)
-    activeServer.registerServerEntityService(new VoltronReadWriteLockServerEntityService());
-    activeServer.registerClientEntityService(new VoltronReadWriteLockEntityClientService());
-
-    activeServer.registerServerEntityService(new MonitoringServiceEntityServerService());
-    activeServer.registerClientEntityService(new MonitoringServiceEntityClientService());
-
-    // off-heap service
-    OffheapResourcesType offheapResourcesType = new OffheapResourcesType();
-    ResourceType resourceType = new ResourceType();
-    resourceType.setName("primary-server-resource");
-    resourceType.setUnit(org.terracotta.offheapresource.config.MemoryUnit.MB);
-    resourceType.setValue(BigInteger.TEN);
-    offheapResourcesType.getResource().add(resourceType);
-    activeServer.registerServiceProvider(new OffHeapResourcesProvider(), new OffHeapResourcesConfiguration(offheapResourcesType));
-
-    stripeControl = new PassthroughClusterControl("server-1", activeServer);
-
-    consumer = new MonitoringServiceEntityFactory(ConnectionFactory.connect(URI.create("passthrough://server-1:9510/cluster-1"), new Properties())).retrieveOrCreate("MonitoringConsumerEntity");
-    consumer.createBestEffortBuffer("client-notifications", 1024, Serializable[].class);
-    consumer.createBestEffortBuffer("client-statistics", 1024, Serializable[].class);
-  }
-
-  @AfterClass
-  public static void afterClass() throws Exception {
-    stripeControl.tearDown();
-  }
-
-  @After
-  public void after() throws Exception {
-    if (cacheManager != null && cacheManager.getStatus() == Status.AVAILABLE) {
-      cacheManager.close();
-    }
+    assertThat(stats.length, equalTo(1));
+    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
+    assertThat(stats[0].getStatistic(Counter.class, "GetCounter").getValue(), equalTo(4L));
+    assertThat(stats[0].getContext().get("cacheName"), equalTo("cache-1"));
+    assertThat(stats[0].getStatistic(CounterHistory.class, "AllCacheGetCount").getValue().length, equalTo(1));
+    assertThat(stats[0].getStatistic(CounterHistory.class, "AllCacheGetCount").getValue()[0].getValue(), equalTo(4L));
   }
 
 }


### PR DESCRIPTION
This PR is just a rewriting of a big integration test in the management module.

It will help also #1390.

The idea is:

1. split the test in several smaller ones (which is done in this PR)
2. Separate the passthrough part from the tests (see below for reason)

Then, after:

1. Rebase #1390 on top of this PR so that #1390 uses this new test: #1390 will just need to adapt the statistic part, IF needed.
2. Move this test in the clusterd-it module (which will be done after because it requires to get rid of the passthrough things, use galvan instead, use the new release of tc-platform, and also requires that an issue in platform is fixed first: Terracotta-OSS/terracotta-core#297)