### PR TITLE
Put operation for passive in serverstore impl

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
@@ -78,6 +78,10 @@ public class ServerStoreImpl implements ServerStore {
     store.replaceAtHead(key, expect, update);
   }
 
+  public void put(long key, Chain chain) {
+    store.put(key, chain);
+  }
+
   @Override
   public void clear() {
     store.clear();

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
@@ -177,6 +177,23 @@ class OffHeapChainMap<K> implements MapInternals {
     }
   }
 
+  public void put(K key, Chain chain) {
+    final Lock lock = heads.writeLock();
+    lock.lock();
+    try {
+      InternalChain current = heads.get(key);
+      if (current != null) {
+        replaceAtHead(key, current.detach(), chain);
+      } else {
+        for (Element x : chain) {
+          append(key, x.getPayload());
+        }
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
   public void clear() {
     heads.writeLock().lock();
     try {

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/offheap/ChainMapTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/offheap/ChainMapTest.java
@@ -323,6 +323,23 @@ public class ChainMapTest {
     }
   }
 
+  @Test
+  public void testPutWhenKeyIsNotNull() {
+    OffHeapChainMap<String> map = new OffHeapChainMap<String>(new UnlimitedPageSource(new OffHeapBufferSource()), StringPortability.INSTANCE, minPageSize, maxPageSize, steal);
+    map.append("key", buffer(3));
+    map.put("key", chain(buffer(1), buffer(2)));
+
+    assertThat(map.get("key"), contains(element(1), element(2)));
+  }
+
+  @Test
+  public void testPutWhenKeyIsNull() {
+    OffHeapChainMap<String> map = new OffHeapChainMap<String>(new UnlimitedPageSource(new OffHeapBufferSource()), StringPortability.INSTANCE, minPageSize, maxPageSize, steal);
+    map.put("key", chain(buffer(1), buffer(2)));
+
+    assertThat(map.get("key"), contains(element(1), element(2)));
+  }
+
   private static ByteBuffer buffer(int i) {
     ByteBuffer buffer = ByteBuffer.allocate(i);
     while (buffer.hasRemaining()) {

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/offheap/OffHeapServerStoreTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/offheap/OffHeapServerStoreTest.java
@@ -103,7 +103,6 @@ public class OffHeapServerStoreTest extends ServerStoreTest {
     });
     when(store.handleOversizeMappingException(anyLong())).thenReturn(true);
 
-
     ByteBuffer payload = createPayload(1L);
 
     store.append(1L, payload);


### PR DESCRIPTION
This PR introduces a put operations on `ServerStoreImpl` only to be used by `EhcachePassiveEntity`, i.e. why it is not part of the `ServerStore` api as it is not supposed to be used by clients.
Also the implementation is kind of a provisional thing for now, so that work for AP can move forward. The implementation for put needs to be rewritten in much proper way