### PR TITLE
Issue 1530

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ subprojects {
   }
 
   test {
-    maxHeapSize = "1024m"
+    maxHeapSize = "1408m"
     systemProperty 'java.awt.headless', 'true'
     if (parent.isCloudbees) {
       systemProperty 'disable.concurrent.tests', 'true'

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockEntityClientService;
@@ -44,17 +45,22 @@ import org.terracotta.connection.Connection;
 import org.terracotta.connection.ConnectionException;
 import org.terracotta.connection.ConnectionPropertyNames;
 import org.terracotta.connection.ConnectionService;
+import org.terracotta.connection.entity.Entity;
+import org.terracotta.connection.entity.EntityRef;
 import org.terracotta.entity.EntityClientService;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.EntityServerService;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
+import org.terracotta.exception.EntityNotFoundException;
+import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.offheapresource.OffHeapResourcesConfiguration;
 import org.terracotta.offheapresource.OffHeapResourcesProvider;
 import org.terracotta.offheapresource.config.MemoryUnit;
 import org.terracotta.offheapresource.config.OffheapResourcesType;
 import org.terracotta.offheapresource.config.ResourceType;
+import org.terracotta.passthrough.PassthroughConnection;
 import org.terracotta.passthrough.PassthroughServer;
 import org.terracotta.passthrough.PassthroughServerRegistry;
 
@@ -207,9 +213,6 @@ public class UnitTestConnectionService implements ConnectionService {
     URI keyURI = createKey(uri);
     ServerDescriptor serverDescriptor = SERVERS.remove(keyURI);
     if (serverDescriptor != null) {
-      serverDescriptor.server.stop();
-      LOGGER.info("Stopped PassthroughServer at {}", keyURI);
-
       for (Connection connection : serverDescriptor.getConnections().keySet()) {
         try {
           LOGGER.warn("Force close {}", formatConnectionId(connection));
@@ -220,6 +223,28 @@ public class UnitTestConnectionService implements ConnectionService {
           // Ignored
         }
       }
+
+      //open destroy connection.  You need to make sure connection doesn't have any entities associated with it.
+      PassthroughConnection connection  = serverDescriptor.server.connectNewClient("destroy-connection");
+
+      for(Entry entry : serverDescriptor.knownEntities.entrySet()) {
+        Class type = (Class)entry.getKey();
+        List args = (List)entry.getValue();
+        Long version = (Long)args.get(0);
+        String stringArg = (String)args.get(1);
+
+        try {
+          EntityRef entityRef = connection.getEntityRef(type, version, stringArg);
+          entityRef.destroy();
+        } catch (EntityNotProvidedException ex) {
+          LOGGER.error("Entity destroy failed: ", ex);
+        } catch (EntityNotFoundException ex) {
+          LOGGER.error("Entity destroy failed: ", ex);
+        }
+      }
+
+      serverDescriptor.server.stop();
+      LOGGER.info("Stopped PassthroughServer at {}", keyURI);
       return serverDescriptor.server;
     } else {
       return null;
@@ -465,6 +490,7 @@ public class UnitTestConnectionService implements ConnectionService {
   private static final class ServerDescriptor {
     private final PassthroughServer server;
     private final Map<Connection, Properties> connections = new IdentityHashMap<Connection, Properties>();
+    private final Map<Class<? extends Entity>, List<Object>> knownEntities = new HashMap<Class<? extends Entity>, List<Object>>();
 
     ServerDescriptor(PassthroughServer server) {
       this.server = server;
@@ -480,6 +506,13 @@ public class UnitTestConnectionService implements ConnectionService {
 
     synchronized void remove(Connection connection) {
       this.connections.remove(connection);
+    }
+
+    public void addKnownEntity(Class<? extends Entity> arg, Object arg1, Object arg2) {
+      List<Object> set = new ArrayList<Object>();
+      set.add(arg1);
+      set.add(arg2);
+      knownEntities.put(arg, set);
     }
   }
 
@@ -502,6 +535,10 @@ public class UnitTestConnectionService implements ConnectionService {
       if (method.getName().equals("close")) {
         serverDescriptor.remove(connection);
         LOGGER.info("Client closed {}", formatConnectionId(connection));
+      }
+
+      if (method.getName().equals("getEntityRef")) {
+        serverDescriptor.addKnownEntity((Class<? extends Entity>) args[0], args[1] ,args[2]);
       }
       try {
         return method.invoke(connection, args);

--- a/clustered/server/build.gradle
+++ b/clustered/server/build.gradle
@@ -22,6 +22,9 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
+  compile ("org.terracotta:statistics:$parent.statisticVersion") {
+    exclude group:'org.slf4j', module:'slf4j-api'
+  }
   compile project(':clustered:common')
   compile group: 'org.terracotta', name: 'offheap-resource', version: parent.offheapResourceVersion
   compile group: 'org.terracotta', name: 'offheap-store', version: parent.offheapVersion

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
@@ -100,38 +100,68 @@ public class ServerStoreImpl implements ServerStore, MapInternals {
 
 
   @Override
-  public long getDataAllocatedMemory() {return store.getDataAllocatedMemory();}
+  public long getSize() {
+    return store.getSize();
+  }
 
   @Override
-  public long getAllocatedMemory() {return store.getAllocatedMemory();}
+  public long getTableCapacity() {
+    return store.getTableCapacity();
+  }
 
   @Override
-  public long getRemovedSlotCount() {return store.getRemovedSlotCount();}
+  public long getUsedSlotCount() {
+    return store.getUsedSlotCount();
+  }
 
   @Override
-  public long getDataVitalMemory() {return store.getDataVitalMemory();}
+  public long getRemovedSlotCount() {
+    return store.getRemovedSlotCount();
+  }
 
   @Override
-  public int getReprobeLength() {return store.getReprobeLength();}
+  public long getAllocatedMemory() {
+    return store.getAllocatedMemory();
+  }
 
   @Override
-  public long getDataSize() {return store.getDataSize();}
+  public long getOccupiedMemory() {
+    return store.getOccupiedMemory();
+  }
 
   @Override
-  public long getDataOccupiedMemory() {return store.getDataOccupiedMemory();}
+  public long getVitalMemory() {
+    return store.getVitalMemory();
+  }
 
   @Override
-  public long getUsedSlotCount() {return store.getUsedSlotCount();}
+  public long getDataAllocatedMemory() {
+    return store.getDataAllocatedMemory();
+  }
 
   @Override
-  public long getSize() {return store.getSize();}
+  public long getDataOccupiedMemory() {
+    return store.getDataOccupiedMemory();
+  }
 
   @Override
-  public long getVitalMemory() {return store.getVitalMemory();}
+  public long getDataVitalMemory() {
+    return store.getDataVitalMemory();
+  }
 
   @Override
-  public long getOccupiedMemory() {return store.getOccupiedMemory();}
+  public long getDataSize() {
+    return store.getDataSize();
+  }
 
   @Override
-  public long getTableCapacity() {return store.getTableCapacity();}
+  public int getReprobeLength() {
+    //TODO
+    //MapInternals Interface may need to change to implement this function correctly.
+    //Currently MapInternals Interface contains function: int getReprobeLength();
+    //however OffHeapServerStore.reprobeLength() returns a long
+    //Thus there could be data loss
+
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
 }


### PR DESCRIPTION
This check in includes the server side allocatedMemory statistic.  Also I had to increase the build.gradle maxHeapSize to 2048m otherwise 48 of the :clustered:client tests failed because the JVM ran out of memory.  I did try to to avoid this by forcing the passthrough server to call the serverside destroy method but this didn't seem to work. 