### PR TITLE
Close Issue #1008 - Expose management data from ehcache server entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.8.beta2'
+  terracottaPlatformVersion = '5.0.8.beta6'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.0.9.beta'
   terracottaCoreVersion = '5.0.9-beta2'

--- a/clustered/client/build.gradle
+++ b/clustered/client/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   compileOnly project(':xml')
   compile project(':clustered:common')
   provided "org.terracotta:entity-client-api:$parent.entityApiVersion"
+  provided "org.terracotta.management:management-registry-service-api:$parent.managementVersion" // provided in management-server jar
 
   testCompile project(':api')
   testCompile project(':xml')

--- a/clustered/integration-test/build.gradle
+++ b/clustered/integration-test/build.gradle
@@ -16,34 +16,20 @@
 
 import org.gradle.internal.jvm.Jvm
 
-// all these libs should be on server classpath for management
-// management-entity-server  : entity used client-side to send management data into the server
-// monitoring-service        : server monitoring service
-// monitoring-service-entity : test entity, so that we can read the server monitoring service
-// management-model          : management metadata describing exposed objects, stats and notifications (jdk-6 compat)
-// cluster-topology          : model classes describing cluster topology (jdk-8 compat)
-// management-registry       : service classes to expose management metadata and query api for stats (jdk-6 compat)
-// sequence-generator        : improved boundary flake seq generator to add seq numbers on management messages
-def serverCP = [
-  'management-entity-server': ':plugin',
-  'monitoring-service': ':plugin',
-  'monitoring-service-entity': ':plugin',
-  'management-model': '',
-  'cluster-topology': '',
-  'management-registry': '',
-  'sequence-generator': '',
-]
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 configurations {
-  serverClasspath
+  serverLibs
 }
 
 dependencies {
   testCompile project(':dist')
   testCompile project(':clustered:clustered-dist')
   testCompile project(':management')
-  testCompile "org.terracotta.management:management-entity-client:$parent.managementVersion"
+  testCompile "org.terracotta.management.dist:management-client:$parent.managementVersion"
   testCompile "org.terracotta.management:monitoring-service-entity:$parent.managementVersion"
+  testCompile "com.fasterxml.jackson.core:jackson-databind:2.8.0"
 
   testCompile group:'org.terracotta', name:'galvan-support', version: galvanVersion
   testCompile (group:'com.google.code.tempus-fugit', name:'tempus-fugit', version:'1.1') {
@@ -52,9 +38,10 @@ dependencies {
   }
   testCompile group: 'javax.cache', name: 'cache-api', version: jcacheVersion
 
-  serverCP.each { k, v ->
-    serverClasspath "org.terracotta.management:$k:$parent.managementVersion$v"
+  serverLibs ("org.terracotta.management.dist:management-server:$parent.managementVersion") {
+    exclude group:'org.terracotta.management.dist', module:'management-common'
   }
+  serverLibs "org.terracotta.management:monitoring-service-entity:$parent.managementVersion" // test entity for monitoring service
 }
 
 task unzipKit(type: Copy) {
@@ -77,7 +64,7 @@ test {
   environment 'JAVA_OPTS', '-Dcom.tc.l2.lockmanager.greedy.locks.enabled=false'
   //If this directory does not exist, tests will fail with a cryptic assert failure
   systemProperty 'kitInstallationPath', "$unzipKit.destinationDir/${project(':clustered:clustered-dist').archivesBaseName}-$project.version-kit"
-  systemProperty 'managementPlugins', serverCP.keySet().collect { String artifact -> project.configurations.serverClasspath.find { it.name.startsWith("$artifact-$parent.managementVersion") } }.join(File.pathSeparator)
+  systemProperty 'managementPlugins', project.configurations.serverLibs.join(File.pathSeparator)
   // Uncomment to include client logging in console output
   // testLogging.showStandardStreams = true
 }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
@@ -15,21 +15,32 @@
  */
 package org.ehcache.clustered.management;
 
-import org.junit.After;
-import org.junit.Assert;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.ehcache.CacheManager;
+import org.ehcache.Status;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.management.config.EhcacheStatisticsProviderConfiguration;
+import org.ehcache.management.registry.DefaultManagementRegistryConfiguration;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.ConnectionFactory;
 import org.terracotta.management.entity.management.ManagementAgentConfig;
-import org.terracotta.management.entity.management.client.ContextualReturnListener;
 import org.terracotta.management.entity.management.client.ManagementAgentEntityFactory;
 import org.terracotta.management.entity.management.client.ManagementAgentService;
 import org.terracotta.management.entity.monitoring.client.MonitoringServiceEntityFactory;
 import org.terracotta.management.entity.monitoring.client.MonitoringServiceProxyEntity;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.call.Parameter;
+import org.terracotta.management.model.cluster.Client;
 import org.terracotta.management.model.cluster.ClientIdentifier;
+import org.terracotta.management.model.cluster.ServerEntityIdentifier;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.message.Message;
 import org.terracotta.management.model.notification.ContextualNotification;
@@ -38,22 +49,31 @@ import org.terracotta.testing.rules.BasicExternalCluster;
 import org.terracotta.testing.rules.Cluster;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Scanner;
+import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder.clusteredDedicated;
+import static org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder.clusteredShared;
+import static org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder.cluster;
+import static org.ehcache.config.builders.CacheConfigurationBuilder.newCacheConfigurationBuilder;
+import static org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractClusteringManagementTest {
 
@@ -61,73 +81,135 @@ public abstract class AbstractClusteringManagementTest {
     "<service xmlns:ohr='http://www.terracotta.org/config/offheap-resource' id=\"resources\">"
       + "<ohr:offheap-resources>"
       + "<ohr:resource name=\"primary-server-resource\" unit=\"MB\">64</ohr:resource>"
+      + "<ohr:resource name=\"secondary-server-resource\" unit=\"MB\">64</ohr:resource>"
       + "</ohr:offheap-resources>" +
       "</service>\n";
 
   protected static MonitoringServiceProxyEntity consumer;
+  protected static CacheManager cacheManager;
+  protected static ClientIdentifier clientIdentifier;
+  protected static ServerEntityIdentifier serverEntityIdentifier;
+  protected static ObjectMapper mapper = new ObjectMapper();
+
+  private static final List<File> MANAGEMENT_PLUGINS = Stream.of(System.getProperty("managementPlugins", "").split(File.pathSeparator))
+    .map(File::new)
+    .collect(Collectors.toList());
 
   @ClassRule
-  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, getManagementPlugins(), "", RESOURCE_CONFIG, "");
+  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, MANAGEMENT_PLUGINS, "", RESOURCE_CONFIG, "");
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+
     CLUSTER.getClusterControl().waitForActive();
 
     consumer = new MonitoringServiceEntityFactory(ConnectionFactory.connect(CLUSTER.getConnectionURI(), new Properties())).retrieveOrCreate("MonitoringConsumerEntity");
     consumer.createMessageBuffer(1024);
+
+    cacheManager = newCacheManagerBuilder()
+      // cluster config
+      .with(cluster(CLUSTER.getConnectionURI().resolve("/my-server-entity-1"))
+        .autoCreate()
+        .defaultServerResource("primary-server-resource")
+        .resourcePool("resource-pool-a", 28, MemoryUnit.MB, "secondary-server-resource") // <2>
+        .resourcePool("resource-pool-b", 16, MemoryUnit.MB)) // will take from primary-server-resource
+      // management config
+      .using(new DefaultManagementRegistryConfiguration()
+        .addTags("webapp-1", "server-node-1")
+        .setCacheManagerAlias("my-super-cache-manager")
+        .addConfiguration(new EhcacheStatisticsProviderConfiguration(
+          1, TimeUnit.MINUTES,
+          100, 1, TimeUnit.SECONDS,
+          10, TimeUnit.SECONDS)))
+      // cache config
+      .withCache("dedicated-cache-1", newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+          .heap(10, EntryUnit.ENTRIES)
+          .offheap(1, MemoryUnit.MB)
+          .with(clusteredDedicated("primary-server-resource", 4, MemoryUnit.MB)))
+        .build())
+      .withCache("shared-cache-2", newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+          .heap(10, EntryUnit.ENTRIES)
+          .offheap(1, MemoryUnit.MB)
+          .with(clusteredShared("resource-pool-a")))
+        .build())
+      .withCache("shared-cache-3", newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+          .heap(10, EntryUnit.ENTRIES)
+          .offheap(1, MemoryUnit.MB)
+          .with(clusteredShared("resource-pool-b")))
+        .build())
+      .build(true);
+
+    // ensure the CM is running and get its client id
+    assertThat(cacheManager.getStatus(), equalTo(Status.AVAILABLE));
+    clientIdentifier = consumer.readTopology().getClients().values()
+      .stream()
+      .filter(client -> client.getName().equals("Ehcache:my-server-entity-1"))
+      .findFirst()
+      .map(Client::getClientIdentifier)
+      .get();
+
+    serverEntityIdentifier = consumer.readTopology()
+      .activeServerEntityStream()
+      .filter(serverEntity -> serverEntity.getName().equals("my-server-entity-1"))
+      .findFirst()
+      .get() // throws if not found
+      .getServerEntityIdentifier();
+
+    // test_notifs_sent_at_CM_init
+    List<Message> messages = consumer.drainMessageBuffer();
+    List<String> notificationTypes = notificationTypes(messages);
+    assertThat(notificationTypes.get(0), equalTo("CLIENT_CONNECTED"));
+    assertThat(notificationTypes.containsAll(Arrays.asList(
+      "SERVER_ENTITY_CREATED", "SERVER_ENTITY_FETCHED",
+      "ENTITY_REGISTRY_AVAILABLE", "ENTITY_REGISTRY_UPDATED", "EHCACHE_RESOURCE_POOLS_CONFIGURED", "EHCACHE_CLIENT_VALIDATED", "EHCACHE_SERVER_STORE_CREATED",
+      "CLIENT_REGISTRY_AVAILABLE", "CLIENT_TAGS_UPDATED")), is(true));
+    assertThat(consumer.readMessageBuffer(), is(nullValue()));
   }
 
