### PR TITLE
Fix #1535 Clean up server dependencies that leaked on client

### DIFF
--- a/clustered/common/build.gradle
+++ b/clustered/common/build.gradle
@@ -17,5 +17,5 @@
 apply plugin: EhDeploy
 
 dependencies {
-  provided "org.terracotta:entity-server-api:$parent.entityApiVersion"
+  provided "org.terracotta:entity-common-api:$parent.entityApiVersion"
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/lock/LockMessaging.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/lock/LockMessaging.java
@@ -20,7 +20,6 @@ import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.MessageCodecException;
-import org.terracotta.entity.SyncMessageCodec;
 
 public class LockMessaging {
 
@@ -60,24 +59,8 @@ public class LockMessaging {
     }
   };
 
-  private static final SyncMessageCodec<LockOperation> SYNC_CODEC = new SyncMessageCodec<LockOperation>() {
-    @Override
-    public byte[] encode(int i, LockOperation message) throws MessageCodecException {
-      throw new AssertionError();
-    }
-
-    @Override
-    public LockOperation decode(int i, byte[] bytes) throws MessageCodecException {
-      throw new AssertionError();
-    }
-  };
-
   public static MessageCodec<LockOperation, LockTransition> codec() {
     return CODEC;
-  }
-
-  public static SyncMessageCodec<LockOperation> syncCodec() {
-    return SYNC_CODEC;
   }
 
   public static LockOperation tryLock(HoldType type) {

--- a/clustered/server/src/main/java/org/ehcache/clustered/lock/server/VoltronReadWriteLockServerEntityService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/lock/server/VoltronReadWriteLockServerEntityService.java
@@ -21,6 +21,7 @@ import org.ehcache.clustered.common.internal.lock.LockMessaging;
 import org.ehcache.clustered.common.internal.lock.LockMessaging.LockOperation;
 import org.ehcache.clustered.common.internal.lock.LockMessaging.LockTransition;
 
+import org.ehcache.clustered.lock.server.messages.LockSyncMessaging;
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ConcurrencyStrategy;
@@ -80,7 +81,7 @@ public class VoltronReadWriteLockServerEntityService implements EntityServerServ
 
   @Override
   public SyncMessageCodec<LockOperation> getSyncMessageCodec() {
-    return LockMessaging.syncCodec();
+    return LockSyncMessaging.syncCodec();
   }
 
   private static final <T> ServiceConfiguration<T> config(final Class<T> klazz) {

--- a/clustered/server/src/main/java/org/ehcache/clustered/lock/server/messages/LockSyncMessaging.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/lock/server/messages/LockSyncMessaging.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.lock.server.messages;
+
+import org.ehcache.clustered.common.internal.lock.LockMessaging;
+import org.terracotta.entity.MessageCodecException;
+import org.terracotta.entity.SyncMessageCodec;
+
+/**
+ * LockSyncMessaging
+ */
+public class LockSyncMessaging {
+
+  public static SyncMessageCodec<LockMessaging.LockOperation> syncCodec() {
+    return SYNC_CODEC;
+  }
+
+  private static final SyncMessageCodec<LockMessaging.LockOperation> SYNC_CODEC = new SyncMessageCodec<LockMessaging.LockOperation>() {
+    @Override
+    public byte[] encode(int i, LockMessaging.LockOperation message) throws MessageCodecException {
+      throw new AssertionError();
+    }
+
+    @Override
+    public LockMessaging.LockOperation decode(int i, byte[] bytes) throws MessageCodecException {
+      throw new AssertionError();
+    }
+  };
+
+}


### PR DESCRIPTION
* clustered common module only depends on common apis
* passive sync codes for the lock have been moved to the server module