### PR TITLE
[release/3.1] Fix #1569 Proper ByteBuffer usage

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/BaseKeyValueOperation.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/BaseKeyValueOperation.java
@@ -46,10 +46,11 @@ abstract class BaseKeyValueOperation<K, V> implements Operation<K, V> {
     }
     this.timeStamp = buffer.getLong();
     int keySize = buffer.getInt();
+    int maxLimit = buffer.limit();
     buffer.limit(buffer.position() + keySize);
     ByteBuffer keyBlob = buffer.slice();
     buffer.position(buffer.limit());
-    buffer.limit(buffer.capacity());
+    buffer.limit(maxLimit);
     try {
       this.key = keySerializer.read(keyBlob);
     } catch (ClassNotFoundException e) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/ChainResolver.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/ChainResolver.java
@@ -122,7 +122,7 @@ public class ChainResolver<K, V> {
           }
         }
       } else {
-        payload.flip();
+        payload.rewind();
         chainBuilder = chainBuilder.add(payload);
       }
     }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/ConditionalReplaceOperation.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/ConditionalReplaceOperation.java
@@ -53,16 +53,17 @@ public class ConditionalReplaceOperation<K, V> implements Operation<K, V>, Resul
     }
     this.timeStamp = buffer.getLong();
     int keySize = buffer.getInt();
+    int maxLimit = buffer.limit();
     buffer.limit(buffer.position() + keySize);
     ByteBuffer keyBlob = buffer.slice();
     buffer.position(buffer.limit());
-    buffer.limit(buffer.capacity());
+    buffer.limit(maxLimit);
 
     int oldValueSize = buffer.getInt();
     buffer.limit(buffer.position() + oldValueSize);
     ByteBuffer oldValueBlob = buffer.slice();
     buffer.position(buffer.limit());
-    buffer.limit(buffer.capacity());
+    buffer.limit(maxLimit);
 
     ByteBuffer valueBlob = buffer.slice();
 


### PR DESCRIPTION
* Set limit based on known limit instead of capacity
* rewind instead of flip after decoding