### PR TITLE
Closes #1433 StateRepository provides StateHolder instead of ConcurrentMap

### DIFF
--- a/api/src/main/java/org/ehcache/spi/persistence/StateHolder.java
+++ b/api/src/main/java/org/ehcache/spi/persistence/StateHolder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.spi.persistence;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@code Map} like structure that can hold key value mappings.
+ *
+ * @param <K> type of Keys
+ * @param <V> type of Values
+ */
+public interface StateHolder<K, V> {
+
+  /**
+   * If the specified key is not already associated with a value (or is mapped
+   * to {@code null}) associates it with the given value and returns
+   * {@code null}, else returns the current value.
+   *
+   * @param key a key
+   * @param value a value
+   * @return the previous value associated with the specified key, or
+   *         {@code null} if there was no mapping for the key.
+   */
+  V putIfAbsent(K key, V value);
+
+  /**
+   * Retrieves the value mapped to the given {@code key}
+   *
+   * @param key a key
+   * @return  the value mapped to the key
+   */
+  V get(K key);
+
+  /**
+   * Retrieves all the entries in the {@code StateHolder} as a {@code Set} of {@code Map.Entry} instances.
+   *
+   * @return the set of this {@code StateHolder} mappings
+   */
+  Set<Map.Entry<K, V>> entrySet();
+
+}

--- a/api/src/main/java/org/ehcache/spi/persistence/StateRepository.java
+++ b/api/src/main/java/org/ehcache/spi/persistence/StateRepository.java
@@ -17,7 +17,6 @@
 package org.ehcache.spi.persistence;
 
 import java.io.Serializable;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * A repository allowing to preserve state in the context of a {@link org.ehcache.Cache}.
