### PR TITLE
Issue #1467 Prevents shadow plugin from populating the 'Class-Path' manifest key

### DIFF
--- a/buildSrc/src/main/groovy/EhDistribute.groovy
+++ b/buildSrc/src/main/groovy/EhDistribute.groovy
@@ -40,6 +40,7 @@ class EhDistribute implements Plugin<Project> {
     def OSGI_OVERRIDE_KEYS = ['Import-Package', 'Export-Package', 'Private-Package', 'Tool', 'Bnd-LastModified', 'Created-By', 'Require-Capability']
 
     project.configurations {
+        shadowCompile
         shadowProvided
     }
 

--- a/buildSrc/src/main/groovy/EhOsgi.groovy
+++ b/buildSrc/src/main/groovy/EhOsgi.groovy
@@ -54,7 +54,7 @@ class EhOsgi implements Plugin<Project> {
 
         if (project.hasProperty('shadowJar')) {
           classesDir = project.shadowJar.archivePath
-          classpath = project.files(project.configurations.shadow, project.configurations.shadowProvided)
+          classpath = project.files(project.configurations.shadowCompile, project.configurations.shadowProvided)
         } else {
           classesDir = new File(project.buildDir, 'classes/main') //can't figure out where to get this value
           classpath = project.sourceSets.main.compileClasspath

--- a/buildSrc/src/main/groovy/EhPomMangle.groovy
+++ b/buildSrc/src/main/groovy/EhPomMangle.groovy
@@ -27,7 +27,7 @@ import scripts.Utils
  *   Removes all implicit dependencies from the pom
  *   and adds only what is specified in (from shadowJar)
  *
- *   project.configurations.shadow  (as compile)
+ *   project.configurations.shadowCompile  (as compile)
  *   project.configurations.shadowProvided (as provided)
  *
  *   as well as (these do not affect shadow)
@@ -49,7 +49,7 @@ class EhPomMangle implements Plugin<Project> {
     project.plugins.apply 'signing'
 
     project.configurations {
-      shadow
+      shadowCompile
       shadowProvided
       pomOnlyCompile
       pomOnlyProvided
@@ -60,7 +60,7 @@ class EhPomMangle implements Plugin<Project> {
       pom.scopeMappings.mappings.remove(project.configurations.runtime)
       pom.scopeMappings.mappings.remove(project.configurations.testCompile)
       pom.scopeMappings.mappings.remove(project.configurations.testRuntime)
-      pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadow, Conf2ScopeMappingContainer.COMPILE)
+      pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadowCompile, Conf2ScopeMappingContainer.COMPILE)
       pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.shadowProvided, Conf2ScopeMappingContainer.PROVIDED)
 
       //Anything extra to add to pom that isn't in the shadowed jar or compilation

--- a/clustered/clustered-dist/build.gradle
+++ b/clustered/clustered-dist/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
   kit "org.terracotta.internal:terracotta-kit:$terracottaCoreVersion@zip" changing true
 
-  shadow "org.slf4j:slf4j-api:$parent.slf4jVersion"
+  shadowCompile "org.slf4j:slf4j-api:$parent.slf4jVersion"
   pomOnlyCompile "org.ehcache:ehcache:$parent.baseVersion"
 }
 
@@ -99,7 +99,7 @@ distributions {
         from project(':dist').javadocJar.archivePath.getPath()
       }
       into ('client/lib') {
-        from configurations.shadow
+        from configurations.shadowCompile
       }
       into ('') {
         from 'src/assemble'

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -28,5 +28,5 @@ dependencies {
 apply plugin: EhDistribute
 
 dependencies {
-  shadow "org.slf4j:slf4j-api:$parent.slf4jVersion"
+  shadowCompile "org.slf4j:slf4j-api:$parent.slf4jVersion"
 }


### PR DESCRIPTION
In order to be minimally disruptive I've done this by creating a shadowCompile configuration that we use everywhere, and then using that rather than the "shadow" configuration created by the plugin.  This way all our usage of the configuration should stay intact, but the shadow plugin won't populate the jar classpath manifest entry.