### PR TITLE
Closes #1525 Closes #1418 Making server side data strutures thread-safe

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/ClientMessageTracker.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/ClientMessageTracker.java
@@ -26,8 +26,8 @@ import java.util.concurrent.ConcurrentMap;
 public class ClientMessageTracker {
 
   private final ConcurrentMap<UUID, MessageTracker> messageTrackers = new ConcurrentHashMap<>();
-  private UUID entityConfiguredStamp = null;
-  private long configuredTimestamp;
+  private volatile UUID entityConfiguredStamp = null;
+  private volatile long configuredTimestamp;
 
   public boolean isAdded(UUID clientId) {
     return messageTrackers.containsKey(clientId);


### PR DESCRIPTION
Since most of the *state* of the classes in the change-set have data structures holding life-cycle related state, I didn't have to do much to address concurrent mutations as that will never happen since all the life-cycle operations are run on the same concurrency key. The only thing that I had to ensure was the visibility of these mutating operations. I could address that mostly by replacing non-thread safe data structures with the ones that provide visibility guarantees.

Now am not sure if I'm supposed to write tests for these changes. If yes, I'm gonna need some guidance on writing tests for these kinda changes.