### PR TITLE
Resource usage stats from Ehcache server entity (close #1551 and close #1530)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.8.beta6'
+  terracottaPlatformVersion = '5.0.9.beta'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.0.9.beta'
   terracottaCoreVersion = '5.0.9-beta2'

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
@@ -141,21 +141,21 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
     assertThat(settings.get("type"), equalTo("PoolBinding"));
     assertThat(settings.get("serverResource"), equalTo("primary-server-resource"));
     assertThat(settings.get("size"), equalTo(16 * 1024 * 1024L));
-    assertThat(settings.get("allocationType"), equalTo("SHARED"));
+    assertThat(settings.get("allocationType"), equalTo("shared"));
 
     settings = (Settings) descriptors.get(1);
     assertThat(settings.get("alias"), equalTo("resource-pool-a"));
     assertThat(settings.get("type"), equalTo("PoolBinding"));
     assertThat(settings.get("serverResource"), equalTo("secondary-server-resource"));
     assertThat(settings.get("size"), equalTo(28 * 1024 * 1024L));
-    assertThat(settings.get("allocationType"), equalTo("SHARED"));
+    assertThat(settings.get("allocationType"), equalTo("shared"));
 
     settings = (Settings) descriptors.get(2);
     assertThat(settings.get("alias"), equalTo("dedicated-cache-1"));
     assertThat(settings.get("type"), equalTo("PoolBinding"));
     assertThat(settings.get("serverResource"), equalTo("primary-server-resource"));
     assertThat(settings.get("size"), equalTo(4 * 1024 * 1024L));
-    assertThat(settings.get("allocationType"), equalTo("DEDICATED"));
+    assertThat(settings.get("allocationType"), equalTo("dedicated"));
 
     settings = (Settings) descriptors.get(3);
     assertThat(settings.get("type"), equalTo("PoolSettingsManagementProvider"));

--- a/clustered/server/build.gradle
+++ b/clustered/server/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     exclude group: 'org.terracotta.management', module: 'management-registry'
     exclude group: 'org.terracotta.management', module: 'management-model'
   }
