### PR TITLE
Resolves #883

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
@@ -87,7 +87,7 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
         newResourcePoolsBuilder()
           .heap(10, EntryUnit.ENTRIES)
           .offheap(1, MemoryUnit.MB)
-          .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+          .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 2, MemoryUnit.MB)))
         .build())
       .build(true);
 
@@ -147,7 +147,7 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
       newResourcePoolsBuilder()
         .heap(10, EntryUnit.ENTRIES)
         .offheap(1, MemoryUnit.MB)
-        .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+        .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 2, MemoryUnit.MB)))
       .build());
 
     ContextContainer contextContainer = consumer.getValueForNode(consumerId, new String[]{"management", "clients", clientIdentifier, "registry", "contextContainer"}, ContextContainer.class);

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheManagerToStringTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheManagerToStringTest.java
@@ -114,7 +114,7 @@ public class EhcacheManagerToStringTest extends AbstractClusteringManagementTest
             newResourcePoolsBuilder()
                 .heap(10, EntryUnit.ENTRIES)
                 .offheap(1, MemoryUnit.MB)
-                .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB)))
+                .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", 2, MemoryUnit.MB)))
             .build())
         .build(true);
 

--- a/clustered/integration-test/src/test/resources/clusteredConfiguration.txt
+++ b/clustered/integration-test/src/test/resources/clusteredConfiguration.txt
@@ -14,7 +14,7 @@ caches:
                     size: 1 MB
                     tierHeight: 1000
                 clustered-dedicated:
-                    size: 1 MB (persistent)
+                    size: 2 MB (persistent)
                     tierHeight: 10
 services:
     - org.ehcache.clustered.client.config.ClusteringServiceConfiguration:


### PR DESCRIPTION
Resolves https://github.com/ehcache/ehcache3/issues/883
sorts the tiers by reverse tier priority (e.g. Heap precedes Off-Heap) instead of by enum index