-  @After
-  public final void clearBuffers() throws Exception {
-    clear();
+  @AfterClass
+  public static void afterClass() throws Exception {
+    if (cacheManager != null && cacheManager.getStatus() == Status.AVAILABLE) {
+      cacheManager.close();
+    }
   }
 
-  protected final void clear() {
-    if(consumer != null) {
+  @Rule
+  public final Timeout globalTimeout = Timeout.seconds(60);
+
+  @Before
+  public void init() throws Exception {
+    if (consumer != null) {
       consumer.clearMessageBuffer();
     }
   }
 
-  protected static void sendManagementCallToCollectStats(String... statNames) throws Exception {
+  protected static ContextualReturn<?> sendManagementCallToCollectStats(String... statNames) throws Exception {
     Connection managementConnection = CLUSTER.newConnection();
     try {
       ManagementAgentService agent = new ManagementAgentService(new ManagementAgentEntityFactory(managementConnection).retrieveOrCreate(new ManagementAgentConfig()));
 
-      assertThat(agent.getManageableClients().size(), equalTo(1)); // only ehcache client is manageable, not this one
+      final AtomicReference<String> managementCallId = new AtomicReference<>();
+      final Exchanger<ContextualReturn<?>> exchanger = new Exchanger<>();
 
-      // find Ehcache client
-      ClientIdentifier me = agent.getClientIdentifier();
-      ClientIdentifier client = null;
-      for (ClientIdentifier clientIdentifier : agent.getManageableClients()) {
-        if (!clientIdentifier.equals(me)) {
-          client = clientIdentifier;
-          break;
-        }
-      }
-      assertThat(client, is(notNullValue()));
-      final ClientIdentifier ehcacheClientIdentifier = client;
-
-      final CountDownLatch callCompleted = new CountDownLatch(1);
-      final AtomicReference<String> managementCallId = new AtomicReference<String>();
-      final BlockingQueue<ContextualReturn<?>> returns = new LinkedBlockingQueue<ContextualReturn<?>>();
-
-      agent.setContextualReturnListener(new ContextualReturnListener() {
-        @Override
-        public void onContextualReturn(ClientIdentifier from, String id, ContextualReturn<?> aReturn) {
-          try {
-            Assert.assertEquals(ehcacheClientIdentifier, from);
-            // make sure the call completed
-            callCompleted.await(10, TimeUnit.SECONDS);
-            assertEquals(managementCallId.get(), id);
-            returns.offer(aReturn);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
+      agent.setContextualReturnListener((from, id, aReturn) -> {
+        try {
+          assertEquals(clientIdentifier, from);
+          assertEquals(managementCallId.get(), id);
+          exchanger.exchange(aReturn);
+        } catch (InterruptedException e) {
+          fail("interrupted");
         }
       });
 
       managementCallId.set(agent.call(
-        ehcacheClientIdentifier,
+        clientIdentifier,
         Context.create("cacheManagerName", "my-super-cache-manager"),
         "StatisticCollectorCapability",
         "updateCollectedStatistics",
@@ -135,11 +217,7 @@ public abstract class AbstractClusteringManagementTest {
         new Parameter("StatisticsCapability"),
         new Parameter(asList(statNames), Collection.class.getName())));
 
-      // now we're sure the call completed
-      callCompleted.countDown();
-
-      // ensure the call is made
-      returns.take();
+      return exchanger.exchange(null);
     } finally {
       managementConnection.close();
     }
@@ -148,41 +226,43 @@ public abstract class AbstractClusteringManagementTest {
   protected static List<ContextualStatistics> waitForNextStats() {
     // uses the monitoring consumre entity to get the content of the stat buffer when some stats are collected
     while (true) {
-      Message message = consumer.readMessageBuffer();
-      if (message != null && message.getType().equals("STATISTICS")) {
-        return message.unwrap(ContextualStatistics.class);
+      List<ContextualStatistics> messages = consumer.drainMessageBuffer()
+        .stream()
+        .filter(message -> message.getType().equals("STATISTICS"))
+        .flatMap(message -> message.unwrap(ContextualStatistics.class).stream())
+        .collect(Collectors.toList());
+      if(messages.isEmpty()) {
+        Thread.yield();
+      } else {
+        return messages;
       }
-      Thread.yield();
     }
-  }
-
-  private static List<File> getManagementPlugins() {
-    String[] paths = System.getProperty("managementPlugins").split(File.pathSeparator);
-    List<File> plugins = new ArrayList<File>(paths.length);
-    for (String path : paths) {
-      plugins.add(new File(path));
-    }
-    return plugins;
   }
 
   protected static List<String> messageTypes(List<Message> messages) {
-    List<String> types = new ArrayList<String>(messages.size());
-    for (Message message : messages) {
-      types.add(message.getType());
-    }
-    return types;
+    return messages.stream().map(Message::getType).collect(Collectors.toList());
   }
 
   protected static List<String> notificationTypes(List<Message> messages) {
-    List<String> types = new ArrayList<String>(messages.size());
-    for (Message message : messages) {
-      if ("NOTIFICATION".equals(message.getType())) {
-        for (ContextualNotification notification : message.unwrap(ContextualNotification.class)) {
-          types.add(notification.getType());
-        }
-      }
+    return messages
+      .stream()
+      .filter(message -> "NOTIFICATION".equals(message.getType()))
+      .flatMap(message -> message.unwrap(ContextualNotification.class).stream())
+      .map(ContextualNotification::getType)
+      .collect(Collectors.toList());
+  }
+
+  protected static String read(String path) throws FileNotFoundException {
+    Scanner scanner = new Scanner(AbstractClusteringManagementTest.class.getResourceAsStream(path), "UTF-8");
+    try {
+      return scanner.useDelimiter("\\A").next();
+    } finally {
+      scanner.close();
     }
-    return types;
+  }
+
+  protected static String normalizeForLineEndings(String stringToNormalize) {
+    return stringToNormalize.replace("\r\n", "\n").replace("\r", "\n");
   }
 
 }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheConfigWithManagementTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheConfigWithManagementTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.management;
+
+import org.ehcache.CacheManager;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.management.config.EhcacheStatisticsProviderConfiguration;
+import org.ehcache.management.registry.DefaultManagementRegistryConfiguration;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.terracotta.testing.rules.BasicExternalCluster;
+import org.terracotta.testing.rules.Cluster;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder.clusteredDedicated;
+import static org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder.clusteredShared;
+import static org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder.cluster;
+import static org.ehcache.config.builders.CacheConfigurationBuilder.newCacheConfigurationBuilder;
+import static org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
+
+public class EhcacheConfigWithManagementTest {
+
+  private static final String RESOURCE_CONFIG =
+    "<service xmlns:ohr='http://www.terracotta.org/config/offheap-resource' id=\"resources\">"
+      + "<ohr:offheap-resources>"
+      + "<ohr:resource name=\"primary-server-resource\" unit=\"MB\">64</ohr:resource>"
+      + "<ohr:resource name=\"secondary-server-resource\" unit=\"MB\">64</ohr:resource>"
+      + "</ohr:offheap-resources>" +
+      "</service>\n";
+
+  private static final List<File> MANAGEMENT_PLUGINS = Stream.of(System.getProperty("managementPlugins", "").split(File.pathSeparator))
+    .map(File::new)
+    .collect(Collectors.toList());
+
+  @ClassRule
+  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, MANAGEMENT_PLUGINS, "", RESOURCE_CONFIG, "");
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    CLUSTER.getClusterControl().waitForActive();
+  }
+
+  @Test
+  public void create_cache_manager() throws Exception {
+    CacheManager cacheManager = newCacheManagerBuilder()
+      // cluster config
+      .with(cluster(CLUSTER.getConnectionURI().resolve("/my-server-entity-3"))
+        .autoCreate()
+        .defaultServerResource("primary-server-resource")
+        .resourcePool("resource-pool-a", 28, MemoryUnit.MB, "secondary-server-resource") // <2>
+        .resourcePool("resource-pool-b", 16, MemoryUnit.MB)) // will take from primary-server-resource
+      // management config
+      .using(new DefaultManagementRegistryConfiguration()
+        .addTags("webapp-1", "server-node-1")
+        .setCacheManagerAlias("my-super-cache-manager")
+        .addConfiguration(new EhcacheStatisticsProviderConfiguration(
+          1, TimeUnit.MINUTES,
+          100, 1, TimeUnit.SECONDS,
+          2, TimeUnit.SECONDS))) // TTD reduce to 2 seconds so that the stat collector runs faster
+      // cache config
+      .withCache("dedicated-cache-1", newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+          .heap(10, EntryUnit.ENTRIES)
+          .offheap(1, MemoryUnit.MB)
+          .with(clusteredDedicated("primary-server-resource", 4, MemoryUnit.MB)))
+        .build())
+      .withCache("shared-cache-2", newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+          .heap(10, EntryUnit.ENTRIES)
+          .offheap(1, MemoryUnit.MB)
+          .with(clusteredShared("resource-pool-a")))
+        .build())
+      .withCache("shared-cache-3", newCacheConfigurationBuilder(
+        String.class, String.class,
+        newResourcePoolsBuilder()
+          .heap(10, EntryUnit.ENTRIES)
+          .offheap(1, MemoryUnit.MB)
+          .with(clusteredShared("resource-pool-b")))
+        .build())
+      .build(true);
+
+    cacheManager.close();
+  }
+
+}

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheManagerToStringTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheManagerToStringTest.java
@@ -92,7 +92,7 @@ public class EhcacheManagerToStringTest extends AbstractClusteringManagementTest
 
   @Test
   public void clusteredToString() throws Exception {
-    URI uri = CLUSTER.getConnectionURI().resolve("/my-server-entity-1");
+    URI uri = CLUSTER.getConnectionURI().resolve("/my-server-entity-2");
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         // cluster config
         .with(ClusteringServiceConfigurationBuilder.cluster(uri)
@@ -169,16 +169,4 @@ public class EhcacheManagerToStringTest extends AbstractClusteringManagementTest
     }
   }
 
-  private String read(String path) throws FileNotFoundException {
-    Scanner scanner = new Scanner(getClass().getResourceAsStream(path), "UTF-8");
-    try {
-      return scanner.useDelimiter("\\A").next();
-    } finally {
-      scanner.close();
-    }
-  }
-
-  private static String normalizeForLineEndings(String stringToNormalize) {
-    return stringToNormalize.replace("\r\n","\n").replace("\r","\n");
-  }
 }

--- a/clustered/integration-test/src/test/resources/clusteredConfiguration.txt
+++ b/clustered/integration-test/src/test/resources/clusteredConfiguration.txt
@@ -18,7 +18,7 @@ caches:
                     tierHeight: 10
 services:
     - org.ehcache.clustered.client.config.ClusteringServiceConfiguration:
-        clusterUri: terracotta://server-1:9510/my-server-entity-1
+        clusterUri: terracotta://server-1:9510/my-server-entity-2
         readOperationTimeout: TimeoutDuration{20 SECONDS}
         autoCreate: true
     - org.ehcache.management.registry.DefaultManagementRegistryConfiguration

--- a/clustered/server/build.gradle
+++ b/clustered/server/build.gradle
@@ -26,6 +26,12 @@ dependencies {
   compile group: 'org.terracotta', name: 'offheap-resource', version: parent.offheapResourceVersion
   compile group: 'org.terracotta', name: 'offheap-store', version: parent.offheapVersion
   compile group: 'org.slf4j', name: 'slf4j-api', version: parent.slf4jVersion
+  compile("org.terracotta.management:management-registry-service-api:$parent.managementVersion") {
+    // provided in management-server jar, but necessary so that ehcache can work without depending on management
+    exclude group: 'org.terracotta.management', module: 'management-registry'
+    exclude group: 'org.terracotta.management', module: 'management-model'
+  }
+  compile"org.terracotta.management.dist:management-common:$parent.managementVersion"
   provided "org.terracotta:entity-server-api:$parent.entityApiVersion"
   provided "org.terracotta:standard-cluster-services:$parent.terracottaApisVersion"
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ClientState.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ClientState.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a client's state against an {@link EhcacheActiveEntity}.
+ */
+public class ClientState {
+  /**
+   * Indicates if the client has either configured or validated with clustered store manager.
+   */
+  private boolean attached = false;
+
+  /**
+   * The set of stores to which the client has attached.
+   */
+  private final Set<String> attachedStores = new HashSet<String>();
+
+  public boolean isAttached() {
+    return attached;
+  }
+
+  void attach() {
+    this.attached = true;
+  }
+
+  boolean addStore(String storeName) {
+    return this.attachedStores.add(storeName);
+  }
+
+  boolean removeStore(String storeName) {
+    return this.attachedStores.remove(storeName);
+  }
+
+  public Set<String> getAttachedStores() {
+    return Collections.unmodifiableSet(new HashSet<String>(this.attachedStores));
+  }
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
@@ -121,7 +121,7 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
 
   @Override
   public Map<String, ServerSideConfiguration.Pool> getSharedResourcePools() {
-    return sharedResourcePools.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().getPool()));
+    return sharedResourcePools == null ? Collections.emptyMap() : sharedResourcePools.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().getPool()));
   }
 
   public void validate(ServerSideConfiguration configuration) throws ClusterException {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.clustered.server;
 
-import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.PoolAllocation;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
@@ -122,6 +121,12 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
   @Override
   public Map<String, ServerSideConfiguration.Pool> getSharedResourcePools() {
     return sharedResourcePools == null ? Collections.emptyMap() : sharedResourcePools.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().getPool()));
+  }
+
+  @Override
+  public ServerSideConfiguration.Pool getDedicatedResourcePool(String name) {
+    ResourcePageSource resourcePageSource = dedicatedResourcePools.get(name);
+    return resourcePageSource == null ? null : resourcePageSource.getPool();
   }
 
   public void validate(ServerSideConfiguration configuration) throws ClusterException {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ServerStoreImpl.java
@@ -21,6 +21,7 @@ import org.ehcache.clustered.common.internal.store.Chain;
 import org.ehcache.clustered.common.internal.store.ServerStore;
 import org.ehcache.clustered.server.offheap.OffHeapChainMap;
 import org.ehcache.clustered.server.offheap.OffHeapServerStore;
+import org.terracotta.offheapstore.MapInternals;
 import org.terracotta.offheapstore.paging.PageSource;
 
 import com.tc.classloader.CommonComponent;
@@ -29,7 +30,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 @CommonComponent
-public class ServerStoreImpl implements ServerStore {
+public class ServerStoreImpl implements ServerStore, MapInternals {
 
   private final ServerStoreConfiguration storeConfiguration;
   private final PageSource pageSource;
@@ -94,4 +95,43 @@ public class ServerStoreImpl implements ServerStore {
   public List<OffHeapChainMap<Long>> getSegments() {
     return store.getSegments();
   }
+
+  // stats
+
+
+  @Override
+  public long getDataAllocatedMemory() {return store.getDataAllocatedMemory();}
+
+  @Override
+  public long getAllocatedMemory() {return store.getAllocatedMemory();}
+
+  @Override
+  public long getRemovedSlotCount() {return store.getRemovedSlotCount();}
+
+  @Override
+  public long getDataVitalMemory() {return store.getDataVitalMemory();}
+
+  @Override
+  public int getReprobeLength() {return store.getReprobeLength();}
+
+  @Override
+  public long getDataSize() {return store.getDataSize();}
+
+  @Override
+  public long getDataOccupiedMemory() {return store.getDataOccupiedMemory();}
+
+  @Override
+  public long getUsedSlotCount() {return store.getUsedSlotCount();}
+
+  @Override
+  public long getSize() {return store.getSize();}
+
+  @Override
+  public long getVitalMemory() {return store.getVitalMemory();}
+
+  @Override
+  public long getOccupiedMemory() {return store.getOccupiedMemory();}
+
+  @Override
+  public long getTableCapacity() {return store.getTableCapacity();}
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClientStateBinding.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClientStateBinding.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.server.ClientState;
+import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.management.service.registry.provider.ClientBinding;
+
+final class ClientStateBinding extends ClientBinding {
+
+  ClientStateBinding(ClientDescriptor clientDescriptor, ClientState clientState) {
+    super(clientDescriptor, clientState);
+  }
+
+  @Override
+  public ClientState getValue() {
+    return (ClientState) super.getValue();
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClientStateSettingsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClientStateSettingsManagementProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.server.ClientState;
+import org.terracotta.management.model.capabilities.descriptors.Descriptor;
+import org.terracotta.management.model.capabilities.descriptors.Settings;
+import org.terracotta.management.model.cluster.ClientIdentifier;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+import org.terracotta.management.service.registry.provider.ClientBindingManagementProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Named("ClientStateSettings")
+@RequiredContext({@Named("consumerId"), @Named("clientId"), @Named("type")})
+class ClientStateSettingsManagementProvider extends ClientBindingManagementProvider<ClientStateBinding> {
+
+  ClientStateSettingsManagementProvider() {
+    super(ClientStateBinding.class);
+  }
+
+  @Override
+  protected ExposedClientStateBinding internalWrap(ClientStateBinding managedObject, long consumerId, ClientIdentifier clientIdentifier) {
+    return new ExposedClientStateBinding(managedObject, consumerId, clientIdentifier);
+  }
+
+  private static class ExposedClientStateBinding extends ExposedClientBinding<ClientStateBinding> {
+
+    ExposedClientStateBinding(ClientStateBinding clientBinding, long consumerId, ClientIdentifier clientIdentifier) {
+      super(clientBinding, consumerId, clientIdentifier);
+    }
+
+    @Override
+    public Context getContext() {
+      return super.getContext().with("type", "ClientState");
+    }
+
+    @Override
+    public Collection<? extends Descriptor> getDescriptors() {
+      ClientState clientState = getClientBinding().getValue();
+      Set<String> attachedStores = clientState.getAttachedStores();
+      return Collections.singleton(new Settings(getContext())
+        .set("attached", clientState.isAttached())
+        .set("attachedStores", new TreeSet<>(attachedStores).toArray(new String[attachedStores.size()]))
+      );
+    }
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/Management.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/Management.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.server.ClientState;
+import org.ehcache.clustered.server.ServerStoreImpl;
+import org.ehcache.clustered.server.state.EhcacheStateService;
+import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.ServiceRegistry;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.service.registry.ConsumerManagementRegistry;
+import org.terracotta.management.service.registry.ConsumerManagementRegistryConfiguration;
+import org.terracotta.management.service.registry.provider.ClientBinding;
+import org.terracotta.offheapresource.OffHeapResource;
+import org.terracotta.offheapresource.OffHeapResourceIdentifier;
+
+import java.util.Set;
+
+public class Management {
+
+  private final ConsumerManagementRegistry managementRegistry;
+  private final ServiceRegistry services;
+  private final EhcacheStateService ehcacheStateService;
+  private final Set<String> offHeapResourceIdentifiers;
+
+  public Management(ServiceRegistry services, EhcacheStateService ehcacheStateService, Set<String> offHeapResourceIdentifiers) {
+    managementRegistry = services.getService(new ConsumerManagementRegistryConfiguration(services));
+    this.services = services;
+    this.ehcacheStateService = ehcacheStateService;
+    this.offHeapResourceIdentifiers = offHeapResourceIdentifiers;
+    if (managementRegistry != null) {
+      // add some providers to describe and compute stats
+      managementRegistry.addManagementProvider(new ClientStateSettingsManagementProvider());
+      managementRegistry.addManagementProvider(new OffHeapResourceSettingsManagementProvider());
+      managementRegistry.addManagementProvider(new ServerStoreSettingsManagementProvider());
+      managementRegistry.addManagementProvider(new PoolSettingsManagementProvider(ehcacheStateService));
+    }
+  }
+
+  // the goal of the following code is to send the management metadata from the entity into the monitoring tre AFTER the entity creation
+  public void init() {
+    if (managementRegistry != null) {
+      managementRegistry.register(ehcacheStateService);
+
+      managementRegistry.register(PoolBinding.ALL_SHARED);
+
+      for (String identifier : offHeapResourceIdentifiers) {
+        OffHeapResource offHeapResource = services.getService(OffHeapResourceIdentifier.identifier(identifier));
+        managementRegistry.register(new OffHeapResourceBinding(identifier, offHeapResource));
+      }
+
+      managementRegistry.refresh();
+    }
+  }
+
+  public void close() {
+    if (managementRegistry != null) {
+      managementRegistry.close();
+    }
+  }
+
+  public void clientConnected(ClientDescriptor clientDescriptor, ClientState clientState) {
+    if (managementRegistry != null) {
+      managementRegistry.registerAndRefresh(new ClientStateBinding(clientDescriptor, clientState));
+    }
+  }
+
+
+  public void clientDisconnected(ClientDescriptor clientDescriptor, ClientState clientState) {
+    if (managementRegistry != null) {
+      managementRegistry.unregisterAndRefresh(new ClientStateBinding(clientDescriptor, clientState));
+    }
+  }
+
+  public void clientReconnected(ClientDescriptor clientDescriptor, ClientState clientState) {
+    if (managementRegistry != null) {
+      managementRegistry.refresh();
+      managementRegistry.pushServerEntityNotification(new ClientStateBinding(clientDescriptor, clientState), "EHCACHE_CLIENT_RECONNECTED");
+    }
+  }
+
+  public void sharedPoolsConfigured() {
+    if (managementRegistry != null) {
+      ehcacheStateService.getSharedResourcePools()
+        .entrySet()
+        .stream()
+        .forEach(e -> managementRegistry.register(new PoolBinding(e.getKey(), e.getValue(), PoolBinding.AllocationType.SHARED)));
+      managementRegistry.refresh();
+      managementRegistry.pushServerEntityNotification(PoolBinding.ALL_SHARED, "EHCACHE_RESOURCE_POOLS_CONFIGURED");
+    }
+  }
+
+  public void clientValidated(ClientDescriptor clientDescriptor, ClientState clientState) {
+    if (managementRegistry != null) {
+      managementRegistry.refresh();
+      managementRegistry.pushServerEntityNotification(new ClientStateBinding(clientDescriptor, clientState), "EHCACHE_CLIENT_VALIDATED");
+    }
+  }
+
+  public void serverStoreCreated(String name) {
+    if (managementRegistry != null) {
+      ServerStoreImpl serverStore = ehcacheStateService.getStore(name);
+      ServerStoreBinding serverStoreBinding = new ServerStoreBinding(name, serverStore);
+      managementRegistry.register(serverStoreBinding);
+      ServerSideConfiguration.Pool pool = ehcacheStateService.getDedicatedResourcePool(name);
+      if (pool != null) {
+        managementRegistry.register(new PoolBinding(name, pool, PoolBinding.AllocationType.DEDICATED));
+      }
+      managementRegistry.refresh();
+      managementRegistry.pushServerEntityNotification(serverStoreBinding, "EHCACHE_SERVER_STORE_CREATED");
+    }
+  }
+
+  public void storeAttached(ClientDescriptor clientDescriptor, ClientState clientState, String storeName) {
+    if (managementRegistry != null) {
+      managementRegistry.refresh();
+      managementRegistry.pushServerEntityNotification(new ClientBinding(clientDescriptor, clientState), "EHCACHE_SERVER_STORE_ATTACHED", Context.create("storeName", storeName));
+    }
+  }
+
+  public void releaseStore(ClientDescriptor clientDescriptor, ClientState clientState, String storeName) {
+    if (managementRegistry != null) {
+      managementRegistry.refresh();
+      managementRegistry.pushServerEntityNotification(new ClientBinding(clientDescriptor, clientState), "EHCACHE_SERVER_STORE_RELEASED", Context.create("storeName", storeName));
+    }
+  }
+
+  public void serverStoreDestroyed(String name) {
+    ServerStoreImpl serverStore = ehcacheStateService.getStore(name);
+    if (managementRegistry != null && serverStore != null) {
+      ServerStoreBinding managedObject = new ServerStoreBinding(name, serverStore);
+      managementRegistry.pushServerEntityNotification(managedObject, "EHCACHE_SERVER_STORE_DESTROYED");
+      managementRegistry.unregister(managedObject);
+      ServerSideConfiguration.Pool pool = ehcacheStateService.getDedicatedResourcePool(name);
+      if (pool != null) {
+        managementRegistry.unregister(new PoolBinding(name, pool, PoolBinding.AllocationType.DEDICATED));
+      }
+      managementRegistry.refresh();
+    }
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/OffHeapResourceBinding.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/OffHeapResourceBinding.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.terracotta.management.service.registry.provider.AliasBinding;
+import org.terracotta.offheapresource.OffHeapResource;
+
+class OffHeapResourceBinding extends AliasBinding {
+
+  OffHeapResourceBinding(String identifier, OffHeapResource offHeapResource) {
+    super(identifier, offHeapResource);
+  }
+
+  @Override
+  public OffHeapResource getValue() {
+    return (OffHeapResource) super.getValue();
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/OffHeapResourceSettingsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/OffHeapResourceSettingsManagementProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.terracotta.management.model.capabilities.descriptors.Descriptor;
+import org.terracotta.management.model.capabilities.descriptors.Settings;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+import org.terracotta.management.service.registry.provider.AliasBindingManagementProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Named("OffHeapResourceSettings")
+@RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
+class OffHeapResourceSettingsManagementProvider extends AliasBindingManagementProvider<OffHeapResourceBinding> {
+
+  OffHeapResourceSettingsManagementProvider() {
+    super(OffHeapResourceBinding.class);
+  }
+
+  @Override
+  public Collection<Descriptor> getDescriptors() {
+    Collection<Descriptor> descriptors = super.getDescriptors();
+    descriptors.add(new Settings()
+      .set("type", "OffHeapResourceSettingsManagementProvider")
+      .set("time", System.currentTimeMillis()));
+    return descriptors;
+  }
+
+  @Override
+  protected ExposedOffHeapResourceBinding wrap(OffHeapResourceBinding managedObject) {
+    return new ExposedOffHeapResourceBinding(managedObject, getConsumerId());
+  }
+
+  private static class ExposedOffHeapResourceBinding extends ExposedAliasBinding<OffHeapResourceBinding> {
+
+    ExposedOffHeapResourceBinding(OffHeapResourceBinding binding, long consumerId) {
+      super(binding, consumerId);
+    }
+
+    @Override
+    public Context getContext() {
+      return super.getContext().with("type", "OffHeapResource");
+    }
+
+    @Override
+    public Collection<? extends Descriptor> getDescriptors() {
+      return Collections.singleton(new Settings(getContext())
+        .set("capacity", getBinding().getValue().capacity())
+        .set("availableAtTime", getBinding().getValue().available())
+      );
+    }
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolBinding.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolBinding.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.terracotta.management.model.Objects;
+import org.terracotta.management.service.registry.provider.AliasBinding;
+
+class PoolBinding extends AliasBinding {
+
+  enum AllocationType {
+    SHARED,
+    DEDICATED
+  }
+
+  // this marker is used to send global notification - it is not a real pool
+  static final PoolBinding ALL_SHARED = new PoolBinding("PoolBinding#all-shared", new ServerSideConfiguration.Pool(1, ""), AllocationType.SHARED);
+
+  private final AllocationType allocationType;
+
+  PoolBinding(String identifier, ServerSideConfiguration.Pool serverStore, AllocationType allocationType) {
+    super(identifier, serverStore);
+    this.allocationType = Objects.requireNonNull(allocationType);
+  }
+
+  AllocationType getAllocationType() {
+    return allocationType;
+  }
+
+  @Override
+  public ServerSideConfiguration.Pool getValue() {
+    return (ServerSideConfiguration.Pool) super.getValue();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    PoolBinding that = (PoolBinding) o;
+    return allocationType == that.allocationType;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + allocationType.hashCode();
+    return result;
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolSettingsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolSettingsManagementProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.server.state.EhcacheStateService;
+import org.terracotta.management.model.capabilities.descriptors.Descriptor;
+import org.terracotta.management.model.capabilities.descriptors.Settings;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+import org.terracotta.management.service.registry.provider.AliasBindingManagementProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Named("PoolSettings")
+@RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
+class PoolSettingsManagementProvider extends AliasBindingManagementProvider<PoolBinding> {
+
+  private final EhcacheStateService ehcacheStateService;
+
+  PoolSettingsManagementProvider(EhcacheStateService ehcacheStateService) {
+    super(PoolBinding.class);
+    this.ehcacheStateService = ehcacheStateService;
+  }
+
+  @Override
+  public Collection<Descriptor> getDescriptors() {
+    Collection<Descriptor> descriptors = super.getDescriptors();
+    descriptors.add(new Settings()
+      .set("type", "PoolSettingsManagementProvider")
+      .set("defaultServerResource", ehcacheStateService.getDefaultServerResource()));
+    return descriptors;
+  }
+
+  @Override
+  protected ExposedPoolBinding wrap(PoolBinding managedObject) {
+    return new ExposedPoolBinding(managedObject, getConsumerId());
+  }
+
+  private static class ExposedPoolBinding extends ExposedAliasBinding<PoolBinding> {
+
+    ExposedPoolBinding(PoolBinding binding, long consumerId) {
+      super(binding, consumerId);
+    }
+
+    @Override
+    public Context getContext() {
+      return super.getContext().with("type", "PoolBinding");
+    }
+
+    @Override
+    public Collection<? extends Descriptor> getDescriptors() {
+      return getBinding() == PoolBinding.ALL_SHARED ?
+        Collections.emptyList() :
+        Collections.singleton(new Settings(getContext())
+          .set("serverResource", getBinding().getValue().getServerResource())
+          .set("size", getBinding().getValue().getSize())
+          .set("allocationType", getBinding().getAllocationType()));
+    }
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ServerStoreBinding.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ServerStoreBinding.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.server.ServerStoreImpl;
+import org.terracotta.management.service.registry.provider.AliasBinding;
+
+class ServerStoreBinding extends AliasBinding {
+
+  ServerStoreBinding(String identifier, ServerStoreImpl serverStore) {
+    super(identifier, serverStore);
+  }
+
+  @Override
+  public ServerStoreImpl getValue() {
+    return (ServerStoreImpl) super.getValue();
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ServerStoreSettingsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ServerStoreSettingsManagementProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.common.PoolAllocation;
+import org.terracotta.management.model.capabilities.descriptors.Descriptor;
+import org.terracotta.management.model.capabilities.descriptors.Settings;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+import org.terracotta.management.service.registry.provider.AliasBindingManagementProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Named("ServerStoreSettings")
+@RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
+class ServerStoreSettingsManagementProvider extends AliasBindingManagementProvider<ServerStoreBinding> {
+
+  ServerStoreSettingsManagementProvider() {
+    super(ServerStoreBinding.class);
+  }
+
+  @Override
+  public Collection<Descriptor> getDescriptors() {
+    Collection<Descriptor> descriptors = super.getDescriptors();
+    descriptors.add(new Settings()
+      .set("type", "ServerStoreSettingsManagementProvider")
+      .set("time", System.currentTimeMillis()));
+    return descriptors;
+  }
+
+  @Override
+  protected ExposedServerStoreBinding wrap(ServerStoreBinding managedObject) {
+    return new ExposedServerStoreBinding(managedObject, getConsumerId());
+  }
+
+  private static class ExposedServerStoreBinding extends ExposedAliasBinding<ServerStoreBinding> {
+
+    ExposedServerStoreBinding(ServerStoreBinding binding, long consumerId) {
+      super(binding, consumerId);
+    }
+
+    @Override
+    public Context getContext() {
+      return super.getContext().with("type", "ServerStore");
+    }
+
+    @Override
+    public Collection<? extends Descriptor> getDescriptors() {
+      return Collections.singleton(getSettings());
+    }
+
+    Settings getSettings() {
+      // names taken from ServerStoreConfiguration.isCompatible()
+      PoolAllocation poolAllocation = getBinding().getValue().getStoreConfiguration().getPoolAllocation();
+      Settings settings = new Settings(getContext())
+        .set("resourcePoolType", poolAllocation.getClass().getSimpleName().toLowerCase())
+        .set("allocatedMemoryAtTime", getBinding().getValue().getAllocatedMemory())
+        .set("tableCapacityAtTime", getBinding().getValue().getTableCapacity())
+        .set("vitalMemoryAtTime", getBinding().getValue().getVitalMemory())
+        .set("longSizeAtTime", getBinding().getValue().getSize())
+        .set("dataAllocatedMemoryAtTime", getBinding().getValue().getDataAllocatedMemory())
+        .set("dataOccupiedMemoryAtTime", getBinding().getValue().getDataOccupiedMemory())
+        .set("dataSizeAtTime", getBinding().getValue().getDataSize())
+        .set("dataVitalMemoryAtTime", getBinding().getValue().getDataVitalMemory());
+      if (poolAllocation instanceof PoolAllocation.Dedicated) {
+        settings.set("resourcePoolDedicatedResourceName", ((PoolAllocation.Dedicated) poolAllocation).getResourceName());
+        settings.set("resourcePoolDedicatedSize", ((PoolAllocation.Dedicated) poolAllocation).getSize());
+      } else if (poolAllocation instanceof PoolAllocation.Shared) {
+        settings.set("resourcePoolSharedPoolName", ((PoolAllocation.Shared) poolAllocation).getResourcePoolName());
+      }
+      return settings;
+    }
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
@@ -23,13 +23,14 @@ import org.ehcache.clustered.common.internal.store.Chain;
 import org.ehcache.clustered.common.internal.store.ServerStore;
 import org.ehcache.clustered.server.KeySegmentMapper;
 import org.ehcache.clustered.server.ServerStoreEvictionListener;
+import org.terracotta.offheapstore.MapInternals;
 import org.terracotta.offheapstore.exceptions.OversizeMappingException;
 import org.terracotta.offheapstore.paging.PageSource;
 
 import static org.terracotta.offheapstore.util.MemoryUnit.KILOBYTES;
 import static org.terracotta.offheapstore.util.MemoryUnit.MEGABYTES;
 
-public class OffHeapServerStore implements ServerStore {
+public class OffHeapServerStore implements ServerStore, MapInternals {
 
   private final List<OffHeapChainMap<Long>> segments;
   private final KeySegmentMapper mapper;
@@ -227,6 +228,116 @@ public class OffHeapServerStore implements ServerStore {
     } finally {
       writeUnlockAll();
     }
+  }
+
+  // stats
+
+  @Override
+  public long getAllocatedMemory() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getAllocatedMemory();
+    }
+    return total;
+  }
+
+  @Override
+  public long getOccupiedMemory() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getOccupiedMemory();
+    }
+    return total;
+  }
+
+  @Override
+  public long getDataAllocatedMemory() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getDataAllocatedMemory();
+    }
+    return total;
+  }
+
+  @Override
+  public long getDataOccupiedMemory() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getDataOccupiedMemory();
+    }
+    return total;
+  }
+
+  @Override
+  public long getDataSize() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getDataSize();
+    }
+    return total;
+  }
+
+  @Override
+  public long getSize() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getSize();
+    }
+    return total;
+  }
+
+  @Override
+  public long getTableCapacity() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getTableCapacity();
+    }
+    return total;
+  }
+
+  @Override
+  public long getUsedSlotCount() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getUsedSlotCount();
+    }
+    return total;
+  }
+
+  @Override
+  public long getRemovedSlotCount() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getRemovedSlotCount();
+    }
+    return total;
+  }
+
+  @Override
+  public int getReprobeLength() {
+    int total = 0;
+    for (MapInternals segment : segments) {
+      total += segment.getReprobeLength();
+    }
+    return total;
+  }
+
+  @Override
+  public long getVitalMemory() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getVitalMemory();
+    }
+    return total;
+  }
+
+  @Override
+  public long getDataVitalMemory() {
+    long total = 0L;
+    for (MapInternals segment : segments) {
+      total += segment.getDataVitalMemory();
+    }
+    return total;
   }
 
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
@@ -34,6 +34,8 @@ public interface EhcacheStateService {
 
   Map<String, ServerSideConfiguration.Pool> getSharedResourcePools();
 
+  ServerSideConfiguration.Pool getDedicatedResourcePool(String name);
+
   ServerStoreImpl getStore(String name);
 
   Set<String> getStores();

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
@@ -48,6 +48,8 @@ import org.terracotta.entity.IEntityMessenger;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceRegistry;
+import org.terracotta.management.service.registry.ConsumerManagementRegistry;
+import org.terracotta.management.service.registry.ConsumerManagementRegistryConfiguration;
 import org.terracotta.offheapresource.OffHeapResource;
 import org.terracotta.offheapresource.OffHeapResourceIdentifier;
 import org.terracotta.offheapresource.OffHeapResources;
@@ -2886,6 +2888,8 @@ public class EhcacheActiveEntityTest {
         return (T) (this.storeManagerService);
       } else if (serviceConfiguration.getServiceType().equals(IEntityMessenger.class)) {
         return (T) mock(IEntityMessenger.class);
+      } else if(serviceConfiguration instanceof ConsumerManagementRegistryConfiguration) {
+        return (T) mock(ConsumerManagementRegistry.class);
       }
 
       throw new UnsupportedOperationException("Registry.getService does not support " + serviceConfiguration.getClass().getName());
@@ -2928,6 +2932,11 @@ public class EhcacheActiveEntityTest {
     @Override
     public long available() {
       return this.capacity - this.used;
+    }
+
+    @Override
+    public long capacity() {
+      return capacity;
     }
 
     private long getUsed() {

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcachePassiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcachePassiveEntityTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import org.terracotta.entity.IEntityMessenger;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceRegistry;
+import org.terracotta.management.service.registry.ConsumerManagementRegistry;
+import org.terracotta.management.service.registry.ConsumerManagementRegistryConfiguration;
 import org.terracotta.offheapresource.OffHeapResource;
 import org.terracotta.offheapresource.OffHeapResourceIdentifier;
 import org.terracotta.offheapresource.OffHeapResources;
@@ -659,6 +661,8 @@ public class EhcachePassiveEntityTest {
         return (T) (this.storeManagerService);
       } else if (serviceConfiguration.getServiceType().equals(IEntityMessenger.class)) {
         return (T) mock(IEntityMessenger.class);
+      } else if(serviceConfiguration instanceof ConsumerManagementRegistryConfiguration) {
+        return (T) mock(ConsumerManagementRegistry.class);
       }
 
       throw new UnsupportedOperationException("Registry.getService does not support " + serviceConfiguration.getClass().getName());
@@ -701,6 +705,11 @@ public class EhcachePassiveEntityTest {
     @Override
     public long available() {
       return this.capacity - this.used;
+    }
+
+    @Override
+    public long capacity() {
+      return capacity;
     }
 
     private long getUsed() {

--- a/management/src/main/java/org/ehcache/management/providers/CacheBindingManagementProvider.java
+++ b/management/src/main/java/org/ehcache/management/providers/CacheBindingManagementProvider.java
@@ -38,7 +38,7 @@ public abstract class CacheBindingManagementProvider extends AbstractManagementP
   @Override
   public Collection<Descriptor> getDescriptors() {
     Collection<Descriptor> capabilities = new LinkedHashSet<Descriptor>();
-    for (ExposedObject o : managedObjects) {
+    for (ExposedObject o : getExposedObjects()) {
       capabilities.addAll(((ExposedCacheBinding) o).getDescriptors());
     }
     return capabilities;

--- a/management/src/main/java/org/ehcache/management/providers/ExposedCacheBinding.java
+++ b/management/src/main/java/org/ehcache/management/providers/ExposedCacheBinding.java
@@ -28,10 +28,12 @@ public abstract class ExposedCacheBinding implements ExposedObject<CacheBinding>
 
   protected final ManagementRegistryServiceConfiguration registryConfiguration;
   protected final CacheBinding cacheBinding;
+  private final Context context;
 
   protected ExposedCacheBinding(ManagementRegistryServiceConfiguration registryConfiguration, CacheBinding cacheBinding) {
     this.registryConfiguration = registryConfiguration;
     this.cacheBinding = cacheBinding;
+    this.context = registryConfiguration.getContext().with("cacheName", cacheBinding.getAlias());
   }
 
   @Override
@@ -46,10 +48,11 @@ public abstract class ExposedCacheBinding implements ExposedObject<CacheBinding>
   }
 
   @Override
-  public final boolean matches(Context context) {
-    return context.contains(registryConfiguration.getContext().with("cacheName", cacheBinding.getAlias()));
+  public Context getContext() {
+    return context;
   }
 
+  @Override
   public Collection<? extends Descriptor> getDescriptors() {
     return Collections.emptyList();
   }

--- a/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistryService.java
+++ b/management/src/main/java/org/ehcache/management/registry/DefaultManagementRegistryService.java
@@ -103,13 +103,11 @@ public class DefaultManagementRegistryService extends AbstractManagementRegistry
   public void cacheAdded(String alias, Cache<?, ?> cache) {
     StatisticsManager.associate(cache).withParent(cacheManager);
 
-    register(cache);
     register(new CacheBinding(alias, cache));
   }
 
   @Override
   public void cacheRemoved(String alias, Cache<?, ?> cache) {
-    unregister(cache);
     unregister(new CacheBinding(alias, cache));
 
     StatisticsManager.dissociate(cache).fromParent(cacheManager);


### PR DESCRIPTION
Depends on Terracotta-OSS/terracotta-platform#165

Depends on tc-platform release __5.0.8.beta3__

Close #1008

New events:

- EHCACHE_CLIENT_RECONNECTED
- EHCACHE_RESOURCE_POOLS_CONFIGURED
- EHCACHE_CLIENT_VALIDATED
- EHCACHE_SERVER_STORE_CREATED
- EHCACHE_SERVER_STORE_ATTACHED
- EHCACHE_SERVER_STORE_RELEASED
- EHCACHE_SERVER_STORE_DESTROYED

Exposes management descriptors for stores, client states, pools and server resources.