+  compile ("org.terracotta:statistics:$parent.statisticVersion") {
+    exclude group:'org.slf4j', module:'slf4j-api'
+  }
   compile"org.terracotta.management.dist:management-common:$parent.managementVersion"
   provided "org.terracotta:entity-server-api:$parent.entityApiVersion"
   provided "org.terracotta:standard-cluster-services:$parent.terracottaApisVersion"

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -821,7 +821,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
       if (!removedFromClient) {
         throw new InvalidStoreException("Clustered tier '" + name + "' is not in use by client");
       } else {
-        management.releaseStore(clientDescriptor, clientStateMap.get(clientDescriptor), name);
+        management.storeReleased(clientDescriptor, clientStateMap.get(clientDescriptor), name);
       }
     } else {
       throw new InvalidStoreException("Clustered tier '" + name + "' does not exist");

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
@@ -74,7 +74,7 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
 
   static {
     STAT_STORE_METHOD_REFERENCES.put("allocatedMemory", ServerStoreImpl::getAllocatedMemory);
-    STAT_STORE_METHOD_REFERENCES.put("dataOccupiedMemory", ServerStoreImpl::getDataOccupiedMemory);
+    STAT_STORE_METHOD_REFERENCES.put("dataAllocatedMemory", ServerStoreImpl::getDataAllocatedMemory);
     STAT_STORE_METHOD_REFERENCES.put("occupiedMemory", ServerStoreImpl::getOccupiedMemory);
     STAT_STORE_METHOD_REFERENCES.put("dataOccupiedMemory", ServerStoreImpl::getDataOccupiedMemory);
     STAT_STORE_METHOD_REFERENCES.put("entries", ServerStoreImpl::getSize);

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/AbstractExposedStatistics.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/AbstractExposedStatistics.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.terracotta.context.extended.RegisteredCompoundStatistic;
+import org.terracotta.context.extended.RegisteredCounterStatistic;
+import org.terracotta.context.extended.RegisteredRatioStatistic;
+import org.terracotta.context.extended.RegisteredSizeStatistic;
+import org.terracotta.context.extended.RegisteredStatistic;
+import org.terracotta.context.extended.StatisticsRegistry;
+import org.terracotta.management.model.capabilities.descriptors.Descriptor;
+import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
+import org.terracotta.management.model.stats.MemoryUnit;
+import org.terracotta.management.model.stats.NumberUnit;
+import org.terracotta.management.model.stats.Sample;
+import org.terracotta.management.model.stats.Statistic;
+import org.terracotta.management.model.stats.StatisticType;
+import org.terracotta.management.model.stats.history.AverageHistory;
+import org.terracotta.management.model.stats.history.CounterHistory;
+import org.terracotta.management.model.stats.history.DurationHistory;
+import org.terracotta.management.model.stats.history.RateHistory;
+import org.terracotta.management.model.stats.history.RatioHistory;
+import org.terracotta.management.model.stats.history.SizeHistory;
+import org.terracotta.management.service.registry.provider.AliasBinding;
+import org.terracotta.management.service.registry.provider.AliasBindingManagementProvider;
+import org.terracotta.offheapstore.util.FindbugsSuppressWarnings;
+import org.terracotta.statistics.extended.CompoundOperation;
+import org.terracotta.statistics.extended.SampledStatistic;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@FindbugsSuppressWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
+class AbstractExposedStatistics<T extends AliasBinding> extends AliasBindingManagementProvider.ExposedAliasBinding<T> implements Closeable {
+
+  protected final StatisticsRegistry statisticsRegistry;
+
+  AbstractExposedStatistics(long consumerId, T binding, StatisticConfiguration statisticConfiguration, ScheduledExecutorService executor, Object statisticContextObject) {
+    super(binding, consumerId);
+    if(statisticContextObject == null) {
+      this.statisticsRegistry = null;
+
+    } else {
+      this.statisticsRegistry = new StatisticsRegistry(
+        statisticContextObject,
+        executor,
+        statisticConfiguration.averageWindowDuration(),
+        statisticConfiguration.averageWindowUnit(),
+        statisticConfiguration.historySize(),
+        statisticConfiguration.historyInterval(),
+        statisticConfiguration.historyIntervalUnit(),
+        statisticConfiguration.timeToDisable(),
+        statisticConfiguration.timeToDisableUnit());
+    }
+  }
+
+  void init() {
+    if (statisticsRegistry != null) {
+      Map<String, RegisteredStatistic> registrations = statisticsRegistry.getRegistrations();
+      for (RegisteredStatistic registeredStatistic : registrations.values()) {
+        registeredStatistic.getSupport().setAlwaysOn(true);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    if (statisticsRegistry != null) {
+      statisticsRegistry.clearRegistrations();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public Statistic<?, ?> queryStatistic(String statisticName, long since) {
+    if (statisticsRegistry != null) {
+      Map<String, RegisteredStatistic> registrations = statisticsRegistry.getRegistrations();
+      for (Entry<String, RegisteredStatistic> entry : registrations.entrySet()) {
+        String name = entry.getKey();
+        RegisteredStatistic registeredStatistic = entry.getValue();
+
+        if (registeredStatistic instanceof RegisteredCompoundStatistic) {
+          RegisteredCompoundStatistic registeredCompoundStatistic = (RegisteredCompoundStatistic) registeredStatistic;
+          CompoundOperation<?> compoundOperation = registeredCompoundStatistic.getCompoundOperation();
+
+          if ((name + "Count").equals(statisticName)) {
+            SampledStatistic<Long> count = compoundOperation.compound((Set) registeredCompoundStatistic.getCompound()).count();
+            return new CounterHistory(buildHistory(count, since), NumberUnit.COUNT);
+          } else if ((name + "Rate").equals(statisticName)) {
+            SampledStatistic<Double> rate = compoundOperation.compound((Set) registeredCompoundStatistic.getCompound()).rate();
+            return new RateHistory(buildHistory(rate, since), TimeUnit.SECONDS);
+
+          } else if ((name + "LatencyMinimum").equals(statisticName)) {
+            SampledStatistic<Long> minimum = compoundOperation.compound((Set) registeredCompoundStatistic.getCompound()).latency().minimum();
+            return new DurationHistory(buildHistory(minimum, since), TimeUnit.NANOSECONDS);
+
+          } else if ((name + "LatencyMaximum").equals(statisticName)) {
+            SampledStatistic<Long> maximum = compoundOperation.compound((Set) registeredCompoundStatistic.getCompound()).latency().maximum();
+            return new DurationHistory(buildHistory(maximum, since), TimeUnit.NANOSECONDS);
+
+          } else if ((name + "LatencyAverage").equals(statisticName)) {
+            SampledStatistic<Double> average = compoundOperation.compound((Set) registeredCompoundStatistic.getCompound()).latency().average();
+            return new AverageHistory(buildHistory(average, since), TimeUnit.NANOSECONDS);
+          }
+        } else if (registeredStatistic instanceof RegisteredRatioStatistic) {
+          RegisteredRatioStatistic registeredRatioStatistic = (RegisteredRatioStatistic) registeredStatistic;
+          CompoundOperation<?> compoundOperation = registeredRatioStatistic.getCompoundOperation();
+
+          if (name.equals(statisticName)) {
+            SampledStatistic<Double> ratio = (SampledStatistic) compoundOperation.ratioOf((Set) registeredRatioStatistic.getNumerator(), (Set) registeredRatioStatistic.getDenominator());
+            return new RatioHistory(buildHistory(ratio, since), NumberUnit.RATIO);
+          }
+        } else if (registeredStatistic instanceof RegisteredSizeStatistic) {
+          RegisteredSizeStatistic registeredSizeStatistic = (RegisteredSizeStatistic) registeredStatistic;
+          if (name.equals(statisticName)) {
+            SampledStatistic<Long> count = (SampledStatistic<Long>) registeredSizeStatistic.getSampledStatistic();
+            return new SizeHistory(buildHistory(count, since), MemoryUnit.B);
+          }
+        } else if (registeredStatistic instanceof RegisteredCounterStatistic) {
+          RegisteredCounterStatistic registeredCounterStatistic = (RegisteredCounterStatistic) registeredStatistic;
+          if (name.equals(statisticName)) {
+            SampledStatistic<Long> count = (SampledStatistic<Long>) registeredCounterStatistic.getSampledStatistic();
+            return new CounterHistory(buildHistory(count, since), NumberUnit.COUNT);
+          }
+        } else {
+          throw new UnsupportedOperationException("Cannot handle registered statistic type : " + registeredStatistic);
+        }
+      }
+    }
+
+    throw new IllegalArgumentException("No registered statistic named '" + statisticName + "'");
+  }
+
+  @Override
+  public Collection<Descriptor> getDescriptors() {
+    Set<Descriptor> capabilities = new HashSet<>();
+    capabilities.addAll(queryStatisticsRegistry());
+    return capabilities;
+  }
+
+  private Set<Descriptor> queryStatisticsRegistry() {
+    Set<Descriptor> capabilities = new HashSet<>();
+
+    if (statisticsRegistry != null) {
+      Map<String, RegisteredStatistic> registrations = statisticsRegistry.getRegistrations();
+
+      for (Entry<String, RegisteredStatistic> entry : registrations.entrySet()) {
+        String statisticName = entry.getKey();
+        RegisteredStatistic registeredStatistic = registrations.get(statisticName);
+
+        if (registeredStatistic instanceof RegisteredCompoundStatistic) {
+          List<StatisticDescriptor> statistics = new ArrayList<>();
+          statistics.add(new StatisticDescriptor(entry.getKey() + "Count", StatisticType.COUNTER_HISTORY));
+          statistics.add(new StatisticDescriptor(entry.getKey() + "Rate", StatisticType.RATE_HISTORY));
+          statistics.add(new StatisticDescriptor(entry.getKey() + "LatencyMinimum", StatisticType.DURATION_HISTORY));
+          statistics.add(new StatisticDescriptor(entry.getKey() + "LatencyMaximum", StatisticType.DURATION_HISTORY));
+          statistics.add(new StatisticDescriptor(entry.getKey() + "LatencyAverage", StatisticType.AVERAGE_HISTORY));
+
+          capabilities.addAll(statistics);
+        } else if (registeredStatistic instanceof RegisteredRatioStatistic) {
+          capabilities.add(new StatisticDescriptor(entry.getKey() + "Ratio", StatisticType.RATIO_HISTORY));
+        } else if (registeredStatistic instanceof RegisteredCounterStatistic) {
+          capabilities.add(new StatisticDescriptor(statisticName, StatisticType.COUNTER_HISTORY));
+        } else if (registeredStatistic instanceof RegisteredSizeStatistic) {
+          capabilities.add(new StatisticDescriptor(statisticName, StatisticType.SIZE_HISTORY));
+        }
+      }
+    }
+
+    return capabilities;
+  }
+
+  private static  <T extends Number> List<Sample<T>> buildHistory(SampledStatistic<T> sampledStatistic, long since) {
+    return sampledStatistic.history()
+      .stream()
+      .filter(timestamped -> timestamped.getTimestamp() >= since)
+      .map(timestamped -> new Sample<>(timestamped.getTimestamp(), timestamped.getSample()))
+      .collect(Collectors.toList());
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/AbstractStatisticsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/AbstractStatisticsManagementProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.capabilities.StatisticsCapability;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.stats.Statistic;
+import org.terracotta.management.registry.action.ExposedObject;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+import org.terracotta.management.service.registry.provider.AliasBinding;
+import org.terracotta.management.service.registry.provider.AliasBindingManagementProvider;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Named("ServerStoreSettings")
+@RequiredContext({@Named("consumerId")})
+abstract class AbstractStatisticsManagementProvider<T extends AliasBinding> extends AliasBindingManagementProvider<T> {
+
+  private final StatisticConfiguration statisticConfiguration;
+
+  public AbstractStatisticsManagementProvider(Class<? extends T> type, StatisticConfiguration statisticConfiguration) {
+    super(type);
+    this.statisticConfiguration = statisticConfiguration;
+  }
+
+  public StatisticConfiguration getStatisticConfiguration() {
+    return statisticConfiguration;
+  }
+
+  @Override
+  protected void dispose(ExposedObject<T> exposedObject) {
+    ((AbstractExposedStatistics<T>) exposedObject).close();
+  }
+
+  @Override
+  public Capability getCapability() {
+    StatisticsCapability.Properties properties = new StatisticsCapability.Properties(
+      statisticConfiguration.averageWindowDuration(),
+      statisticConfiguration.averageWindowUnit(),
+      statisticConfiguration.historySize(),
+      statisticConfiguration.historyInterval(),
+      statisticConfiguration.historyIntervalUnit(),
+      statisticConfiguration.timeToDisable(),
+      statisticConfiguration.timeToDisableUnit());
+    return new StatisticsCapability(getCapabilityName(), properties, getDescriptors(), getCapabilityContext());
+  }
+
+  @Override
+  public Map<String, Statistic<?, ?>> collectStatistics(Context context, Collection<String> statisticNames, long since) {
+    Map<String, Statistic<?, ?>> statistics = new HashMap<String, Statistic<?, ?>>(statisticNames.size());
+    AbstractExposedStatistics<T> ehcacheStatistics = (AbstractExposedStatistics<T>) findExposedObject(context);
+    if (ehcacheStatistics != null) {
+      for (String statisticName : statisticNames) {
+        try {
+          statistics.put(statisticName, ehcacheStatistics.queryStatistic(statisticName, since));
+        } catch (IllegalArgumentException ignored) {
+          // ignore when statisticName does not exist and throws an exception
+        }
+      }
+    }
+    return statistics;
+  }
+
+  @Override
+  protected AbstractExposedStatistics<T> wrap(T managedObject) {
+    AbstractExposedStatistics<T> exposed = internalWrap(managedObject);
+    exposed.init();
+    return exposed;
+  }
+
+  protected abstract AbstractExposedStatistics<T> internalWrap(T managedObject);
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/Management.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/Management.java
@@ -132,7 +132,7 @@ public class Management {
     }
   }
 
-  public void releaseStore(ClientDescriptor clientDescriptor, ClientState clientState, String storeName) {
+  public void storeReleased(ClientDescriptor clientDescriptor, ClientState clientState, String storeName) {
     if (managementRegistry != null) {
       managementRegistry.refresh();
       managementRegistry.pushServerEntityNotification(new ClientBinding(clientDescriptor, clientState), "EHCACHE_SERVER_STORE_RELEASED", Context.create("storeName", storeName));

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolSettingsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolSettingsManagementProvider.java
@@ -19,12 +19,14 @@ import org.ehcache.clustered.server.state.EhcacheStateService;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.capabilities.descriptors.Settings;
 import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.ExposedObject;
 import org.terracotta.management.registry.action.Named;
 import org.terracotta.management.registry.action.RequiredContext;
 import org.terracotta.management.service.registry.provider.AliasBindingManagementProvider;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 @Named("PoolSettings")
 @RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
@@ -44,6 +46,11 @@ class PoolSettingsManagementProvider extends AliasBindingManagementProvider<Pool
       .set("type", "PoolSettingsManagementProvider")
       .set("defaultServerResource", ehcacheStateService.getDefaultServerResource()));
     return descriptors;
+  }
+
+  @Override
+  public Collection<ExposedObject<PoolBinding>> getExposedObjects() {
+    return super.getExposedObjects().stream().filter(e -> e.getTarget() != PoolBinding.ALL_SHARED).collect(Collectors.toList());
   }
 
   @Override
@@ -69,7 +76,7 @@ class PoolSettingsManagementProvider extends AliasBindingManagementProvider<Pool
         Collections.singleton(new Settings(getContext())
           .set("serverResource", getBinding().getValue().getServerResource())
           .set("size", getBinding().getValue().getSize())
-          .set("allocationType", getBinding().getAllocationType()));
+          .set("allocationType", getBinding().getAllocationType().name().toLowerCase()));
     }
   }
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolStatisticsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolStatisticsManagementProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.ehcache.clustered.server.state.EhcacheStateService;
+import org.ehcache.clustered.server.state.ResourcePageSource;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.ExposedObject;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.terracotta.context.extended.ValueStatisticDescriptor.descriptor;
+
+@Named("PoolStatistics")
+@RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
+class PoolStatisticsManagementProvider extends AbstractStatisticsManagementProvider<PoolBinding> {
+
+  private final EhcacheStateService ehcacheStateService;
+  private final ScheduledExecutorService executor;
+
+  PoolStatisticsManagementProvider(EhcacheStateService ehcacheStateService, StatisticConfiguration statisticConfiguration, ScheduledExecutorService executor) {
+    super(PoolBinding.class, statisticConfiguration);
+    this.ehcacheStateService = ehcacheStateService;
+    this.executor = executor;
+  }
+
+  @Override
+  public Collection<ExposedObject<PoolBinding>> getExposedObjects() {
+    return super.getExposedObjects().stream().filter(e -> e.getTarget() != PoolBinding.ALL_SHARED).collect(Collectors.toList());
+  }
+
+  @Override
+  protected AbstractExposedStatistics<PoolBinding> internalWrap(PoolBinding managedObject) {
+    ResourcePageSource resourcePageSource = null;
+
+    if (managedObject != PoolBinding.ALL_SHARED) {
+      String poolName = managedObject.getAlias();
+      resourcePageSource = managedObject.getAllocationType() == PoolBinding.AllocationType.DEDICATED ?
+        ehcacheStateService.getDedicatedResourcePageSource(poolName) :
+        ehcacheStateService.getSharedResourcePageSource(poolName);
+      Objects.requireNonNull(resourcePageSource, "Unable to locale pool " + poolName);
+    }
+
+    return new PoolExposedStatistics(getConsumerId(), managedObject, getStatisticConfiguration(), executor, resourcePageSource);
+  }
+
+  private static class PoolExposedStatistics extends AbstractExposedStatistics<PoolBinding> {
+
+    PoolExposedStatistics(long consumerId, PoolBinding binding, StatisticConfiguration statisticConfiguration, ScheduledExecutorService executor, ResourcePageSource resourcePageSource) {
+      super(consumerId, binding, statisticConfiguration, executor, resourcePageSource);
+
+      if (resourcePageSource != null) {
+        statisticsRegistry.registerSize("AllocatedSize", descriptor("allocatedSize", tags("tier", "Pool")));
+      }
+    }
+
+    @Override
+    public Context getContext() {
+      return super.getContext().with("type", "PoolBinding");
+    }
+
+  }
+
+  private static Set<String> tags(String... tags) {return new HashSet<>(asList(tags));}
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ServerStoreStatisticsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ServerStoreStatisticsManagementProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.Arrays.asList;
+import static org.terracotta.context.extended.ValueStatisticDescriptor.descriptor;
+
+@Named("ServerStoreStatistics")
+@RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
+class ServerStoreStatisticsManagementProvider extends AbstractStatisticsManagementProvider<ServerStoreBinding> {
+
+  private final ScheduledExecutorService executor;
+
+  ServerStoreStatisticsManagementProvider(StatisticConfiguration statisticConfiguration, ScheduledExecutorService executor) {
+    super(ServerStoreBinding.class, statisticConfiguration);
+    this.executor = executor;
+  }
+
+  @Override
+  protected AbstractExposedStatistics<ServerStoreBinding> internalWrap(ServerStoreBinding managedObject) {
+    return new ServerStoreExposedStatistics(getConsumerId(), managedObject, getStatisticConfiguration(), executor);
+  }
+
+  private static class ServerStoreExposedStatistics extends AbstractExposedStatistics<ServerStoreBinding> {
+
+    ServerStoreExposedStatistics(long consumerId, ServerStoreBinding binding, StatisticConfiguration statisticConfiguration, ScheduledExecutorService executor) {
+      super(consumerId, binding, statisticConfiguration, executor, binding.getValue());
+
+      statisticsRegistry.registerSize("AllocatedMemory", descriptor("allocatedMemory", tags("tier", "Store")));
+      statisticsRegistry.registerSize("DataAllocatedMemory", descriptor("dataAllocatedMemory", tags("tier", "Store")));
+      statisticsRegistry.registerSize("OccupiedMemory", descriptor("occupiedMemory", tags("tier", "Store")));
+      statisticsRegistry.registerSize("DataOccupiedMemory", descriptor("dataOccupiedMemory", tags("tier", "Store")));
+      statisticsRegistry.registerCounter("Entries", descriptor("entries", tags("tier", "Store")));
+      statisticsRegistry.registerCounter("UsedSlotCount", descriptor("usedSlotCount", tags("tier", "Store")));
+      statisticsRegistry.registerSize("DataVitalMemory", descriptor("dataVitalMemory", tags("tier", "Store")));
+      statisticsRegistry.registerSize("VitalMemory", descriptor("vitalMemory", tags("tier", "Store")));
+      statisticsRegistry.registerSize("ReprobeLength", descriptor("reprobeLength", tags("tier", "Store")));
+      statisticsRegistry.registerCounter("RemovedSlotCount", descriptor("removedSlotCount", tags("tier", "Store")));
+      statisticsRegistry.registerSize("DataSize", descriptor("dataSize", tags("tier", "Store")));
+      statisticsRegistry.registerSize("TableCapacity", descriptor("tableCapacity", tags("tier", "Store")));
+    }
+
+    @Override
+    public Context getContext() {
+      return super.getContext().with("type", "ServerStore");
+    }
+
+  }
+
+  private static Set<String> tags(String... tags) {return new HashSet<>(asList(tags));}
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/StatisticCollectorManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/StatisticCollectorManagementProvider.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.management.registry.ManagementRegistry;
+import org.terracotta.management.registry.StatisticQuery;
+import org.terracotta.management.registry.action.ExposedObject;
+import org.terracotta.management.registry.action.Named;
+import org.terracotta.management.registry.action.RequiredContext;
+import org.terracotta.management.registry.collect.StatisticCollector;
+import org.terracotta.management.registry.collect.StatisticCollectorProvider;
+import org.terracotta.management.service.registry.MonitoringResolver;
+import org.terracotta.management.service.registry.provider.ConsumerManagementProvider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Named("StatisticCollector")
+@RequiredContext({@Named("consumerId")})
+class StatisticCollectorManagementProvider extends StatisticCollectorProvider<StatisticCollector> implements ConsumerManagementProvider<StatisticCollector> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StatisticCollectorManagementProvider.class);
+
+  private final ManagementRegistry managementRegistry;
+  private final StatisticConfiguration statisticConfiguration;
+  private final ScheduledExecutorService scheduledExecutorService;
+  private final String[] statsCapabilitynames;
+  private final ConcurrentMap<String, StatisticQuery.Builder> selectedStatsPerCapability = new ConcurrentHashMap<>();
+
+  private volatile MonitoringResolver resolver;
+
+  StatisticCollectorManagementProvider(ManagementRegistry managementRegistry, StatisticConfiguration statisticConfiguration, ScheduledExecutorService scheduledExecutorService, String[] statsCapabilitynames) {
+    super(StatisticCollector.class, null);
+    this.managementRegistry = managementRegistry;
+    this.statisticConfiguration = statisticConfiguration;
+    this.scheduledExecutorService = scheduledExecutorService;
+    this.statsCapabilitynames = statsCapabilitynames;
+  }
+
+  @Override
+  public void accept(MonitoringResolver resolver) {
+    this.resolver = resolver;
+  }
+
+  @Override
+  public boolean pushServerEntityNotification(StatisticCollector managedObjectSource, String type, Map<String, String> attrs) {
+    return false;
+  }
+
+  @Override
+  protected ExposedObject<StatisticCollector> wrap(StatisticCollector managedObject) {
+    return new StatisticCollectorProvider.ExposedStatisticCollector<>(managedObject, Context.create("consumerId", String.valueOf(resolver.getConsumerId())));
+  }
+
+  @Override
+  protected void dispose(ExposedObject<StatisticCollector> exposedObject) {
+    exposedObject.getTarget().stopStatisticCollector();
+  }
+
+  void start() {
+    StatisticCollector managedObject = new StatisticCollector() {
+
+      private volatile ScheduledFuture<?> task;
+
+      @Override
+      public void startStatisticCollector() {
+        if (task == null) {
+          LOGGER.trace("startStatisticCollector()");
+
+          long timeToDisableMs = TimeUnit.MILLISECONDS.convert(statisticConfiguration.timeToDisable(), statisticConfiguration.timeToDisableUnit());
+          long pollingIntervalMs = Math.round(timeToDisableMs * 0.75); // we poll at 75% of the time to disable (before the time to disable happens)
+          final AtomicLong lastPoll = new AtomicLong(getTimeMs());
+
+          task = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+              if (task != null && !selectedStatsPerCapability.isEmpty()) {
+                Collection<ContextualStatistics> statistics = new ArrayList<>();
+                long since = lastPoll.get();
+
+                selectedStatsPerCapability.entrySet()
+                  .stream()
+                  .filter(entry -> Arrays.binarySearch(statsCapabilitynames, entry.getKey()) >= 0)
+                  .forEach(entry -> {
+                    AbstractStatisticsManagementProvider<?> provider = (AbstractStatisticsManagementProvider<?>) managementRegistry.getManagementProvidersByCapability(entry.getKey())
+                      .iterator().next();
+                    // note: .iterator().next() because the management registry is not shared, so there cannot be more than 1 capability with the same name.
+                    Collection<Context> allContexts = provider.getExposedObjects().stream().map(ExposedObject::getContext).collect(Collectors.toList());
+                    for (ContextualStatistics contextualStatistics : entry.getValue().since(since).on(allContexts).build().execute()) {
+                      statistics.add(contextualStatistics);
+                    }
+                  });
+
+                // next time, only poll history from this time
+                lastPoll.set(getTimeMs());
+
+                if (task != null && !statistics.isEmpty() && resolver != null) {
+                  resolver.pushServerEntityStatistics(statistics.toArray(new ContextualStatistics[statistics.size()]));
+                }
+              }
+            } catch (RuntimeException e) {
+              LOGGER.error("StatisticCollector: " + e.getMessage(), e);
+            }
+          }, pollingIntervalMs, pollingIntervalMs, TimeUnit.MILLISECONDS);
+        }
+      }
+
+      @Override
+      public void stopStatisticCollector() {
+        if (task != null) {
+          LOGGER.trace("stopStatisticCollector()");
+          ScheduledFuture<?> _task = task;
+          task = null;
+          _task.cancel(false);
+        }
+      }
+
+      @Override
+      public void updateCollectedStatistics(String capabilityName, Collection<String> statisticNames) {
+        if (!statisticNames.isEmpty()) {
+          LOGGER.trace("updateCollectedStatistics({}, {})", capabilityName, statisticNames);
+          StatisticQuery.Builder builder = managementRegistry.withCapability(capabilityName).queryStatistics(statisticNames);
+          selectedStatsPerCapability.put(capabilityName, builder);
+        } else {
+          // we clear the stats set
+          selectedStatsPerCapability.remove(capabilityName);
+        }
+      }
+    };
+
+    register(managedObject);
+
+    managedObject.startStatisticCollector();
+  }
+
+  private long getTimeMs() {
+    // TODO FIXME: there is no timesource service in voltron: https://github.com/Terracotta-OSS/terracotta-apis/issues/167
+    return System.currentTimeMillis();
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/StatisticConfiguration.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/StatisticConfiguration.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.management;
+
+import org.terracotta.management.model.Objects;
+import org.terracotta.management.registry.ManagementProvider;
+
+import java.util.concurrent.TimeUnit;
+
+class StatisticConfiguration {
+
+  private long averageWindowDuration = 60;
+  private TimeUnit averageWindowUnit = TimeUnit.SECONDS;
+  private int historySize = 100;
+  private long historyInterval = 1;
+  private TimeUnit historyIntervalUnit = TimeUnit.SECONDS;
+  private long timeToDisable = 30;
+  private TimeUnit timeToDisableUnit = TimeUnit.SECONDS;
+
+  StatisticConfiguration() {
+  }
+
+  StatisticConfiguration(long averageWindowDuration, TimeUnit averageWindowUnit, int historySize, long historyInterval, TimeUnit historyIntervalUnit, long timeToDisable, TimeUnit timeToDisableUnit) {
+    this.averageWindowDuration = averageWindowDuration;
+    this.averageWindowUnit = Objects.requireNonNull(averageWindowUnit);
+    this.historySize = historySize;
+    this.historyInterval = historyInterval;
+    this.historyIntervalUnit = Objects.requireNonNull(historyIntervalUnit);
+    this.timeToDisable = timeToDisable;
+    this.timeToDisableUnit = Objects.requireNonNull(timeToDisableUnit);
+  }
+
+  public long averageWindowDuration() {
+    return averageWindowDuration;
+  }
+
+  public TimeUnit averageWindowUnit() {
+    return averageWindowUnit;
+  }
+
+  public int historySize() {
+    return historySize;
+  }
+
+  public long historyInterval() {
+    return historyInterval;
+  }
+
+  public TimeUnit historyIntervalUnit() {
+    return historyIntervalUnit;
+  }
+
+  public long timeToDisable() {
+    return timeToDisable;
+  }
+
+  public TimeUnit timeToDisableUnit() {
+    return timeToDisableUnit;
+  }
+
+
+  @Override
+  public String toString() {
+    return "{averageWindowDuration=" + averageWindowDuration() +
+        ", averageWindowUnit=" + averageWindowUnit() +
+        ", historyInterval=" + historyInterval() +
+        ", historyIntervalUnit=" + historyIntervalUnit() +
+        ", historySize=" + historySize() +
+        ", timeToDisable=" + timeToDisable() +
+        ", timeToDisableUnit=" + timeToDisableUnit() +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StatisticConfiguration that = (StatisticConfiguration) o;
+    if (averageWindowDuration != that.averageWindowDuration) return false;
+    if (historySize != that.historySize) return false;
+    if (historyInterval != that.historyInterval) return false;
+    if (timeToDisable != that.timeToDisable) return false;
+    if (averageWindowUnit != that.averageWindowUnit) return false;
+    if (historyIntervalUnit != that.historyIntervalUnit) return false;
+    return timeToDisableUnit == that.timeToDisableUnit;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (averageWindowDuration ^ (averageWindowDuration >>> 32));
+    result = 31 * result + averageWindowUnit.hashCode();
+    result = 31 * result + historySize;
+    result = 31 * result + (int) (historyInterval ^ (historyInterval >>> 32));
+    result = 31 * result + historyIntervalUnit.hashCode();
+    result = 31 * result + (int) (timeToDisable ^ (timeToDisable >>> 32));
+    result = 31 * result + timeToDisableUnit.hashCode();
+    return result;
+  }
+
+  public StatisticConfiguration setAverageWindowDuration(long averageWindowDuration) {
+    this.averageWindowDuration = averageWindowDuration;
+    return this;
+  }
+
+  public StatisticConfiguration setAverageWindowUnit(TimeUnit averageWindowUnit) {
+    this.averageWindowUnit = averageWindowUnit;
+    return this;
+  }
+
+  public StatisticConfiguration setHistoryInterval(long historyInterval) {
+    this.historyInterval = historyInterval;
+    return this;
+  }
+
+  public StatisticConfiguration setHistoryIntervalUnit(TimeUnit historyIntervalUnit) {
+    this.historyIntervalUnit = historyIntervalUnit;
+    return this;
+  }
+
+  public StatisticConfiguration setHistorySize(int historySize) {
+    this.historySize = historySize;
+    return this;
+  }
+
+  public StatisticConfiguration setTimeToDisable(long timeToDisable) {
+    this.timeToDisable = timeToDisable;
+    return this;
+  }
+
+  public StatisticConfiguration setTimeToDisableUnit(TimeUnit timeToDisableUnit) {
+    this.timeToDisableUnit = timeToDisableUnit;
+    return this;
+  }
+
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
@@ -34,7 +34,11 @@ public interface EhcacheStateService {
 
   Map<String, ServerSideConfiguration.Pool> getSharedResourcePools();
 
+  ResourcePageSource getSharedResourcePageSource(String name);
+
   ServerSideConfiguration.Pool getDedicatedResourcePool(String name);
+
+  ResourcePageSource getDedicatedResourcePageSource(String name);
 
   ServerStoreImpl getStore(String name);
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/ResourcePageSource.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/ResourcePageSource.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.server.state;
+
+import com.tc.classloader.CommonComponent;
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.terracotta.offheapstore.buffersource.OffHeapBufferSource;
+import org.terracotta.offheapstore.paging.OffHeapStorageArea;
+import org.terracotta.offheapstore.paging.Page;
+import org.terracotta.offheapstore.paging.PageSource;
+import org.terracotta.offheapstore.paging.UpfrontAllocatingPageSource;
+
+import static org.terracotta.offheapstore.util.MemoryUnit.GIGABYTES;
+import static org.terracotta.offheapstore.util.MemoryUnit.MEGABYTES;
+
+/**
+ * Pairs a {@link ServerSideConfiguration.Pool} and an {@link UpfrontAllocatingPageSource} instance providing storage
+ * for the pool.
+ */
+@CommonComponent
+public class ResourcePageSource implements PageSource {
+  /**
+   * A description of the resource allocation underlying this {@code PageSource}.
+   */
+  private final ServerSideConfiguration.Pool pool;
+  private final UpfrontAllocatingPageSource delegatePageSource;
+
+  public ResourcePageSource(ServerSideConfiguration.Pool pool) {
+    this.pool = pool;
+    this.delegatePageSource = new UpfrontAllocatingPageSource(new OffHeapBufferSource(), pool.getSize(), GIGABYTES.toBytes(1), MEGABYTES.toBytes(128));
+  }
+
+  public ServerSideConfiguration.Pool getPool() {
+    return pool;
+  }
+
+  public long getAllocatedSize() {
+    return delegatePageSource.getAllocatedSizeUnSync();
+  }
+
+  @Override
+  public Page allocate(int size, boolean thief, boolean victim, OffHeapStorageArea owner) {
+    return delegatePageSource.allocate(size, thief, victim, owner);
+  }
+
+  @Override
+  public void free(Page page) {
+    delegatePageSource.free(page);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("ResourcePageSource{");
+    sb.append("pool=").append(pool);
+    sb.append(", delegatePageSource=").append(delegatePageSource);
+    sb.append('}');
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
Close #1551 and close #1530.

**Important notes for Ehcache / M&M people:**

__THESE ARE NOT BLOCKERS for M&M: JUST THINGS TO TAKE CARE OF__

1. **TimeSource**

We need in management to get the server time in a uniform way both from ehcache server entity and within the monitoring service. Currently, we are calling: `System.currentTimeMillis()` because there is no time service in voltron.

See `StatisticCollectorManagementProvider` in this PR.

I started a discussion for that: Terracotta-OSS/terracotta-apis#167

1. **Scheduling tasks**

There is no way to schedule a task in voltron yet, so I needed to start a scheduled executor service (the thread is set to daemon) used only by management to compute stats.

See `Management` in this PR

I started an issue for that: Terracotta-OSS/terracotta-apis#158

1. **Statistics configuration**

We have currently no way to pass the stats config object to use server-side. One idea is that it could be an optional XML config in ehcache xml, sent when the entity is configured with the server config. For the moment, the stat config is then fixed and cannot be changed.

See `Management` and `StatisticConfiguration` in this PR

I started an issue for that: #1567 

1. **Management calls to server entities**

~~We have no way yet to issue a management call to the server entity to configure which stat to collect depending on what we need. So for the moment, all stats are collected.~~

~~See `Management` in this PR~~

~~I started an issue for that: Terracotta-OSS/terracotta-apis#168~~

__UPDATE:__ After discussion with @anthonydahanne and @lorban, I figured out we can do management calls already to exposed objects into the voltron registry service if we extend it.

See: #1575 and Terracotta-OSS/terracotta-platform#178