@@ -25,17 +24,17 @@ import java.util.concurrent.ConcurrentMap;
 public interface StateRepository {
 
   /**
-   * Gets a named persistent map rooted in the current {@code StateRepository}.
+   * Gets a named state holder rooted in the current {@code StateRepository}.
    * <P>
-   *   If the map existed already, it is returned with its content fully available.
+   *   If the state holder existed already, it is returned with its content fully available.
    * </P>
    *
-   * @param name the map name
-   * @param keyClass concrete map key type
-   * @param valueClass concrete map value type
-   * @param <K> the map key type, must be {@code Serializable}
-   * @param <V> the map value type, must be {@code Serializable}
-   * @return a map
+   * @param name the state holder name
+   * @param keyClass concrete key type
+   * @param valueClass concrete value type
+   * @param <K> the key type, must be {@code Serializable}
+   * @param <V> the value type, must be {@code Serializable}
+   * @return a state holder
    */
-  <K extends Serializable, V extends Serializable> ConcurrentMap<K, V> getPersistentConcurrentMap(String name, Class<K> keyClass, Class<V> valueClass);
+  <K extends Serializable, V extends Serializable> StateHolder<K, V> getPersistentStateHolder(String name, Class<K> keyClass, Class<V> valueClass);
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/ClusteredStateHolder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/ClusteredStateHolder.java
@@ -21,42 +21,20 @@ import org.ehcache.clustered.common.internal.exceptions.ClusterException;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 import org.ehcache.clustered.common.internal.messages.StateRepositoryMessageFactory;
 import org.ehcache.clustered.common.internal.messages.StateRepositoryOpMessage;
+import org.ehcache.spi.persistence.StateHolder;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeoutException;
 
-public class ConcurrentClusteredMap<K, V> implements ConcurrentMap<K, V> {
+public class ClusteredStateHolder<K, V> implements StateHolder<K, V> {
 
   private final StateRepositoryMessageFactory messageFactory;
   private final EhcacheClientEntity entity;
 
-  public ConcurrentClusteredMap(final String cacheId, final String mapId, final EhcacheClientEntity entity) {
+  public ClusteredStateHolder(final String cacheId, final String mapId, final EhcacheClientEntity entity) {
     this.messageFactory = new StateRepositoryMessageFactory(cacheId, mapId, entity.getClientId());
     this.entity = entity;
-  }
-
-  @Override
-  public int size() {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public boolean isEmpty() {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public boolean containsKey(final Object key) {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public boolean containsValue(final Object value) {
-    throw new UnsupportedOperationException("TODO");
   }
 
   @Override
@@ -76,38 +54,8 @@ public class ConcurrentClusteredMap<K, V> implements ConcurrentMap<K, V> {
   }
 
   @Override
-  public V put(final K key, final V value) {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public V remove(final Object key) {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public void putAll(final Map<? extends K, ? extends V> m) {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public void clear() {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public Set<K> keySet() {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public Collection<V> values() {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public Set<Entry<K, V>> entrySet() {
-    return (Set<Entry<K, V>>) getResponse(messageFactory.entrySetMessage());
+  public Set<Map.Entry<K, V>> entrySet() {
+    return (Set<Map.Entry<K, V>>) getResponse(messageFactory.entrySetMessage());
   }
 
   @Override
@@ -115,18 +63,4 @@ public class ConcurrentClusteredMap<K, V> implements ConcurrentMap<K, V> {
     return (V) getResponse(messageFactory.putIfAbsentMessage(key, value));
   }
 
-  @Override
-  public boolean remove(final Object key, final Object value) {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public boolean replace(final K key, final V oldValue, final V newValue) {
-    throw new UnsupportedOperationException("TODO");
-  }
-
-  @Override
-  public V replace(final K key, final V value) {
-    throw new UnsupportedOperationException("TODO");
-  }
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/ClusteredStateRepository.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/ClusteredStateRepository.java
@@ -18,10 +18,10 @@ package org.ehcache.clustered.client.internal.service;
 
 import org.ehcache.clustered.client.internal.EhcacheClientEntity;
 import org.ehcache.clustered.client.service.ClusteringService;
+import org.ehcache.spi.persistence.StateHolder;
 import org.ehcache.spi.persistence.StateRepository;
 
 import java.io.Serializable;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * ClusteredStateRepository
@@ -39,7 +39,7 @@ class ClusteredStateRepository implements StateRepository {
   }
 
   @Override
-  public <K extends Serializable, V extends Serializable> ConcurrentMap<K, V> getPersistentConcurrentMap(String name, Class<K> keyClass, Class<V> valueClass) {
-    return new ConcurrentClusteredMap<K, V>(clusterCacheIdentifier.getId(), composedId + "-" + name, clientEntity);
+  public <K extends Serializable, V extends Serializable> StateHolder<K, V> getPersistentStateHolder(String name, Class<K> keyClass, Class<V> valueClass) {
+    return new ClusteredStateHolder<K, V>(clusterCacheIdentifier.getId(), composedId + "-" + name, clientEntity);
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/ClusteredStateRepositoryReplicationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/service/ClusteredStateRepositoryReplicationTest.java
@@ -25,6 +25,7 @@ import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockEntityClie
 import org.ehcache.clustered.client.service.ClusteringService;
 import org.ehcache.clustered.lock.server.VoltronReadWriteLockServerEntityService;
 import org.ehcache.clustered.server.EhcacheServerEntityService;
+import org.ehcache.spi.persistence.StateHolder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +38,6 @@ import org.terracotta.passthrough.PassthroughTestHelpers;
 
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.util.concurrent.ConcurrentMap;
 
 import static org.ehcache.clustered.client.internal.UnitTestConnectionService.getOffheapResourcesType;
 import static org.hamcrest.Matchers.is;
@@ -102,15 +102,15 @@ public class ClusteredStateRepositoryReplicationTest {
       }
     }, "test", clientEntity);
 
-    ConcurrentMap<String, String> testMap = stateRepository.getPersistentConcurrentMap("testMap", String.class, String.class);
-    testMap.putIfAbsent("One", "One");
-    testMap.putIfAbsent("Two", "Two");
+    StateHolder<String, String> testHolder = stateRepository.getPersistentStateHolder("testHolder", String.class, String.class);
+    testHolder.putIfAbsent("One", "One");
+    testHolder.putIfAbsent("Two", "Two");
 
     clusterControl.terminateActive();
     clusterControl.waitForActive();
 
-    assertThat(testMap.get("One"), is("One"));
-    assertThat(testMap.get("Two"), is("Two"));
+    assertThat(testHolder.get("One"), is("One"));
+    assertThat(testHolder.get("Two"), is("Two"));
 
     service.stop();
   }

--- a/docs/src/docs/asciidoc/user/serializers-copiers.adoc
+++ b/docs/src/docs/asciidoc/user/serializers-copiers.adoc
@@ -151,12 +151,12 @@ To address these requirements you can have a `StatefulSerializer` implementation
 public void init(StateRepository repository) {
 }
 ```
-The `StateRepository.getPersistentConcurrentMap(String, Class<K>, Class<V>)` provides a `ConcurrentMap` that you can use to store any relevant state.
+The `StateRepository.getPersistentStateHolder(String, Class<K>, Class<V>)` provides a `StateHolder` (a map like structure) that you can use to store any relevant state.
 The `StateRepository` is provided by the authoritative tier of the cache and hence will have the same persistence properties of that tier.
-For persistent caches it is highly recommended that all state is stored in these maps as the users won't have to worry about the persistence aspects of this map as it is taken care by `Ehcache`.
+For persistent caches it is highly recommended that all state is stored in these holders as the users won't have to worry about the persistence aspects of this state holder as it is taken care by `Ehcache`.
 
-* In the case of a disk persistent cache, the contents of the map will be persisted locally on to the disk.
-* For clustered caches the contents are persisted in the cluster itself so that other clients using the same cache can also access the contents of the map.
+* In the case of a disk persistent cache, the contents of the state holder will be persisted locally on to the disk.
+* For clustered caches the contents are persisted in the cluster itself so that other clients using the same cache can also access the contents of the state holder.
 
 NOTE: The constructor with the signature `(ClassLoader classLoader, FileBasedPersistenceContext persistenceContext)`
       that existed till v3.1 has been removed since v3.2 in favor of `StatefulSerializer`s.

--- a/impl/src/main/java/org/ehcache/impl/persistence/FileBasedStateRepository.java
+++ b/impl/src/main/java/org/ehcache/impl/persistence/FileBasedStateRepository.java
@@ -20,6 +20,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.ehcache.CachePersistenceException;
 import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
+import org.ehcache.impl.serialization.TransientStateHolder;
+import org.ehcache.spi.persistence.StateHolder;
 import org.ehcache.spi.persistence.StateRepository;
 
 import java.io.Closeable;
@@ -42,10 +44,10 @@ import static org.ehcache.impl.persistence.FileUtils.safeIdentifier;
  */
 class FileBasedStateRepository implements StateRepository, Closeable {
 
-  private static final String MAP_FILE_PREFIX = "map-";
-  private static final String MAP_FILE_SUFFIX = ".bin";
+  private static final String HOLDER_FILE_PREFIX = "holder-";
+  private static final String HOLDER_FILE_SUFFIX = ".bin";
   private final File dataDirectory;
-  private final ConcurrentMap<String, Tuple> knownMaps;
+  private final ConcurrentMap<String, Tuple> knownHolders;
   private final AtomicInteger nextIndex = new AtomicInteger();
 
   FileBasedStateRepository(File directory) throws CachePersistenceException {
@@ -56,7 +58,7 @@ class FileBasedStateRepository implements StateRepository, Closeable {
       throw new IllegalArgumentException(directory + " is not a directory");
     }
     this.dataDirectory = directory;
-    knownMaps = new ConcurrentHashMap<String, Tuple>();
+    knownHolders = new ConcurrentHashMap<String, Tuple>();
     loadMaps();
   }
 
@@ -66,7 +68,7 @@ class FileBasedStateRepository implements StateRepository, Closeable {
       for (File file : dataDirectory.listFiles(new FilenameFilter() {
         @Override
         public boolean accept(File dir, String name) {
-          return name.endsWith(MAP_FILE_SUFFIX);
+          return name.endsWith(HOLDER_FILE_SUFFIX);
         }
       })) {
         FileInputStream fis = new FileInputStream(file);
@@ -78,7 +80,7 @@ class FileBasedStateRepository implements StateRepository, Closeable {
             if (nextIndex.get() <= tuple.index) {
               nextIndex.set(tuple.index + 1);
             }
-            knownMaps.put(name, tuple);
+            knownHolders.put(name, tuple);
           } finally {
             oin.close();
           }
@@ -87,13 +89,13 @@ class FileBasedStateRepository implements StateRepository, Closeable {
         }
       }
     } catch (Exception e) {
-      knownMaps.clear();
+      knownHolders.clear();
       throw new CachePersistenceException("Failed to load existing StateRepository data", e);
     }
   }
 
   private void saveMaps() throws IOException {
-    for (Map.Entry<String, Tuple> entry : knownMaps.entrySet()) {
+    for (Map.Entry<String, Tuple> entry : knownHolders.entrySet()) {
       File outFile = new File(dataDirectory, createFileName(entry));
       FileOutputStream fos = new FileOutputStream(outFile);
       try {
@@ -110,20 +112,20 @@ class FileBasedStateRepository implements StateRepository, Closeable {
     }
   }
 
-  private String createFileName(Map.Entry<String, Tuple> entry) {return MAP_FILE_PREFIX + entry.getValue().index + "-" + safeIdentifier(entry.getKey(), false) + MAP_FILE_SUFFIX;}
+  private String createFileName(Map.Entry<String, Tuple> entry) {return HOLDER_FILE_PREFIX + entry.getValue().index + "-" + safeIdentifier(entry.getKey(), false) + HOLDER_FILE_SUFFIX;}
 
   @Override
-  public <K extends Serializable, V extends Serializable> ConcurrentMap<K, V> getPersistentConcurrentMap(String name, Class<K> keyClass, Class<V> valueClass) {
-    Tuple result = knownMaps.get(name);
+  public <K extends Serializable, V extends Serializable> StateHolder<K, V> getPersistentStateHolder(String name, Class<K> keyClass, Class<V> valueClass) {
+    Tuple result = knownHolders.get(name);
     if (result == null) {
-      ConcurrentHashMap<K, V> newMap = new ConcurrentHashMap<K, V>();
-      result = knownMaps.putIfAbsent(name, new Tuple(nextIndex.getAndIncrement(), newMap));
+      StateHolder<K, V> holder = new TransientStateHolder<K, V>();
+      result = knownHolders.putIfAbsent(name, new Tuple(nextIndex.getAndIncrement(), holder));
 
       if (result == null) {
-        return newMap;
+        return holder;
       }
     }
-    return (ConcurrentMap<K, V>) result.map;
+    return (StateHolder<K, V>) result.holder;
   }
 
   @Override
@@ -133,11 +135,11 @@ class FileBasedStateRepository implements StateRepository, Closeable {
 
   static class Tuple implements Serializable {
     final int index;
-    final ConcurrentMap<?, ?> map;
+    final StateHolder<?, ?> holder;
 
-    Tuple(int index, ConcurrentMap<?, ?> map) {
+    Tuple(int index, StateHolder<?, ?> holder) {
       this.index = index;
-      this.map = map;
+      this.holder = holder;
     }
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/serialization/CompactJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/impl/serialization/CompactJavaSerializer.java
@@ -27,9 +27,6 @@ import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +34,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.ehcache.spi.persistence.StateHolder;
 import org.ehcache.spi.persistence.StateRepository;
 import org.ehcache.spi.serialization.SerializerException;
 import org.ehcache.impl.internal.util.ByteBufferInputStream;
@@ -53,7 +51,7 @@ import org.ehcache.spi.serialization.StatefulSerializer;
  */
 public class CompactJavaSerializer<T> implements StatefulSerializer<T> {
 
-  private volatile ConcurrentMap<Integer, ObjectStreamClass> readLookup;
+  private volatile StateHolder<Integer, ObjectStreamClass> readLookup;
   private final ConcurrentMap<Integer, ObjectStreamClass> readLookupLocalCache = new ConcurrentHashMap<Integer, ObjectStreamClass>();
   private final ConcurrentMap<SerializableDataKey, Integer> writeLookup = new ConcurrentHashMap<SerializableDataKey, Integer>();
 
@@ -80,7 +78,7 @@ public class CompactJavaSerializer<T> implements StatefulSerializer<T> {
 
   @Override
   public void init(final StateRepository stateRepository) {
-    this.readLookup = stateRepository.getPersistentConcurrentMap("CompactJavaSerializer-ObjectStreamClassIndex", Integer.class, ObjectStreamClass.class);
+    this.readLookup = stateRepository.getPersistentStateHolder("CompactJavaSerializer-ObjectStreamClassIndex", Integer.class, ObjectStreamClass.class);
     loadMappingsInWriteContext(readLookup.entrySet(), true);
   }
 

--- a/impl/src/main/java/org/ehcache/impl/serialization/TransientStateHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/serialization/TransientStateHolder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.serialization;
+
+import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
+import org.ehcache.spi.persistence.StateHolder;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+public class TransientStateHolder<K, V> implements StateHolder<K, V>, Serializable {
+
+  private final ConcurrentMap<K, V> map = new ConcurrentHashMap<K, V>();
+
+  @Override
+  public V putIfAbsent(final K key, final V value) {
+    return map.putIfAbsent(key, value);
+  }
+
+  @Override
+  public V get(final K key) {
+    return map.get(key);
+  }
+
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    return map.entrySet();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    final TransientStateHolder<?, ?> that = (TransientStateHolder<?, ?>)o;
+
+    return map.equals(that.map);
+
+  }
+
+  @Override
+  public int hashCode() {
+    return map.hashCode();
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/persistence/FileBasedStateRepositoryTest.java
+++ b/impl/src/test/java/org/ehcache/impl/persistence/FileBasedStateRepositoryTest.java
@@ -16,6 +16,8 @@
 
 package org.ehcache.impl.persistence;
 
+import org.ehcache.impl.serialization.TransientStateHolder;
+import org.ehcache.spi.persistence.StateHolder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -26,8 +28,6 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
@@ -37,31 +37,31 @@ import static org.junit.Assert.*;
  */
 public class FileBasedStateRepositoryTest {
 
-  private static String MAP_FILE_NAME = "map-0-myMap.bin";
+  private static String HOLDER_FILE_NAME = "holder-0-myHolder.bin";
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
 
   @Test
-  public void testMapSave() throws Exception {
+  public void testHolderSave() throws Exception {
     File directory = folder.newFolder("testSave");
     FileBasedStateRepository stateRepository = new FileBasedStateRepository(directory);
-    String mapName = "myMap";
-    ConcurrentMap<Long, String> myMap = stateRepository.getPersistentConcurrentMap(mapName, Long.class, String.class);
+    String holderName = "myHolder";
+    StateHolder<Long, String> myHolder = stateRepository.getPersistentStateHolder(holderName, Long.class, String.class);
 
-    myMap.put(42L, "TheAnswer!");
+    myHolder.putIfAbsent(42L, "TheAnswer!");
 
     stateRepository.close();
 
-    FileInputStream fis = new FileInputStream(new File(directory, MAP_FILE_NAME));
+    FileInputStream fis = new FileInputStream(new File(directory, HOLDER_FILE_NAME));
     try {
       ObjectInputStream ois = new ObjectInputStream(fis);
       try {
         String name = (String) ois.readObject();
-        assertThat(name, is(mapName));
+        assertThat(name, is(holderName));
         FileBasedStateRepository.Tuple loadedTuple = (FileBasedStateRepository.Tuple) ois.readObject();
         assertThat(loadedTuple.index, is(0));
-        assertThat((ConcurrentMap<Long, String>)loadedTuple.map, is(myMap));
+        assertThat((StateHolder<Long, String>)loadedTuple.holder, is(myHolder));
       } finally {
         ois.close();
       }
@@ -71,17 +71,17 @@ public class FileBasedStateRepositoryTest {
   }
 
   @Test
-  public void testMapLoad() throws Exception {
+  public void testHolderLoad() throws Exception {
     File directory = folder.newFolder("testLoad");
-    String mapName = "myMap";
-    ConcurrentMap<Long, String> map = new ConcurrentHashMap<Long, String>();
-    map.put(42L, "Again? That's not even funny anymore!!");
+    String holderName = "myHolder";
+    StateHolder<Long, String> map = new TransientStateHolder<Long, String>();
+    map.putIfAbsent(42L, "Again? That's not even funny anymore!!");
 
-    FileOutputStream fos = new FileOutputStream(new File(directory, MAP_FILE_NAME));
+    FileOutputStream fos = new FileOutputStream(new File(directory, HOLDER_FILE_NAME));
     try {
       ObjectOutputStream oos = new ObjectOutputStream(fos);
       try {
-        oos.writeObject(mapName);
+        oos.writeObject(holderName);
         oos.writeObject(new FileBasedStateRepository.Tuple(0, map));
       } finally {
         oos.close();
@@ -91,22 +91,22 @@ public class FileBasedStateRepositoryTest {
     }
 
     FileBasedStateRepository stateRepository = new FileBasedStateRepository(directory);
-    ConcurrentMap<Long, String> myMap = stateRepository.getPersistentConcurrentMap(mapName, Long.class, String.class);
+    StateHolder<Long, String> myHolder = stateRepository.getPersistentStateHolder(holderName, Long.class, String.class);
 
-    assertThat(myMap, is(map));
+    assertThat(myHolder, is(map));
   }
 
   @Test
   public void testIndexProperlySetAfterLoad() throws Exception {
     File directory = folder.newFolder("testIndexAfterLoad");
-    String mapName = "myMap";
+    String holderName = "myHolder";
 
-    FileOutputStream fos = new FileOutputStream(new File(directory, MAP_FILE_NAME));
+    FileOutputStream fos = new FileOutputStream(new File(directory, HOLDER_FILE_NAME));
     try {
       ObjectOutputStream oos = new ObjectOutputStream(fos);
       try {
-        oos.writeObject(mapName);
-        oos.writeObject(new FileBasedStateRepository.Tuple(0, new ConcurrentHashMap<Long, String>()));
+        oos.writeObject(holderName);
+        oos.writeObject(new FileBasedStateRepository.Tuple(0, new TransientStateHolder<Long, String>()));
       } finally {
         oos.close();
       }
@@ -115,13 +115,13 @@ public class FileBasedStateRepositoryTest {
     }
 
     FileBasedStateRepository stateRepository = new FileBasedStateRepository(directory);
-    stateRepository.getPersistentConcurrentMap("otherMap", Long.class, Long.class);
+    stateRepository.getPersistentStateHolder("otherHolder", Long.class, Long.class);
     stateRepository.close();
 
     File[] files = directory.listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        return name.contains("otherMap") && name.contains("-1-");
+        return name.contains("otherHolder") && name.contains("-1-");
       }
     });
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/TransientStateRepositoryTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/TransientStateRepositoryTest.java
@@ -16,10 +16,8 @@
 
 package org.ehcache.impl.serialization;
 
+import org.ehcache.spi.persistence.StateHolder;
 import org.junit.Test;
-
-import java.io.Serializable;
-import java.util.concurrent.ConcurrentMap;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
@@ -32,10 +30,10 @@ public class TransientStateRepositoryTest {
   @Test
   public void testRemembersCreatedMaps() throws Exception {
     TransientStateRepository repository = new TransientStateRepository();
-    ConcurrentMap<Long, String> test = repository.getPersistentConcurrentMap("test", Long.class, String.class);
-    test.put(42L, "Again??");
+    StateHolder<Long, String> test = repository.getPersistentStateHolder("test", Long.class, String.class);
+    test.putIfAbsent(42L, "Again??");
 
-    test = repository.getPersistentConcurrentMap("test", Long.class, String.class);
+    test = repository.getPersistentStateHolder("test", Long.class, String.class);
     assertThat(test.get(42L), is("Again??"));
   }
 


### PR DESCRIPTION
In a lot of places variables are still named "xxxMap" instead of "xxxStateHolder". Will do that if the name `StateHolder` gets finalized.