### PR TITLE
Issue #1430: Clean up compiler warnings

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,3 +20,6 @@ checkstyle {
   configFile = file("$projectDir/config/checkstyle.xml")
 }
 
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ['-Werror']
+}

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ subprojects {
 
   dependencies {
     compileOnly "com.google.code.findbugs:annotations:$parent.findbugsVersion"
+    testCompileOnly "com.google.code.findbugs:annotations:$parent.findbugsVersion"
     testCompile 'junit:junit:4.12', 'org.assertj:assertj-core:1.7.1', 'org.hamcrest:hamcrest-library:1.3'
     testCompile('org.mockito:mockito-core:1.9.5') {
       exclude group:'org.hamcrest', module:'hamcrest-core'

--- a/clustered/clustered-dist/build.gradle
+++ b/clustered/clustered-dist/build.gradle
@@ -42,8 +42,8 @@ configurations {
 }
 
 dependencies {
-  compile "org.terracotta.internal:client-runtime:$terracottaCoreVersion" changing true
-  compile "org.terracotta.internal:client-logging:$terracottaCoreVersion" changing true
+  compile "org.terracotta.internal:client-runtime:$terracottaCoreVersion"
+  compile "org.terracotta.internal:client-logging:$terracottaCoreVersion"
 
   serverLibs(project(':clustered:server')) {
     exclude group: 'org.terracotta', module: 'entity-server-api'
@@ -52,7 +52,7 @@ dependencies {
     exclude group: 'org.terracotta.internal', module: 'tc-config-parser'
   }
 
-  kit "org.terracotta.internal:terracotta-kit:$terracottaCoreVersion@zip" changing true
+  kit "org.terracotta.internal:terracotta-kit:$terracottaCoreVersion@zip"
 
   shadowCompile "org.slf4j:slf4j-api:$parent.slf4jVersion"
   pomOnlyCompile "org.ehcache:ehcache:$parent.baseVersion"

--- a/core-spi-test/build.gradle
+++ b/core-spi-test/build.gradle
@@ -20,3 +20,7 @@ dependencies {
     exclude group:'org.hamcrest', module:'hamcrest-core'
   }
 }
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ['-Werror']
+}

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
@@ -50,12 +50,13 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = (Store<K, V>) this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
   public void testWrongReturnValueType() throws Exception {
     kvStore = factory.newStore();
@@ -75,10 +76,11 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     try {
-      kvStore.computeIfAbsent(key, new Function() {
+      kvStore.computeIfAbsent(key, new Function<K, V>() {
         @Override
-        public Object apply(Object key) {
-          return badValue; // returning wrong value type from function
+        @SuppressWarnings("unchecked")
+        public V apply(K key) {
+          return (V) badValue; // returning wrong value type from function
         }
       });
       throw new AssertionError();
@@ -89,8 +91,8 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     }
   }
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
   @SPITest
+  @SuppressWarnings("unchecked")
   public void testWrongKeyType() throws Exception {
     kvStore2 = factory.newStore();
 
@@ -107,7 +109,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     }
 
     try {
-      kvStore2.computeIfAbsent(badKey, new Function() { // wrong key type
+      kvStore2.computeIfAbsent(badKey, new Function<Object, Object>() { // wrong key type
             @Override
             public Object apply(Object key) {
               throw new AssertionError();

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
@@ -50,12 +50,14 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SuppressWarnings("unchecked")
   @SPITest
   public void testWrongReturnValueType() throws Exception {
     kvStore = factory.newStore();
@@ -87,7 +89,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     }
   }
 
-  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SuppressWarnings("unchecked")
   @SPITest
   public void testWrongKeyType() throws Exception {
     kvStore2 = factory.newStore();

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
@@ -49,8 +49,10 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 
@@ -89,7 +91,7 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   @SPITest
-  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @SuppressWarnings("unchecked")
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore2 = factory.newStore();

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCreationEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreCreationEventListenerTest.java
@@ -124,6 +124,7 @@ public class StoreCreationEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   private StoreEventListener<K, V> addListener(Store<K, V> kvStore) {
+    @SuppressWarnings("unchecked")
     StoreEventListener<K, V> listener = mock(StoreEventListener.class);
 
     kvStore.getStoreEventSource().addEventListener(listener);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEvictionEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEvictionEventListenerTest.java
@@ -137,6 +137,7 @@ public class StoreEvictionEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   private StoreEventListener<K, V> addListener(Store<K, V> kvStore) {
+    @SuppressWarnings("unchecked")
     StoreEventListener<K, V> listener = mock(StoreEventListener.class);
 
     kvStore.getStoreEventSource().addEventListener(listener);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreExpiryEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreExpiryEventListenerTest.java
@@ -162,6 +162,7 @@ public class StoreExpiryEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   private StoreEventListener<K, V> addListener(Store<K, V> kvStore) {
+    @SuppressWarnings("unchecked")
     StoreEventListener<K, V> listener = mock(StoreEventListener.class);
 
     kvStore.getStoreEventSource().addEventListener(listener);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -58,8 +58,10 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -56,8 +56,10 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -56,8 +56,10 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemovalEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemovalEventListenerTest.java
@@ -110,6 +110,7 @@ public class StoreRemovalEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   private StoreEventListener<K, V> addListener(Store<K, V> kvStore) {
+    @SuppressWarnings("unchecked")
     StoreEventListener<K, V> listener = mock(StoreEventListener.class);
 
     kvStore.getStoreEventSource().addEventListener(listener);

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
@@ -49,8 +49,10 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 
@@ -94,10 +96,8 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore = factory.newStore();
 
-    K key = null;
-
     try {
-      kvStore.remove(key);
+      kvStore.remove(null);
       throw new AssertionError("Expected NullPointerException because the key is null");
     } catch (NullPointerException e) {
       // expected

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -51,8 +51,10 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 
@@ -138,10 +140,9 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     kvStore = factory.newStore();
 
     K key = factory.createKey(1);
-    V value = null;
 
     try {
-      kvStore.replace(key, value);
+      kvStore.replace(key, null);
       throw new AssertionError("Expected NullPointerException because the value is null");
     } catch (NullPointerException e) {
       // expected
@@ -151,6 +152,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   @SPITest
+  @SuppressWarnings("unchecked")
   public void wrongKeyTypeThrowsException()
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore2 = factory.newStore();
@@ -172,6 +174,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   @SPITest
+  @SuppressWarnings("unchecked")
   public void wrongValueTypeThrowsException()
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore2 = factory.newStore();

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
@@ -53,8 +53,10 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
       kvStore = null;
     }
     if (kvStore2 != null) {
+      @SuppressWarnings("unchecked")
+      Store<K, V> kvStore2 = this.kvStore2;
       factory.close(kvStore2);
-      kvStore2 = null;
+      this.kvStore2 = null;
     }
   }
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreUpdateEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreUpdateEventListenerTest.java
@@ -126,6 +126,7 @@ public class StoreUpdateEventListenerTest<K, V> extends SPIStoreTester<K, V> {
   }
 
   private StoreEventListener<K, V> addListener(Store<K, V> kvStore) {
+    @SuppressWarnings("unchecked")
     StoreEventListener<K, V> listener = mock(StoreEventListener.class);
 
     kvStore.getStoreEventSource().addEventListener(listener);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,3 +23,7 @@ dependencies {
   }
   testCompile project(':spi-tester')
 }
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ['-Werror']
+}

--- a/core/src/main/java/org/ehcache/core/internal/service/ServiceLocator.java
+++ b/core/src/main/java/org/ehcache/core/internal/service/ServiceLocator.java
@@ -250,7 +250,9 @@ public final class ServiceLocator implements ServiceProvider<Service> {
       for (ServiceFactory<?> factory : serviceFactories) {
         final Class<?> factoryServiceType = factory.getServiceType();
         if (serviceType.isAssignableFrom(factoryServiceType)) {
-          with(((ServiceFactory<T>) factory).create(config));
+          @SuppressWarnings("unchecked")
+          ServiceFactory<T> serviceFactory = (ServiceFactory<T>) factory;
+          with(serviceFactory.create(config));
           success = true;
         }
       }
@@ -383,7 +385,9 @@ public final class ServiceLocator implements ServiceProvider<Service> {
             // Can have only one service registered under a concrete type
             continue;
           }
-          serviceFactories.add((ServiceFactory<? extends T>) factory);
+          @SuppressWarnings("unchecked")
+          ServiceFactory<? extends T> serviceFactory = (ServiceFactory<? extends T>) factory;
+          serviceFactories.add(serviceFactory);
         }
       }
       return serviceFactories;
@@ -411,7 +415,9 @@ public final class ServiceLocator implements ServiceProvider<Service> {
     if (annotation != null) {
       for (final Class<?> dependency : annotation.value()) {
         if (Service.class.isAssignableFrom(dependency)) {
-          dependencies.add((Class<? extends Service>) dependency);
+          @SuppressWarnings("unchecked")
+          Class<? extends Service> serviceDependency = (Class<? extends Service>) dependency;
+          dependencies.add(serviceDependency);
         } else {
           throw new IllegalStateException("Service dependency declared by " + clazz.getName() +
             " is not a Service: " + dependency.getName());
@@ -505,11 +511,12 @@ public final class ServiceLocator implements ServiceProvider<Service> {
     }
 
     public <T extends Service> Set<T> get(Class<T> serviceType) {
-      Set<Service> s = services.get(serviceType);
+      @SuppressWarnings("unchecked")
+      Set<T> s = (Set<T>) services.get(serviceType);
       if (s == null) {
         return emptySet();
       } else {
-        return (Set<T>) unmodifiableSet(s);
+        return unmodifiableSet(s);
       }
     }
 

--- a/core/src/test/java/org/ehcache/core/CacheTest.java
+++ b/core/src/test/java/org/ehcache/core/CacheTest.java
@@ -47,11 +47,11 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public abstract class CacheTest {
 
-  protected abstract InternalCache<Object, Object> getCache(Store store);
+  protected abstract InternalCache<Object, Object> getCache(Store<Object, Object> store);
 
   @Test
   public void testTransistionsState() {
-    Store store = mock(Store.class);
+    Store<Object, Object> store = mock(Store.class);
 
     InternalCache ehcache = getCache(store);
     assertThat(ehcache.getStatus(), CoreMatchers.is(Status.UNINITIALIZED));
@@ -63,10 +63,10 @@ public abstract class CacheTest {
 
   @Test
   public void testThrowsWhenNotAvailable() throws StoreAccessException {
-    Store store = mock(Store.class);
+    Store<Object, Object> store = mock(Store.class);
     Store.Iterator mockIterator = mock(Store.Iterator.class);
     when(store.iterator()).thenReturn(mockIterator);
-    InternalCache ehcache = getCache(store);
+    InternalCache<Object, Object> ehcache = getCache(store);
 
     try {
       ehcache.get("foo");

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicIteratorTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicIteratorTest.java
@@ -207,13 +207,16 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
    */
   @Test
   public void testIteratorStoreAccessException() throws Exception {
+    @SuppressWarnings("unchecked")
     Store.ValueHolder<String> valueHolder = mock(Store.ValueHolder.class);
     doReturn("bar").when(valueHolder).value();
 
+    @SuppressWarnings("unchecked")
     Cache.Entry<String, Store.ValueHolder<String>> storeEntry = mock(Cache.Entry.class);
     doReturn(valueHolder).when(storeEntry).getValue();
     doReturn("foo").when(storeEntry).getKey();
 
+    @SuppressWarnings("unchecked")
     Store.Iterator<Cache.Entry<String, Store.ValueHolder<String>>> storeIterator = mock(Store.Iterator.class);
     doReturn(true).when(storeIterator).hasNext();
     doReturn(storeEntry).when(storeIterator).next();

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
@@ -259,14 +259,15 @@ public class EhcacheBasicRemoveAllTest extends EhcacheBasicCrudBase {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void removeAllStoreCallsMethodTwice() throws Exception {
-    this.store = mock(Store.class);
-    CacheLoaderWriter cacheLoaderWriter = mock(CacheLoaderWriter.class);
+    CacheLoaderWriter<String, String> cacheLoaderWriter = mock(CacheLoaderWriter.class);
     final List<String> removed = new ArrayList<String>();
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        Iterable<String> i = (Iterable) invocation.getArguments()[0];
+        @SuppressWarnings("unchecked")
+        Iterable<String> i = (Iterable<String>) invocation.getArguments()[0];
         for (String key : i) {
           removed.add(key);
         }
@@ -275,13 +276,13 @@ public class EhcacheBasicRemoveAllTest extends EhcacheBasicCrudBase {
     }).when(cacheLoaderWriter).deleteAll(any(Iterable.class));
     final EhcacheWithLoaderWriter<String, String> ehcache = this.getEhcacheWithLoaderWriter(cacheLoaderWriter);
 
-    final ArgumentCaptor<Function> functionArgumentCaptor = ArgumentCaptor.forClass(Function.class);
+    final ArgumentCaptor<Function<Iterable<? extends Map.Entry<? extends String, ? extends String>>, Iterable<? extends Map.Entry<? extends String, ? extends String>>>> functionArgumentCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Function.class);
 
     when(store.bulkCompute(anySet(), functionArgumentCaptor.capture())).then(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        Function function = functionArgumentCaptor.getValue();
-        Iterable arg = new HashMap((Map) function.getClass().getDeclaredField("val$entriesToRemove").get(function)).entrySet();
+        Function<Iterable<? extends Map.Entry<? extends String, ? extends String>>, Iterable<? extends Map.Entry<? extends String, ? extends String>>> function = functionArgumentCaptor.getValue();
+        Iterable<? extends Map.Entry<? extends String, ? extends String>> arg = new HashMap<String, String>((Map) function.getClass().getDeclaredField("val$entriesToRemove").get(function)).entrySet();
         function.apply(arg);
         function.apply(arg);
         return null;

--- a/core/src/test/java/org/ehcache/core/EhcacheTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheTest.java
@@ -31,9 +31,10 @@ import org.slf4j.LoggerFactory;
 public class EhcacheTest extends CacheTest {
 
   @Override
-  protected InternalCache<Object, Object> getCache(Store store) {
+  protected InternalCache<Object, Object> getCache(Store<Object, Object> store) {
     final CacheConfiguration<Object, Object> config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
+    @SuppressWarnings("unchecked")
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
     return new Ehcache<Object, Object>(config, store, cacheEventDispatcher, LoggerFactory.getLogger(Ehcache.class + "-" + "EhcacheTest"));
   }

--- a/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicPutAllTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicPutAllTest.java
@@ -1871,6 +1871,7 @@ public class EhcacheWithLoaderWriterBasicPutAllTest extends EhcacheBasicCrudBase
     final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(originalWriterContent);
     this.cacheLoaderWriter = spy(fakeLoaderWriter);
 
+    @SuppressWarnings("unchecked")
     final Expiry<String, String> expiry = mock(Expiry.class);
     when(expiry.getExpiryForCreation(any(String.class), any(String.class))).thenReturn(Duration.ZERO);
 
@@ -1901,6 +1902,7 @@ public class EhcacheWithLoaderWriterBasicPutAllTest extends EhcacheBasicCrudBase
     final FakeCacheLoaderWriter fakeLoaderWriter = new FakeCacheLoaderWriter(originalWriterContent);
     this.cacheLoaderWriter = spy(fakeLoaderWriter);
 
+    @SuppressWarnings("unchecked")
     final Expiry<String, String> expiry = mock(Expiry.class);
     when(expiry.getExpiryForUpdate(any(String.class), argThat(org.ehcache.core.util.Matchers.<String>holding(instanceOf(String.class))), any(String.class))).thenReturn(Duration.ZERO);
 

--- a/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicReplaceTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicReplaceTest.java
@@ -520,6 +520,7 @@ public class EhcacheWithLoaderWriterBasicReplaceTest extends EhcacheBasicCrudBas
 
     final FakeCacheLoaderWriter fakeWriter = new FakeCacheLoaderWriter(Collections.<String, String>singletonMap("key", "old-value"));
 
+    @SuppressWarnings("unchecked")
     final Expiry<String, String> expiry = mock(Expiry.class);
     when(expiry.getExpiryForUpdate(eq("key"), argThat(holding("old-value")), eq("value"))).thenReturn(Duration.ZERO);
 

--- a/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicReplaceValueTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicReplaceValueTest.java
@@ -895,6 +895,7 @@ public class EhcacheWithLoaderWriterBasicReplaceValueTest extends EhcacheBasicCr
 
     final FakeCacheLoaderWriter fakeWriter = new FakeCacheLoaderWriter(Collections.<String, String>singletonMap("key", "old-value"));
 
+    @SuppressWarnings("unchecked")
     final Expiry<String, String> expiry = mock(Expiry.class);
     when(expiry.getExpiryForUpdate(eq("key"), argThat(holding("old-value")), eq("value"))).thenReturn(Duration.ZERO);
 

--- a/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterTest.java
@@ -52,18 +52,21 @@ import static org.mockito.Mockito.mock;
 public class EhcacheWithLoaderWriterTest extends CacheTest {
 
   @Override
-  protected InternalCache<Object, Object> getCache(Store store) {
+  protected InternalCache<Object, Object> getCache(Store<Object, Object> store) {
     final CacheConfiguration<Object, Object> config = new BaseCacheConfiguration<Object, Object>(Object.class, Object.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());
+    @SuppressWarnings("unchecked")
     CacheEventDispatcher<Object, Object> cacheEventDispatcher = mock(CacheEventDispatcher.class);
+    @SuppressWarnings("unchecked")
     CacheLoaderWriter<Object, Object> cacheLoaderWriter = mock(CacheLoaderWriter.class);
-    return new EhcacheWithLoaderWriter(config, store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(EhcacheWithLoaderWriter.class + "-" + "EhcacheWithLoaderWriterTest"));
+    return new EhcacheWithLoaderWriter<Object, Object>(config, store, cacheLoaderWriter, cacheEventDispatcher, LoggerFactory.getLogger(EhcacheWithLoaderWriter.class + "-" + "EhcacheWithLoaderWriterTest"));
   }
 
   @Test
   public void testIgnoresKeysReturnedFromCacheLoaderLoadAll() {
     LoadAllVerifyStore store = new LoadAllVerifyStore();
     KeyFumblingCacheLoaderWriter loader = new KeyFumblingCacheLoaderWriter();
+    @SuppressWarnings("unchecked")
     CacheEventDispatcher<String, String> cacheEventDispatcher = mock(CacheEventDispatcher.class);
     CacheConfiguration<String, String> config = new BaseCacheConfiguration<String, String>(String.class, String.class, null,
         null, null, ResourcePoolsHelper.createHeapOnlyPools());

--- a/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
+++ b/core/src/test/java/org/ehcache/core/config/ResourcePoolsImplTest.java
@@ -25,10 +25,11 @@ import org.ehcache.config.units.MemoryUnit;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
-import static java.util.Arrays.asList;
 import static org.ehcache.config.ResourceType.Core.HEAP;
 import static org.ehcache.config.ResourceType.Core.OFFHEAP;
 import static org.ehcache.config.units.EntryUnit.ENTRIES;
@@ -296,6 +297,12 @@ public class ResourcePoolsImplTest {
     }
     assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getSize(), Matchers.is(20L));
     assertThat(existing.getPoolForResource(ResourceType.Core.HEAP).getUnit(), Matchers.<ResourceUnit>is(MemoryUnit.MB));
+  }
+
+  private <T> Collection<T> asList(T value1, T value2) {
+    @SuppressWarnings("unchecked")
+    List<T> list = Arrays.asList(value1, value2);
+    return list;
   }
 
 }

--- a/impl/src/main/java/org/ehcache/impl/config/copy/DefaultCopyProviderConfiguration.java
+++ b/impl/src/main/java/org/ehcache/impl/config/copy/DefaultCopyProviderConfiguration.java
@@ -94,7 +94,9 @@ public class DefaultCopyProviderConfiguration extends ClassInstanceProviderConfi
     if (!overwrite && getDefaults().containsKey(clazz)) {
       throw new IllegalArgumentException("Duplicate copier for class : " + clazz);
     }
-    getDefaults().put(clazz, (ClassInstanceConfiguration) new DefaultCopierConfiguration<T>(copierClass));
+    @SuppressWarnings("unchecked")
+    ClassInstanceConfiguration<Copier<?>> configuration = (ClassInstanceConfiguration) new DefaultCopierConfiguration<T>(copierClass);
+    getDefaults().put(clazz, configuration);
     return this;
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
@@ -252,6 +252,7 @@ import org.ehcache.impl.internal.concurrent.JSR166Helper.*;
  * @param <K> the type of keys maintained by this map
  * @param <V> the type of mapped values
  */
+@SuppressWarnings("unchecked")
 public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
     implements ConcurrentMap<K,V>, Serializable {
     private static final long serialVersionUID = 7249069246763182397L;

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -395,7 +395,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
         throw new IllegalArgumentException("Given store is not managed by this provider : " + resource);
       }
       try {
-        OffHeapDiskStore offHeapDiskStore = (OffHeapDiskStore)resource;
+        OffHeapDiskStore<?, ?> offHeapDiskStore = (OffHeapDiskStore<?, ?>)resource;
         close(offHeapDiskStore);
         StatisticsManager.nodeFor(offHeapDiskStore).clean();
         tierOperationStatistics.remove(offHeapDiskStore);

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/holders/SerializedOnHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/holders/SerializedOnHeapValueHolder.java
@@ -87,7 +87,8 @@ public class SerializedOnHeapValueHolder<V> extends OnHeapValueHolder<V> impleme
     if (this == other) return true;
     if (other == null || getClass() != other.getClass()) return false;
 
-    SerializedOnHeapValueHolder<V> that = (SerializedOnHeapValueHolder)other;
+    @SuppressWarnings("unchecked")
+    SerializedOnHeapValueHolder<V> that = (SerializedOnHeapValueHolder<V>)other;
 
     if (!super.equals(that)) return false;
     try {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/portability/SerializerPortability.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/portability/SerializerPortability.java
@@ -51,7 +51,9 @@ public class SerializerPortability<T> implements Portability<T> {
   @Override
   public boolean equals(Object o, ByteBuffer byteBuffer) {
     try {
-      return serializer.equals((T)o, byteBuffer);
+      @SuppressWarnings("unchecked")
+      T otherValue = (T) o;
+      return serializer.equals(otherValue, byteBuffer);
     } catch (ClassNotFoundException e) {
       throw new SerializerException(e);
     }

--- a/impl/src/main/java/org/ehcache/impl/persistence/FileBasedStateRepository.java
+++ b/impl/src/main/java/org/ehcache/impl/persistence/FileBasedStateRepository.java
@@ -125,7 +125,10 @@ class FileBasedStateRepository implements StateRepository, Closeable {
         return holder;
       }
     }
-    return (StateHolder<K, V>) result.holder;
+
+    @SuppressWarnings("unchecked")
+    StateHolder<K, V> holder = (StateHolder<K, V>) result.holder;
+    return holder;
   }
 
   @Override

--- a/impl/src/main/java/org/ehcache/impl/serialization/CompactJavaSerializer.java
+++ b/impl/src/main/java/org/ehcache/impl/serialization/CompactJavaSerializer.java
@@ -109,7 +109,9 @@ public class CompactJavaSerializer<T> implements StatefulSerializer<T> {
     try {
       ObjectInputStream oin = getObjectInputStream(new ByteBufferInputStream(binary));
       try {
-        return (T) oin.readObject();
+        @SuppressWarnings("unchecked")
+        T value = (T) oin.readObject();
+        return value;
       } finally {
         oin.close();
       }

--- a/impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
@@ -36,10 +36,8 @@ import org.ehcache.spi.serialization.SerializerException;
 import org.ehcache.spi.service.ServiceConfiguration;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.core.IsSame;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -65,7 +63,10 @@ public class CacheConfigurationBuilderTest {
         .withEvictionAdvisor(evictionAdvisor)
         .build();
 
-    assertThat(evictionAdvisor, (Matcher)sameInstance(cacheConfiguration.getEvictionAdvisor()));
+    @SuppressWarnings("unchecked")
+    Matcher<EvictionAdvisor<Object, Object>> evictionAdvisorMatcher = (Matcher) sameInstance(cacheConfiguration
+      .getEvictionAdvisor());
+    assertThat(evictionAdvisor, evictionAdvisorMatcher);
   }
 
   @Test
@@ -285,7 +286,9 @@ public class CacheConfigurationBuilderTest {
     Class<Integer> keyClass = Integer.class;
     Class<String> valueClass = String.class;
     ClassLoader loader = mock(ClassLoader.class);
+    @SuppressWarnings("unchecked")
     EvictionAdvisor<Integer, String> eviction = mock(EvictionAdvisor.class);
+    @SuppressWarnings("unchecked")
     Expiry<Integer, String> expiry = mock(Expiry.class);
     ServiceConfiguration<?> service = mock(ServiceConfiguration.class);
 

--- a/impl/src/test/java/org/ehcache/config/builders/CacheManagerBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/CacheManagerBuilderTest.java
@@ -23,6 +23,7 @@ import org.ehcache.impl.copy.IdentityCopier;
 import org.ehcache.impl.copy.SerializingCopier;
 import org.ehcache.impl.serialization.CompactJavaSerializer;
 import org.ehcache.impl.serialization.JavaSerializer;
+import org.ehcache.spi.serialization.Serializer;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,6 +57,7 @@ public class CacheManagerBuilderTest {
 
   @Test
   public void testCanOverrideCopierInConfig() {
+    @SuppressWarnings("unchecked")
     CacheManagerBuilder<CacheManager> managerBuilder = newCacheManagerBuilder()
         .withCopier(Long.class, (Class) IdentityCopier.class);
     assertNotNull(managerBuilder.withCopier(Long.class, SerializingCopier.<Long>asCopierClass()));
@@ -63,9 +65,13 @@ public class CacheManagerBuilderTest {
 
   @Test
   public void testCanOverrideSerializerConfig() {
-    CacheManagerBuilder managerBuilder = newCacheManagerBuilder()
-        .withSerializer(String.class, (Class) JavaSerializer.class);
-    assertNotNull(managerBuilder.withSerializer(String.class, (Class) CompactJavaSerializer.class));
+    @SuppressWarnings("unchecked")
+    Class<Serializer<String>> serializer1 = (Class) JavaSerializer.class;
+    CacheManagerBuilder<CacheManager> managerBuilder = newCacheManagerBuilder()
+        .withSerializer(String.class, serializer1);
+    @SuppressWarnings("unchecked")
+    Class<Serializer<String>> serializer2 = (Class) CompactJavaSerializer.class;
+    assertNotNull(managerBuilder.withSerializer(String.class, serializer2));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/impl/src/test/java/org/ehcache/core/spi/ServiceProviderTest.java
+++ b/impl/src/test/java/org/ehcache/core/spi/ServiceProviderTest.java
@@ -28,7 +28,6 @@ import org.hamcrest.core.IsSame;
 import org.junit.Test;
 
 import static org.ehcache.core.internal.service.ServiceLocator.dependencySet;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -58,7 +57,7 @@ public class ServiceProviderTest {
       IsCollectionContaining.<CachingTier.Provider>hasItem(IsSame.<CachingTier.Provider>sameInstance(cachingTierProvider)));
     assertThat(serviceLocator.getServicesOfType(AuthoritativeTier.Provider.class),
       IsCollectionContaining.<AuthoritativeTier.Provider>hasItem(IsSame.<AuthoritativeTier.Provider>sameInstance(authoritativeTierProvider)));
-    assertThat(serviceLocator.getServicesOfType((Class<OffHeapDiskStore.Provider>) diskStoreProvider.getClass()),
-      IsCollectionContaining.<OffHeapDiskStore.Provider>hasItem(IsSame.sameInstance(diskStoreProvider)));
+    assertThat(serviceLocator.getServicesOfType(OffHeapDiskStore.Provider.class),
+      IsCollectionContaining.<OffHeapDiskStore.Provider>hasItem(IsSame.<OffHeapDiskStore.Provider>sameInstance(diskStoreProvider)));
   }
 }

--- a/impl/src/test/java/org/ehcache/impl/config/event/DefaultCacheEventListenerConfigurationTest.java
+++ b/impl/src/test/java/org/ehcache/impl/config/event/DefaultCacheEventListenerConfigurationTest.java
@@ -39,9 +39,10 @@ public class DefaultCacheEventListenerConfigurationTest {
   @Test(expected = IllegalArgumentException.class)
   public void testFailsToConstructWithEmptyEventSetAndClass() {
     Set<EventType> fireOn = emptySet();
-    new DefaultCacheEventListenerConfiguration(fireOn, (Class)TestCacheEventListener.class);
+    Class<TestCacheEventListener> eventListenerClass = TestCacheEventListener.class;
+    new DefaultCacheEventListenerConfiguration(fireOn, eventListenerClass);
   }
 
-  abstract static class TestCacheEventListener<K, V> implements CacheEventListener<K, V> {
+  abstract static class TestCacheEventListener implements CacheEventListener<String, String> {
   }
 }

--- a/impl/src/test/java/org/ehcache/impl/config/serializer/SerializerCountingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/config/serializer/SerializerCountingTest.java
@@ -58,6 +58,7 @@ public class SerializerCountingTest {
   public TemporaryFolder folder = new TemporaryFolder();
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     cacheManager = newCacheManagerBuilder()
         .using(new DefaultSerializationProviderConfiguration().addSerializerFor(Serializable.class, (Class) CountingSerializer.class)

--- a/impl/src/test/java/org/ehcache/impl/internal/classes/ClassInstanceProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/classes/ClassInstanceProviderTest.java
@@ -39,9 +39,12 @@ import static org.mockito.Mockito.verify;
  */
 public class ClassInstanceProviderTest {
 
+  @SuppressWarnings("unchecked")
+  private Class<ClassInstanceConfiguration<TestService>> configClass = (Class)ClassInstanceConfiguration.class;
+
   @Test
   public void testNewInstanceUsingAliasAndNoArgs() throws Exception {
-    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, (Class)ClassInstanceConfiguration.class);
+    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, configClass);
 
     classInstanceProvider.preconfigured.put("test stuff", new ClassInstanceConfiguration<TestService>(TestService.class));
     TestService obj = classInstanceProvider.newInstance("test stuff", (ServiceConfiguration) null);
@@ -51,7 +54,7 @@ public class ClassInstanceProviderTest {
 
   @Test
   public void testNewInstanceUsingAliasAndArg() throws Exception {
-    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, (Class)ClassInstanceConfiguration.class);
+    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, configClass);
 
     classInstanceProvider.preconfigured.put("test stuff", new ClassInstanceConfiguration<TestService>(TestService.class, "test string"));
     TestService obj = classInstanceProvider.newInstance("test stuff", (ServiceConfiguration<?>) null);
@@ -61,7 +64,7 @@ public class ClassInstanceProviderTest {
 
   @Test
   public void testNewInstanceUsingServiceConfig() throws Exception {
-    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, (Class)ClassInstanceConfiguration.class);
+    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, configClass);
 
     TestServiceConfiguration config = new TestServiceConfiguration();
     TestService obj = classInstanceProvider.newInstance("test stuff", config);
@@ -74,7 +77,7 @@ public class ClassInstanceProviderTest {
     TestServiceProviderConfiguration factoryConfig = new TestServiceProviderConfiguration();
     factoryConfig.getDefaults().put("test stuff", new ClassInstanceConfiguration<TestService>(TestService.class));
 
-    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(factoryConfig, (Class)ClassInstanceConfiguration.class);
+    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(factoryConfig, configClass);
     classInstanceProvider.start(null);
 
     TestService obj = classInstanceProvider.newInstance("test stuff", (ServiceConfiguration) null);
@@ -121,7 +124,7 @@ public class ClassInstanceProviderTest {
 
   @Test
   public void testNewInstanceWithActualInstanceInServiceConfig() throws Exception {
-    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, (Class)ClassInstanceConfiguration.class);
+    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, configClass);
 
     TestService service = new TestService();
     TestServiceConfiguration config = new TestServiceConfiguration(service);
@@ -133,7 +136,7 @@ public class ClassInstanceProviderTest {
 
   @Test
   public void testSameInstanceRetrievedMultipleTimesUpdatesTheProvidedCount() throws Exception {
-    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, (Class)ClassInstanceConfiguration.class);
+    ClassInstanceProvider<String, TestService> classInstanceProvider = new ClassInstanceProvider<String, TestService>(null, configClass);
 
     TestService service = new TestService();
     TestServiceConfiguration config = new TestServiceConfiguration(service);
@@ -148,7 +151,9 @@ public class ClassInstanceProviderTest {
 
   @Test
   public void testInstancesNotCreatedByProviderDoesNotClose() throws IOException {
-    ClassInstanceProvider<String, TestCloaseableService> classInstanceProvider = new ClassInstanceProvider<String, TestCloaseableService>(null, (Class)ClassInstanceConfiguration.class);
+    @SuppressWarnings("unchecked")
+    Class<ClassInstanceConfiguration<TestCloaseableService>> configClass = (Class) ClassInstanceConfiguration.class;
+    ClassInstanceProvider<String, TestCloaseableService> classInstanceProvider = new ClassInstanceProvider<String, TestCloaseableService>(null, configClass);
 
     TestCloaseableService service = mock(TestCloaseableService.class);
     TestCloaseableServiceConfig config = new TestCloaseableServiceConfig(service);

--- a/impl/src/test/java/org/ehcache/impl/internal/copy/SerializingCopierTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/copy/SerializingCopierTest.java
@@ -33,6 +33,7 @@ public class SerializingCopierTest {
 
   @Test
   public void testCopy() throws Exception {
+    @SuppressWarnings("unchecked")
     Serializer<String> serializer = mock(Serializer.class);
     String in = new String("foo");
     ByteBuffer buff = mock(ByteBuffer.class);

--- a/impl/src/test/java/org/ehcache/impl/internal/events/CacheEventDispatcherFactoryImplTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/CacheEventDispatcherFactoryImplTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ExecutorService;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -45,28 +45,34 @@ public class CacheEventDispatcherFactoryImplTest {
 
   @Test
   public void testConfigurationOfThreadPoolAlias() {
+    @SuppressWarnings("unchecked")
     ServiceProvider<Service> serviceProvider = mock(ServiceProvider.class);
     when(serviceProvider.getService(ExecutionService.class)).thenReturn(mock(ExecutionService.class));
     CacheEventDispatcherFactoryImpl factory = new CacheEventDispatcherFactoryImpl();
     factory.start(serviceProvider);
     DefaultCacheEventDispatcherConfiguration config = spy(new DefaultCacheEventDispatcherConfiguration("aName"));
-    factory.createCacheEventDispatcher(mock(Store.class), config);
+    @SuppressWarnings("unchecked")
+    Store<Object, Object> store = mock(Store.class);
+    factory.createCacheEventDispatcher(store, config);
     verify(config).getThreadPoolAlias();
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testCreateCacheEventDispatcherReturnsDisabledDispatcherWhenNoThreadPool() throws Exception {
     ServiceProvider<Service> serviceProvider = mock(ServiceProvider.class);
     ExecutionService executionService = mock(ExecutionService.class);
     when(serviceProvider.getService(ExecutionService.class)).thenReturn(executionService);
-    when(executionService.getOrderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenThrow(IllegalArgumentException.class);
-    when(executionService.getUnorderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenThrow(IllegalArgumentException.class);
+    when(executionService.getOrderedExecutor(eq("myAlias"), any(BlockingQueue.class))).thenThrow(IllegalArgumentException.class);
+    when(executionService.getUnorderedExecutor(eq("myAlias"), any(BlockingQueue.class))).thenThrow(IllegalArgumentException.class);
 
     CacheEventDispatcherFactoryImpl cacheEventDispatcherFactory = new CacheEventDispatcherFactoryImpl();
     cacheEventDispatcherFactory.start(serviceProvider);
 
+    @SuppressWarnings("unchecked")
+    Store<Object, Object> store = mock(Store.class);
     try {
-      cacheEventDispatcherFactory.createCacheEventDispatcher(mock(Store.class), new DefaultCacheEventDispatcherConfiguration("myAlias"));
+      cacheEventDispatcherFactory.createCacheEventDispatcher(store, new DefaultCacheEventDispatcherConfiguration("myAlias"));
       fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException iae) {
       // expected
@@ -74,17 +80,19 @@ public class CacheEventDispatcherFactoryImplTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testCreateCacheEventReturnsDisabledDispatcherWhenThreadPoolFound() throws Exception {
     ServiceProvider<Service> serviceProvider = mock(ServiceProvider.class);
     ExecutionService executionService = mock(ExecutionService.class);
     when(serviceProvider.getService(ExecutionService.class)).thenReturn(executionService);
-    when(executionService.getOrderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenReturn(mock(ExecutorService.class));
-    when(executionService.getUnorderedExecutor(eq("myAlias"), (BlockingQueue) anyObject())).thenReturn(mock(ExecutorService.class));
+    when(executionService.getOrderedExecutor(eq("myAlias"), any(BlockingQueue.class))).thenReturn(mock(ExecutorService.class));
+    when(executionService.getUnorderedExecutor(eq("myAlias"), any(BlockingQueue.class))).thenReturn(mock(ExecutorService.class));
 
     CacheEventDispatcherFactoryImpl cacheEventDispatcherFactory = new CacheEventDispatcherFactoryImpl();
     cacheEventDispatcherFactory.start(serviceProvider);
 
-    CacheEventDispatcher dispatcher = cacheEventDispatcherFactory.createCacheEventDispatcher(mock(Store.class), new DefaultCacheEventDispatcherConfiguration("myAlias"));
+    Store<Object, Object> store = mock(Store.class);
+    CacheEventDispatcher dispatcher = cacheEventDispatcherFactory.createCacheEventDispatcher(store, new DefaultCacheEventDispatcherConfiguration("myAlias"));
     assertThat(dispatcher, instanceOf(CacheEventDispatcherImpl.class));
   }
 }

--- a/impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
@@ -16,9 +16,11 @@
 
 package org.ehcache.impl.internal.events;
 
+import org.ehcache.core.spi.store.events.StoreEvent;
 import org.ehcache.event.EventType;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -40,10 +42,13 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 public class FudgingInvocationScopedEventSinkTest {
 
-  private StoreEventListener listener;
+  private StoreEventListener<String, String> listener;
   private FudgingInvocationScopedEventSink<String, String> eventSink;
+  private Matcher<StoreEvent<String, String>> createdMatcher = eventType(EventType.CREATED);
+  private Matcher<StoreEvent<String, String>> evictedMatcher = eventType(EventType.EVICTED);
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     HashSet<StoreEventListener<String, String>> storeEventListeners = new HashSet<StoreEventListener<String, String>>();
     listener = mock(StoreEventListener.class);
@@ -60,8 +65,8 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.EVICTED)));
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
+    inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     verifyNoMoreInteractions(listener);
   }
 
@@ -72,8 +77,8 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.EVICTED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
+    inOrder.verify(listener).onEvent(argThat(evictedMatcher));
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
   }
 
@@ -85,8 +90,8 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.EVICTED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
+    inOrder.verify(listener).onEvent(argThat(evictedMatcher));
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
   }
 
@@ -99,8 +104,8 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(3)).onEvent(argThat(eventType(EventType.EVICTED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
+    inOrder.verify(listener, times(3)).onEvent(argThat(evictedMatcher));
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
   }
 
@@ -114,8 +119,8 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(3)).onEvent(argThat(eventType(EventType.EVICTED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
+    inOrder.verify(listener, times(3)).onEvent(argThat(evictedMatcher));
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
   }
 
@@ -127,9 +132,10 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.UPDATED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.EVICTED)));
+    Matcher<StoreEvent<String, String>> updatedMatcher = eventType(EventType.UPDATED);
+    inOrder.verify(listener).onEvent(argThat(updatedMatcher));
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
+    inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     verifyNoMoreInteractions(listener);
   }
 }

--- a/impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
@@ -16,9 +16,11 @@
 
 package org.ehcache.impl.internal.events;
 
+import org.ehcache.core.spi.store.events.StoreEvent;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
 import org.ehcache.event.EventType;
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -39,10 +41,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 public class InvocationScopedEventSinkTest {
 
-  private StoreEventListener listener;
+  private StoreEventListener<String, String> listener;
   private InvocationScopedEventSink<String, String> eventSink;
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     HashSet<StoreEventListener<String, String>> storeEventListeners = new HashSet<StoreEventListener<String, String>>();
     listener = mock(StoreEventListener.class);
@@ -63,9 +66,12 @@ public class InvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.CREATED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.UPDATED)));
-    inOrder.verify(listener).onEvent(argThat(eventType(EventType.EVICTED)));
+    Matcher<StoreEvent<String, String>> createdMatcher = eventType(EventType.CREATED);
+    inOrder.verify(listener).onEvent(argThat(createdMatcher));
+    Matcher<StoreEvent<String, String>> updatedMatcher = eventType(EventType.UPDATED);
+    inOrder.verify(listener).onEvent(argThat(updatedMatcher));
+    Matcher<StoreEvent<String, String>> evictedMatcher = eventType(EventType.EVICTED);
+    inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     verifyNoMoreInteractions(listener);
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/events/ScopedStoreEventDispatcherTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/ScopedStoreEventDispatcherTest.java
@@ -25,6 +25,7 @@ import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
 import org.hamcrest.Matcher;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +64,10 @@ public class ScopedStoreEventDispatcherTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testListenerNotifiedUnordered() {
     ScopedStoreEventDispatcher<String, String> dispatcher = new ScopedStoreEventDispatcher<String, String>(1);
+    @SuppressWarnings("unchecked")
     StoreEventListener<String, String> listener = mock(StoreEventListener.class);
     dispatcher.addEventListener(listener);
 
@@ -76,8 +79,10 @@ public class ScopedStoreEventDispatcherTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testListenerNotifiedOrdered() {
     ScopedStoreEventDispatcher<String, String> dispatcher = new ScopedStoreEventDispatcher<String, String>(1);
+    @SuppressWarnings("unchecked")
     StoreEventListener<String, String> listener = mock(StoreEventListener.class);
     dispatcher.addEventListener(listener);
     dispatcher.setEventOrdering(true);
@@ -92,9 +97,11 @@ public class ScopedStoreEventDispatcherTest {
   @Test
   public void testEventFiltering() {
     ScopedStoreEventDispatcher<String, String> dispatcher = new ScopedStoreEventDispatcher<String, String>(1);
+    @SuppressWarnings("unchecked")
     StoreEventListener<String, String> listener = mock(StoreEventListener.class);
     dispatcher.addEventListener(listener);
 
+    @SuppressWarnings("unchecked")
     StoreEventFilter<String, String> filter = mock(StoreEventFilter.class);
     when(filter.acceptEvent(eq(EventType.CREATED), anyString(), anyString(), anyString())).thenReturn(true);
     when(filter.acceptEvent(eq(EventType.REMOVED), anyString(), anyString(), anyString())).thenReturn(false);

--- a/impl/src/test/java/org/ehcache/impl/internal/executor/PartitionedOrderedExecutorTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/executor/PartitionedOrderedExecutorTest.java
@@ -297,7 +297,7 @@ public class PartitionedOrderedExecutorTest {
       List<Future<?>> tasks = new ArrayList<Future<?>>();
       for (int i = 0; i < 100; i++) {
         final int index = i;
-        tasks.add(executor.submit(new Callable() {
+        tasks.add(executor.submit(new Callable<Object>() {
 
           @Override
           public Object call() throws Exception {

--- a/impl/src/test/java/org/ehcache/impl/internal/loaderwriter/writebehind/AbstractWriteBehindTestBase.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/loaderwriter/writebehind/AbstractWriteBehindTestBase.java
@@ -71,8 +71,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testWriteOrdering() throws Exception {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -104,8 +103,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testWrites() throws Exception {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -133,8 +131,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testBulkWrites() throws Exception {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -181,8 +178,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testThatAllGetsReturnLatestData() throws BulkCacheWritingException, Exception {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
@@ -230,8 +226,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testAllGetsReturnLatestDataWithKeyCollision() {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -260,10 +255,10 @@ public abstract class AbstractWriteBehindTestBase {
 
   @Test
   public void testBatchedDeletedKeyReturnsNull() throws Exception {
+    @SuppressWarnings("unchecked")
     CacheLoaderWriter<String, String> loaderWriter = mock(CacheLoaderWriter.class);
     when(loaderWriter.load("key")).thenReturn("value");
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -285,6 +280,7 @@ public abstract class AbstractWriteBehindTestBase {
   public void testUnBatchedDeletedKeyReturnsNull() throws Exception {
     final Semaphore semaphore = new Semaphore(0);
 
+    @SuppressWarnings("unchecked")
     CacheLoaderWriter<String, String> loaderWriter = mock(CacheLoaderWriter.class);
     when(loaderWriter.load("key")).thenReturn("value");
     doAnswer(new Answer() {
@@ -294,8 +290,7 @@ public abstract class AbstractWriteBehindTestBase {
         return null;
       }
     }).when(loaderWriter).delete("key");
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -316,10 +311,10 @@ public abstract class AbstractWriteBehindTestBase {
 
   @Test
   public void testBatchedOverwrittenKeyReturnsNewValue() throws Exception {
+    @SuppressWarnings("unchecked")
     CacheLoaderWriter<String, String> loaderWriter = mock(CacheLoaderWriter.class);
     when(loaderWriter.load("key")).thenReturn("value");
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -341,6 +336,7 @@ public abstract class AbstractWriteBehindTestBase {
   public void testUnBatchedOverwrittenKeyReturnsNewValue() throws Exception {
     final Semaphore semaphore = new Semaphore(0);
 
+    @SuppressWarnings("unchecked")
     CacheLoaderWriter<String, String> loaderWriter = mock(CacheLoaderWriter.class);
     when(loaderWriter.load("key")).thenReturn("value");
     doAnswer(new Answer() {
@@ -350,8 +346,7 @@ public abstract class AbstractWriteBehindTestBase {
         return null;
       }
     }).when(loaderWriter).delete("key");
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -373,8 +368,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testCoaslecedWritesAreNotSeen() throws InterruptedException {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -401,8 +395,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testUnBatchedWriteBehindStopWaitsForEmptyQueue() {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -420,8 +413,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testBatchedWriteBehindStopWaitsForEmptyQueue() {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -439,6 +431,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testUnBatchedWriteBehindBlocksWhenFull() throws Exception {
     final Semaphore gate = new Semaphore(0);
+    @SuppressWarnings("unchecked")
     CacheLoaderWriter<String, String> loaderWriter = mock(CacheLoaderWriter.class);
     doAnswer(new Answer() {
 
@@ -449,8 +442,7 @@ public abstract class AbstractWriteBehindTestBase {
       }
     }).when(loaderWriter).write(anyString(), anyString());
 
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -489,6 +481,7 @@ public abstract class AbstractWriteBehindTestBase {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testBatchedWriteBehindBlocksWhenFull() throws Exception {
     final Semaphore gate = new Semaphore(0);
     CacheLoaderWriter<String, String> loaderWriter = mock(CacheLoaderWriter.class);
@@ -501,8 +494,7 @@ public abstract class AbstractWriteBehindTestBase {
       }
     }).when(loaderWriter).writeAll(any(Iterable.class));
 
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -543,8 +535,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testFilledBatchedIsWritten() throws Exception {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -572,8 +563,7 @@ public abstract class AbstractWriteBehindTestBase {
   @Test
   public void testAgedBatchedIsWritten() throws Exception {
     WriteBehindTestLoaderWriter<String, String> loaderWriter = new WriteBehindTestLoaderWriter<String, String>();
-    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
-    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn((CacheLoaderWriter)loaderWriter);
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = getMockedCacheLoaderWriterProvider(loaderWriter);
 
     CacheManager cacheManager = managerBuilder().using(cacheLoaderWriterProvider).build(true);
     try {
@@ -604,6 +594,7 @@ public abstract class AbstractWriteBehindTestBase {
       private WriteBehind writeBehind = null;
 
       @Override
+      @SuppressWarnings("unchecked")
       public <K, V> WriteBehind<K, V> createWriteBehindLoaderWriter(final CacheLoaderWriter<K, V> cacheLoaderWriter, final WriteBehindConfiguration configuration) {
         this.writeBehind = super.createWriteBehindLoaderWriter(cacheLoaderWriter, configuration);
         return writeBehind;
@@ -632,4 +623,12 @@ public abstract class AbstractWriteBehindTestBase {
       cacheManager.close();
     }
   }
+
+  @SuppressWarnings("unchecked")
+  protected CacheLoaderWriterProvider getMockedCacheLoaderWriterProvider(CacheLoaderWriter loaderWriter) {
+    CacheLoaderWriterProvider cacheLoaderWriterProvider = mock(CacheLoaderWriterProvider.class);
+    when(cacheLoaderWriterProvider.createCacheLoaderWriter(anyString(), (CacheConfiguration<String, String>)anyObject())).thenReturn(loaderWriter);
+    return cacheLoaderWriterProvider;
+  }
+
 }

--- a/impl/src/test/java/org/ehcache/impl/internal/persistence/TestDiskResourceService.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/persistence/TestDiskResourceService.java
@@ -62,7 +62,8 @@ public class TestDiskResourceService extends ExternalResource implements DiskRes
     fileService = new DefaultLocalPersistenceService(new CacheManagerPersistenceConfiguration(folder.newFolder()));
     fileService.start(null);
     diskResourceService = new DefaultDiskResourceService();
-    ServiceProvider sp = mock(ServiceProvider.class);
+    @SuppressWarnings("unchecked")
+    ServiceProvider<Service> sp = mock(ServiceProvider.class);
     Mockito.when(sp.getService(LocalPersistenceService.class)).thenReturn(fileService);
     diskResourceService.start(sp);
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/sizeof/DefaultSizeOfEngineTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/sizeof/DefaultSizeOfEngineTest.java
@@ -37,7 +37,10 @@ public class DefaultSizeOfEngineTest {
   public void testMaxObjectGraphSizeExceededException() {
     SizeOfEngine sizeOfEngine = new DefaultSizeOfEngine(3, Long.MAX_VALUE);
     try {
-      sizeOfEngine.sizeof(new MaxDepthGreaterThanThree(), new CopiedOnHeapValueHolder(new MaxDepthGreaterThanThree(), 0l, true, new IdentityCopier()));
+      @SuppressWarnings("unchecked")
+      IdentityCopier<MaxDepthGreaterThanThree> valueCopier = new IdentityCopier();
+      sizeOfEngine.sizeof(new MaxDepthGreaterThanThree(),
+        new CopiedOnHeapValueHolder<MaxDepthGreaterThanThree>(new MaxDepthGreaterThanThree(), 0L, true, valueCopier));
       fail();
     } catch (Exception limitExceededException) {
       assertThat(limitExceededException, instanceOf(LimitExceededException.class));
@@ -49,7 +52,9 @@ public class DefaultSizeOfEngineTest {
     SizeOfEngine sizeOfEngine = new DefaultSizeOfEngine(Long.MAX_VALUE, 1000);
     try {
       String overSized = new String(new byte[1000]);
-      sizeOfEngine.sizeof(overSized, new CopiedOnHeapValueHolder("test", 0l, true, new IdentityCopier()));
+      @SuppressWarnings("unchecked")
+      IdentityCopier<String> valueCopier = new IdentityCopier();
+      sizeOfEngine.sizeof(overSized, new CopiedOnHeapValueHolder<String>("test", 0L, true, valueCopier));
       fail();
     } catch (Exception limitExceededException) {
       assertThat(limitExceededException, instanceOf(LimitExceededException.class));

--- a/impl/src/test/java/org/ehcache/impl/internal/spi/copy/DefaultCopyProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/spi/copy/DefaultCopyProviderTest.java
@@ -42,6 +42,7 @@ public class DefaultCopyProviderTest {
   public void testCreateKeyCopierWithCustomCopierConfig() {
     DefaultCopyProvider provider = new DefaultCopyProvider(null);
 
+    @SuppressWarnings("unchecked")
     DefaultCopierConfiguration<Long> config = new DefaultCopierConfiguration<Long>(
         (Class)TestCopier.class, DefaultCopierConfiguration.Type.KEY);
 
@@ -61,13 +62,16 @@ public class DefaultCopyProviderTest {
     DefaultCopierConfiguration<Long> config = new DefaultCopierConfiguration<Long>(
         SerializingCopier.<Long>asCopierClass(), DefaultCopierConfiguration.Type.KEY);
 
-    assertThat(copyProvider.createKeyCopier(Long.class, mock(Serializer.class), config), instanceOf(SerializingCopier.class));
+    @SuppressWarnings("unchecked")
+    Serializer<Long> serializer = mock(Serializer.class);
+    assertThat(copyProvider.createKeyCopier(Long.class, serializer, config), instanceOf(SerializingCopier.class));
   }
 
   @Test
   public void testCreateValueCopierWithCustomCopierConfig() {
     DefaultCopyProvider provider = new DefaultCopyProvider(null);
 
+    @SuppressWarnings("unchecked")
     DefaultCopierConfiguration<Long> config = new DefaultCopierConfiguration<Long>(
         (Class)TestCopier.class, DefaultCopierConfiguration.Type.VALUE);
 
@@ -87,7 +91,9 @@ public class DefaultCopyProviderTest {
     DefaultCopierConfiguration<Long> config = new DefaultCopierConfiguration<Long>(
         SerializingCopier.<Long>asCopierClass(), DefaultCopierConfiguration.Type.VALUE);
 
-    assertThat(copyProvider.createValueCopier(Long.class, mock(Serializer.class), config), instanceOf(SerializingCopier.class));
+    @SuppressWarnings("unchecked")
+    Serializer<Long> serializer = mock(Serializer.class);
+    assertThat(copyProvider.createValueCopier(Long.class, serializer, config), instanceOf(SerializingCopier.class));
   }
 
   @Test
@@ -96,7 +102,9 @@ public class DefaultCopyProviderTest {
     TestCloseableCopier<Long> testCloseableCopier = new TestCloseableCopier<Long>();
     DefaultCopierConfiguration<Long> config = new DefaultCopierConfiguration<Long>(testCloseableCopier, DefaultCopierConfiguration.Type.KEY);
 
-    assertThat(copyProvider.createKeyCopier(Long.class, mock(Serializer.class), config), sameInstance((Copier)testCloseableCopier));
+    @SuppressWarnings("unchecked")
+    Serializer<Long> serializer = mock(Serializer.class);
+    assertThat(copyProvider.createKeyCopier(Long.class, serializer, config), sameInstance((Copier)testCloseableCopier));
 
     copyProvider.releaseCopier(testCloseableCopier);
 

--- a/impl/src/test/java/org/ehcache/impl/internal/spi/loaderwriter/DefaultCacheLoaderWriterProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/spi/loaderwriter/DefaultCacheLoaderWriterProviderTest.java
@@ -24,6 +24,7 @@ import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.impl.config.loaderwriter.DefaultCacheLoaderWriterConfiguration;
 import org.ehcache.impl.config.loaderwriter.DefaultCacheLoaderWriterProviderConfiguration;
+import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceProvider;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.ehcache.spi.service.ServiceConfiguration;
@@ -108,13 +109,17 @@ public class DefaultCacheLoaderWriterProviderTest {
     configuration.addLoaderFor("cache", MyLoader.class);
     DefaultCacheLoaderWriterProvider loaderWriterProvider = new DefaultCacheLoaderWriterProvider(configuration);
 
-    loaderWriterProvider.start(mock(ServiceProvider.class));
-    assertThat(loaderWriterProvider.createCacheLoaderWriter("cache", mock(CacheConfiguration.class)), CoreMatchers.instanceOf(MyLoader.class));
+    @SuppressWarnings("unchecked")
+    ServiceProvider<Service> serviceProvider = mock(ServiceProvider.class);
+    loaderWriterProvider.start(serviceProvider);
+    @SuppressWarnings("unchecked")
+    CacheConfiguration<Object, Object> cacheConfiguration = mock(CacheConfiguration.class);
+    assertThat(loaderWriterProvider.createCacheLoaderWriter("cache", cacheConfiguration), CoreMatchers.instanceOf(MyLoader.class));
 
     loaderWriterProvider.stop();
-    loaderWriterProvider.start(mock(ServiceProvider.class));
+    loaderWriterProvider.start(serviceProvider);
 
-    assertThat(loaderWriterProvider.createCacheLoaderWriter("cache", mock(CacheConfiguration.class)), CoreMatchers.instanceOf(MyLoader.class));
+    assertThat(loaderWriterProvider.createCacheLoaderWriter("cache", cacheConfiguration), CoreMatchers.instanceOf(MyLoader.class));
   }
 
   public static class MyLoader implements CacheLoaderWriter<Object, Object> {
@@ -140,7 +145,7 @@ public class DefaultCacheLoaderWriterProviderTest {
 
     @Override
     public void write(final Object key, final Object value) throws Exception {
-      this.lastWritten = value;
+      lastWritten = value;
     }
 
     @Override
@@ -177,7 +182,7 @@ public class DefaultCacheLoaderWriterProviderTest {
 
     @Override
     public void write(final Object key, final Object value) throws Exception {
-      this.lastWritten = value;
+      lastWritten = value;
     }
 
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCacheTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCacheTest.java
@@ -50,11 +50,13 @@ public class EhcachePersistentConcurrentOffHeapClockCacheTest extends AbstractEh
   public final TemporaryFolder folder = new TemporaryFolder();
 
   @Override
+  @SuppressWarnings("unchecked")
   protected EhcachePersistentConcurrentOffHeapClockCache<String, String> createTestSegment() throws IOException {
     return createTestSegment(noAdvice(), mock(EvictionListener.class));
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   protected EhcacheOffHeapBackingMap<String, String> createTestSegment(EvictionAdvisor<? super String, ? super String> evictionPredicate) throws IOException {
     return createTestSegment(evictionPredicate, mock(EvictionListener.class));
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreProviderTest.java
@@ -71,16 +71,17 @@ public class OffHeapDiskStoreProviderTest {
 
     OffHeapDiskStore<Long, String> store = provider.createStore(getStoreConfig(), mock(PersistableResourceService.PersistenceSpaceIdentifier.class));
 
-     Query storeQuery = queryBuilder()
-         .children()
-         .filter(context(attributes(Matchers.<Map<String, Object>>allOf(
-             hasAttribute("tags", new Matcher<Set<String>>() {
-               @Override
-               protected boolean matchesSafely(Set<String> object) {
-                 return object.containsAll(singleton("Disk"));
-               }
-             })))))
-         .build();
+    @SuppressWarnings("unchecked")
+    Query storeQuery = queryBuilder()
+      .children()
+      .filter(context(attributes(Matchers.<Map<String, Object>>allOf(
+        hasAttribute("tags", new Matcher<Set<String>>() {
+          @Override
+          protected boolean matchesSafely(Set<String> object) {
+            return object.containsAll(singleton("Disk"));
+          }
+        })))))
+      .build();
 
      Set<TreeNode> nodes = singleton(ContextManager.nodeFor(store));
 
@@ -124,8 +125,9 @@ public class OffHeapDiskStoreProviderTest {
        public ResourcePools getResourcePools() {
          return new ResourcePools() {
            @Override
-           public ResourcePool getPoolForResource(ResourceType resourceType) {
-             return new SizedResourcePool() {
+           @SuppressWarnings("unchecked")
+           public <P extends ResourcePool> P getPoolForResource(ResourceType<P> resourceType) {
+             return (P) new SizedResourcePool() {
                @Override
                public ResourceType getType() {
                  return ResourceType.Core.DISK;
@@ -154,6 +156,7 @@ public class OffHeapDiskStoreProviderTest {
            }
 
            @Override
+           @SuppressWarnings("unchecked")
            public Set<ResourceType<?>> getResourceTypeSet() {
              return (Set) singleton(ResourceType.Core.OFFHEAP);
            }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreSPITest.java
@@ -191,7 +191,7 @@ public class OffHeapDiskStoreSPITest extends AuthoritativeTierSPITest<String, St
       public void close(final Store<String, String> store) {
         String spaceName = createdStores.get(store);
         try {
-          OffHeapDiskStore.Provider.close((OffHeapDiskStore)store);
+          OffHeapDiskStore.Provider.close((OffHeapDiskStore<String, String>)store);
         } catch (IOException ex) {
           throw new RuntimeException(ex);
         }
@@ -210,7 +210,7 @@ public class OffHeapDiskStoreSPITest extends AuthoritativeTierSPITest<String, St
   public void tearDown() throws CachePersistenceException, IOException {
     try {
       for (Map.Entry<Store<String, String>, String> entry : createdStores.entrySet()) {
-        OffHeapDiskStore.Provider.close((OffHeapDiskStore) entry.getKey());
+        OffHeapDiskStore.Provider.close((OffHeapDiskStore<String, String>) entry.getKey());
         diskResourceService.destroy(entry.getValue());
       }
     } finally {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
@@ -128,6 +128,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     PersistenceSpaceIdentifier space = diskResourceService.getPersistenceSpaceIdentifier("cache", cacheConfiguration);
 
     {
+      @SuppressWarnings("unchecked")
       Store.Configuration<Long, String> storeConfig1 = mock(Store.Configuration.class);
       when(storeConfig1.getKeyType()).thenReturn(Long.class);
       when(storeConfig1.getValueType()).thenReturn(String.class);
@@ -143,6 +144,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     }
 
     {
+      @SuppressWarnings("unchecked")
       Store.Configuration<Long, Serializable> storeConfig2 = mock(Store.Configuration.class);
       when(storeConfig2.getKeyType()).thenReturn(Long.class);
       when(storeConfig2.getValueType()).thenReturn(Serializable.class);
@@ -176,6 +178,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     PersistenceSpaceIdentifier space = diskResourceService.getPersistenceSpaceIdentifier("cache", cacheConfiguration);
 
     {
+      @SuppressWarnings("unchecked")
       Store.Configuration<Long, Object[]> storeConfig1 = mock(Store.Configuration.class);
       when(storeConfig1.getKeyType()).thenReturn(Long.class);
       when(storeConfig1.getValueType()).thenReturn(Object[].class);
@@ -191,6 +194,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     }
 
     {
+      @SuppressWarnings("unchecked")
       Store.Configuration<Long, Object[]> storeConfig2 = mock(Store.Configuration.class);
       when(storeConfig2.getKeyType()).thenReturn(Long.class);
       when(storeConfig2.getValueType()).thenReturn(Object[].class);
@@ -276,6 +280,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testAuthoritativeRank() throws Exception {
     OffHeapDiskStore.Provider provider = new OffHeapDiskStore.Provider();
     assertThat(provider.rankAuthority(ResourceType.Core.DISK, EMPTY_LIST), is(1));
@@ -411,6 +416,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
       }
     })))).filter(context(attributes(hasAttribute("name", "invalidateAll")))).ensureUnique().build();
 
+    @SuppressWarnings("unchecked")
     OperationStatistic<LowerCachingTierOperationsOutcome.InvalidateAllOutcome> invalidateAll = (OperationStatistic<LowerCachingTierOperationsOutcome.InvalidateAllOutcome>) invalidateAllQuery.execute(singleton(nodeFor(cache))).iterator().next().getContext().attributes().get("this");
 
     assertThat(invalidateAll.sum(), is(0L));

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/factories/EhcachePersistentSegmentTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/factories/EhcachePersistentSegmentTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.store.disk.factories;
 
-import org.ehcache.config.Eviction;
 import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.impl.internal.store.disk.factories.EhcachePersistentSegmentFactory.EhcachePersistentSegment;
 import org.ehcache.impl.internal.store.offheap.SwitchableEvictionAdvisor;
@@ -52,10 +51,12 @@ public class EhcachePersistentSegmentTest {
   @Rule
   public final TemporaryFolder folder = new TemporaryFolder();
 
+  @SuppressWarnings("unchecked")
   private EhcachePersistentSegmentFactory.EhcachePersistentSegment<String, String> createTestSegment() throws IOException {
     return createTestSegment(noAdvice(), mock(EvictionListener.class));
   }
 
+  @SuppressWarnings("unchecked")
   private EhcachePersistentSegmentFactory.EhcachePersistentSegment<String, String> createTestSegment(EvictionAdvisor<String, String> evictionPredicate) throws IOException {
     return createTestSegment(evictionPredicate, mock(EvictionListener.class));
   }
@@ -145,6 +146,7 @@ public class EhcachePersistentSegmentTest {
 
   @Test
   public void testEvictionFiresEvent() throws IOException {
+    @SuppressWarnings("unchecked")
     EvictionListener<String, String> evictionListener = mock(EvictionListener.class);
     EhcachePersistentSegment<String, String> segment = createTestSegment(evictionListener);
     try {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/ByteSizedOnHeapStoreByRefSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/ByteSizedOnHeapStoreByRefSPITest.java
@@ -75,6 +75,7 @@ public class ByteSizedOnHeapStoreByRefSPITest extends StoreSPITest<String, Strin
         return newStore(null, evictionAdvisor, Expirations.noExpiration(), SystemTimeSource.INSTANCE);
       }
 
+      @SuppressWarnings("unchecked")
       private Store<String, String> newStore(Long capacity, EvictionAdvisor<String, String> evictionAdvisor, Expiry<? super String, ? super String> expiry, TimeSource timeSource) {
         ResourcePools resourcePools = buildResourcePools(capacity);
         Store.Configuration<String, String> config = new StoreConfigurationImpl<String, String>(getKeyType(), getValueType(),
@@ -84,6 +85,7 @@ public class ByteSizedOnHeapStoreByRefSPITest extends StoreSPITest<String, Strin
       }
 
       @Override
+      @SuppressWarnings("unchecked")
       public Store.ValueHolder<String> newValueHolder(final String value) {
         return new CopiedOnHeapValueHolder<String>(value, SystemTimeSource.INSTANCE.getTimeMillis(), false, DEFAULT_COPIER);
       }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/CountSizedOnHeapStoreByRefTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/CountSizedOnHeapStoreByRefTest.java
@@ -44,6 +44,7 @@ public class CountSizedOnHeapStoreByRefTest extends OnHeapStoreByRefTest {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   protected <K, V> OnHeapStore<K, V> newStore(final TimeSource timeSource,
       final Expiry<? super K, ? super V> expiry,
       final EvictionAdvisor<? super K, ? super V> evictionAdvisor, final int capacity) {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/CountSizedOnHeapStoreByValueTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/CountSizedOnHeapStoreByValueTest.java
@@ -21,6 +21,7 @@ import org.ehcache.core.CacheConfigurationProperty;
 import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.units.EntryUnit;
+import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.expiry.Expiry;
 import org.ehcache.impl.internal.sizeof.NoopSizeOfEngine;
 import org.ehcache.core.spi.time.TimeSource;
@@ -47,6 +48,7 @@ public class CountSizedOnHeapStoreByValueTest extends OnHeapStoreByValueTest {
   protected <K, V> OnHeapStore<K, V> newStore(final TimeSource timeSource,
       final Expiry<? super K, ? super V> expiry,
       final EvictionAdvisor<? super K, ? super V> evictionAdvisor, final Copier<K> keyCopier, final Copier<V> valueCopier, final int capacity) {
+    StoreEventDispatcher<K, V> eventDispatcher = getStoreEventDispatcher();
     return new OnHeapStore<K, V>(new Store.Configuration<K, V>() {
 
       @SuppressWarnings("unchecked")

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreBulkMethodsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreBulkMethodsTest.java
@@ -62,14 +62,15 @@ public class OnHeapStoreBulkMethodsTest {
     return config;
   }
 
+  @SuppressWarnings("unchecked")
   protected <Number, CharSequence> OnHeapStore<Number, CharSequence> newStore() {
     Store.Configuration<Number, CharSequence> configuration = mockStoreConfig();
     return new OnHeapStore<Number, CharSequence>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER,
         new NoopSizeOfEngine(), NullStoreEventDispatcher.<Number, CharSequence>nullStoreEventDispatcher());
   }
 
-  @SuppressWarnings("unchecked")
   @Test
+  @SuppressWarnings("unchecked")
   public void testBulkComputeFunctionGetsValuesOfEntries() throws Exception {
     @SuppressWarnings("rawtypes")
     Store.Configuration config = mock(Store.Configuration.class);
@@ -164,6 +165,7 @@ public class OnHeapStoreBulkMethodsTest {
   public void testBulkComputeStoreRemovesValueWhenFunctionReturnsNullMappings() throws Exception {
     Store.Configuration<Number, CharSequence> configuration = mockStoreConfig();
 
+    @SuppressWarnings("unchecked")
     OnHeapStore<Number, CharSequence> store = new OnHeapStore<Number, CharSequence>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER, new NoopSizeOfEngine(), NullStoreEventDispatcher.<Number, CharSequence>nullStoreEventDispatcher());
     store.put(1, "one");
     store.put(2, "two");

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreByRefSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreByRefSPITest.java
@@ -81,6 +81,7 @@ public class OnHeapStoreByRefSPITest extends StoreSPITest<String, String> {
         return newStore(null, evictionAdvisor, Expirations.noExpiration(), SystemTimeSource.INSTANCE);
       }
 
+      @SuppressWarnings("unchecked")
       private Store<String, String> newStore(Long capacity, EvictionAdvisor<String, String> evictionAdvisor, Expiry<? super String, ? super String> expiry, TimeSource timeSource) {
         ResourcePools resourcePools = buildResourcePools(capacity);
         Store.Configuration<String, String> config = new StoreConfigurationImpl<String, String>(getKeyType(), getValueType(),
@@ -89,6 +90,7 @@ public class OnHeapStoreByRefSPITest extends StoreSPITest<String, String> {
       }
 
       @Override
+      @SuppressWarnings("unchecked")
       public Store.ValueHolder<String> newValueHolder(final String value) {
         return new CopiedOnHeapValueHolder<String>(value, SystemTimeSource.INSTANCE.getTimeMillis(), false, DEFAULT_COPIER);
       }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreCachingTierByRefSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreCachingTierByRefSPITest.java
@@ -27,7 +27,6 @@ import org.ehcache.impl.internal.store.heap.holders.CopiedOnHeapValueHolder;
 import org.ehcache.core.spi.time.SystemTimeSource;
 import org.ehcache.internal.tier.CachingTierFactory;
 import org.ehcache.internal.tier.CachingTierSPITest;
-import org.ehcache.core.internal.service.ServiceLocator;
 import org.ehcache.spi.service.ServiceProvider;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.tiering.CachingTier;
@@ -54,6 +53,7 @@ public class OnHeapStoreCachingTierByRefSPITest extends CachingTierSPITest<Strin
   }
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     cachingTierFactory = new CachingTierFactory<String, String>() {
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreEvictionTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreEvictionTest.java
@@ -206,10 +206,12 @@ public class OnHeapStoreEvictionTest {
 
     private static final Copier DEFAULT_COPIER = new IdentityCopier();
 
+    @SuppressWarnings("unchecked")
     public OnHeapStoreForTests(final Configuration<K, V> config, final TimeSource timeSource) {
       super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER,  new NoopSizeOfEngine(), NullStoreEventDispatcher.<K, V>nullStoreEventDispatcher());
     }
 
+    @SuppressWarnings("unchecked")
     public OnHeapStoreForTests(final Configuration<K, V> config, final TimeSource timeSource, final SizeOfEngine engine) {
       super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER, engine, NullStoreEventDispatcher.<K, V>nullStoreEventDispatcher());
     }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreKeyCopierTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreKeyCopierTest.java
@@ -93,6 +93,8 @@ public class OnHeapStoreKeyCopierTest {
     when(configuration.getKeyType()).thenReturn(Key.class);
     when(configuration.getValueType()).thenReturn(String.class);
     when(configuration.getExpiry()).thenReturn(Expirations.noExpiration());
+    @SuppressWarnings("unchecked")
+    Store.Configuration<Key, String> config = configuration;
 
     Copier<Key> keyCopier = new Copier<Key>() {
       @Override
@@ -112,7 +114,7 @@ public class OnHeapStoreKeyCopierTest {
       }
     };
 
-    store = new OnHeapStore<Key, String>(configuration, SystemTimeSource.INSTANCE, keyCopier, new IdentityCopier<String>(), new NoopSizeOfEngine(), NullStoreEventDispatcher.<Key, String>nullStoreEventDispatcher());
+    store = new OnHeapStore<Key, String>(config, SystemTimeSource.INSTANCE, keyCopier, new IdentityCopier<String>(), new NoopSizeOfEngine(), NullStoreEventDispatcher.<Key, String>nullStoreEventDispatcher());
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreProviderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreProviderTest.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import static java.util.Collections.EMPTY_LIST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
 
 /**
  * Basic tests for {@link org.ehcache.impl.internal.store.heap.OnHeapStore.Provider}.
@@ -73,6 +72,7 @@ public class OnHeapStoreProviderTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testRankCachingTier() throws Exception {
     OnHeapStore.Provider provider = new OnHeapStore.Provider();
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreValueCopierTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreValueCopierTest.java
@@ -92,6 +92,8 @@ public class OnHeapStoreValueCopierTest {
     when(configuration.getKeyType()).thenReturn(Long.class);
     when(configuration.getValueType()).thenReturn(Value.class);
     when(configuration.getExpiry()).thenReturn(Expirations.noExpiration());
+    @SuppressWarnings("unchecked")
+    Store.Configuration<Long, Value> config = configuration;
 
     Copier<Value> valueCopier = new Copier<Value>() {
       @Override
@@ -111,7 +113,7 @@ public class OnHeapStoreValueCopierTest {
       }
     };
 
-    store = new OnHeapStore<Long, Value>(configuration, SystemTimeSource.INSTANCE, new IdentityCopier<Long>(), valueCopier,  new NoopSizeOfEngine(), NullStoreEventDispatcher.<Long, Value>nullStoreEventDispatcher());
+    store = new OnHeapStore<Long, Value>(config, SystemTimeSource.INSTANCE, new IdentityCopier<Long>(), valueCopier,  new NoopSizeOfEngine(), NullStoreEventDispatcher.<Long, Value>nullStoreEventDispatcher());
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
@@ -579,7 +579,7 @@ public class ByteAccountingTest {
       }
     });
 
-    assertThat(store.getCurrentUsageInBytes(), is(0l));
+    assertThat(store.getCurrentUsageInBytes(), is(0L));
   }
 
   @Test
@@ -780,7 +780,8 @@ public class ByteAccountingTest {
   @Test
   public void testEviction() throws StoreAccessException {
     OnHeapStoreForTests<String, String> store = newStore(1);
-    StoreEventListener listener = mock(StoreEventListener.class);
+    @SuppressWarnings("unchecked")
+    StoreEventListener<String, String> listener = mock(StoreEventListener.class);
     store.getStoreEventSource().addEventListener(listener);
 
     store.put(KEY, VALUE);
@@ -794,7 +795,7 @@ public class ByteAccountingTest {
     long requiredSize = getSize(key1, value1);
 
     store.put(key1, value1);
-    Matcher<StoreEvent<String, byte[]>> matcher = eventType(EventType.EVICTED);
+    Matcher<StoreEvent<String, String>> matcher = eventType(EventType.EVICTED);
     verify(listener, times(1)).onEvent(argThat(matcher));
     if (store.get(key1) != null) {
       assertThat(store.getCurrentUsageInBytes(), is(requiredSize));
@@ -805,7 +806,8 @@ public class ByteAccountingTest {
   }
 
   static long getSize(String key, String value) {
-    CopiedOnHeapValueHolder<String> valueHolder = new CopiedOnHeapValueHolder<String>(value, 0l, 0l, true, DEFAULT_COPIER);
+    @SuppressWarnings("unchecked")
+    CopiedOnHeapValueHolder<String> valueHolder = new CopiedOnHeapValueHolder<String>(value, 0L, 0L, true, DEFAULT_COPIER);
     long size = 0L;
     try {
       size = SIZE_OF_ENGINE.sizeof(key, valueHolder);
@@ -819,6 +821,7 @@ public class ByteAccountingTest {
 
     private static final Copier DEFAULT_COPIER = new IdentityCopier();
 
+    @SuppressWarnings("unchecked")
     OnHeapStoreForTests(final Configuration<K, V> config, final TimeSource timeSource,
                         final SizeOfEngine engine, StoreEventDispatcher<K, V> eventDispatcher) {
       super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER, engine, eventDispatcher);

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteSizedOnHeapStoreByRefTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteSizedOnHeapStoreByRefTest.java
@@ -48,6 +48,7 @@ public class ByteSizedOnHeapStoreByRefTest extends OnHeapStoreByRefTest {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   protected <K, V> OnHeapStore<K, V> newStore(final TimeSource timeSource,
       final Expiry<? super K, ? super V> expiry,
       final EvictionAdvisor<? super K, ? super V> evictionAdvisor, final int capacity) {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteSizedOnHeapStoreByValueTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteSizedOnHeapStoreByValueTest.java
@@ -21,6 +21,7 @@ import org.ehcache.core.CacheConfigurationProperty;
 import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.expiry.Expiry;
 import org.ehcache.impl.internal.sizeof.DefaultSizeOfEngine;
 import org.ehcache.impl.internal.store.heap.OnHeapStore;
@@ -52,6 +53,7 @@ public class ByteSizedOnHeapStoreByValueTest extends OnHeapStoreByValueTest {
       final Expiry<? super K, ? super V> expiry,
       final EvictionAdvisor<? super K, ? super V> evictionAdvisor, final Copier<K> keyCopier,
       final Copier<V> valueCopier, final int capacity) {
+    StoreEventDispatcher<K, V> eventDispatcher = getStoreEventDispatcher();
     return new OnHeapStore<K, V>(new Store.Configuration<K, V>() {
 
       @SuppressWarnings("unchecked")

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreBulkMethodsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreBulkMethodsTest.java
@@ -54,6 +54,7 @@ public class OnHeapStoreBulkMethodsTest extends org.ehcache.impl.internal.store.
     return config;
   }
 
+  @SuppressWarnings("unchecked")
   protected <Number, CharSequence> OnHeapStore<Number, CharSequence> newStore() {
     Store.Configuration<Number, CharSequence> configuration = mockStoreConfig();
     return new OnHeapStore<Number, CharSequence>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER,

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreCachingTierByRefSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreCachingTierByRefSPITest.java
@@ -52,6 +52,7 @@ public class OnHeapStoreCachingTierByRefSPITest extends CachingTierSPITest<Strin
   }
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     cachingTierFactory = new CachingTierFactory<String, String>() {
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStoreTest.java
@@ -52,7 +52,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
@@ -322,7 +321,7 @@ public abstract class AbstractOffHeapStoreTest {
       ((AbstractValueHolder)valueHolder).accessed(timeSource.getTimeMillis(), new Duration(1L, TimeUnit.MILLISECONDS));
       assertThat(store.flush(key, new DelegatingValueHolder<String>(valueHolder)), is(true));
     }
-    assertThat(store.getAndFault(key).hits(), is(5l));
+    assertThat(store.getAndFault(key).hits(), is(5L));
   }
 
   @Test
@@ -702,6 +701,7 @@ public abstract class AbstractOffHeapStoreTest {
 
   private void performEvictionTest(TestTimeSource timeSource, Expiry<Object, Object> expiry, EvictionAdvisor<String, byte[]> evictionAdvisor) throws StoreAccessException {AbstractOffHeapStore<String, byte[]> offHeapStore = createAndInitStore(timeSource, expiry, evictionAdvisor);
     try {
+      @SuppressWarnings("unchecked")
       StoreEventListener<String, byte[]> listener = mock(StoreEventListener.class);
       offHeapStore.getStoreEventSource().addEventListener(listener);
 
@@ -734,6 +734,7 @@ public abstract class AbstractOffHeapStoreTest {
     };
   }
 
+  @SuppressWarnings("unchecked")
   private OperationStatistic<StoreOperationOutcomes.ExpirationOutcome> getExpirationStatistic(Store<?, ?> store) {
     StatisticsManager statisticsManager = new StatisticsManager();
     statisticsManager.root(store);

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/EhcacheConcurrentOffHeapClockCacheTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/EhcacheConcurrentOffHeapClockCacheTest.java
@@ -42,11 +42,13 @@ import static org.mockito.Mockito.mock;
 public class EhcacheConcurrentOffHeapClockCacheTest extends AbstractEhcacheOffHeapBackingMapTest {
 
   @Override
+  @SuppressWarnings("unchecked")
   protected EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment() {
     return createTestSegment(Eviction.noAdvice(), mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class));
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   protected EhcacheConcurrentOffHeapClockCache<String, String> createTestSegment(EvictionAdvisor<? super String, ? super String> evictionPredicate) {
     return createTestSegment(evictionPredicate, mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class));
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreTest.java
@@ -17,7 +17,6 @@
 package org.ehcache.impl.internal.store.offheap;
 
 import org.ehcache.config.EvictionAdvisor;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
 import org.ehcache.config.units.MemoryUnit;
@@ -81,6 +80,7 @@ public class OffHeapStoreTest extends AbstractOffHeapStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testRankAuthority() throws Exception {
     OffHeapStore.Provider provider = new OffHeapStore.Provider();
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/factories/EhcacheSegmentTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/factories/EhcacheSegmentTest.java
@@ -42,10 +42,12 @@ import static org.mockito.Mockito.verify;
 
 public class EhcacheSegmentTest {
 
+  @SuppressWarnings("unchecked")
   private EhcacheSegmentFactory.EhcacheSegment<String, String> createTestSegment() {
     return createTestSegment(Eviction.noAdvice(), mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class));
   }
 
+  @SuppressWarnings("unchecked")
   private EhcacheSegmentFactory.EhcacheSegment<String, String> createTestSegment(EvictionAdvisor<? super String, ? super String> evictionPredicate) {
     return createTestSegment(evictionPredicate, mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class));
   }
@@ -135,6 +137,7 @@ public class EhcacheSegmentTest {
 
   @Test
   public void testEvictionFiresEvent() {
+    @SuppressWarnings("unchecked")
     EhcacheSegmentFactory.EhcacheSegment.EvictionListener<String, String> evictionListener = mock(EhcacheSegmentFactory.EhcacheSegment.EvictionListener.class);
     EhcacheSegmentFactory.EhcacheSegment<String, String> segment = createTestSegment(evictionListener);
     try {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/CompoundCachingTierTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/CompoundCachingTierTest.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.when;
 public class CompoundCachingTierTest {
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetOrComputeIfAbsentComputesWhenBothTiersEmpty() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -83,6 +84,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetOrComputeIfAbsentDoesNotComputesWhenHigherTierContainsValue() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -107,6 +109,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetOrComputeIfAbsentDoesNotComputesWhenLowerTierContainsValue() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -138,6 +141,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetOrComputeIfAbsentComputesWhenLowerTierExpires() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     final LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -186,6 +190,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testInvalidateNoArg() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -198,6 +203,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testInvalidateWhenNoValueDoesNotFireListener() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -218,6 +224,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testInvalidateWhenValueInLowerTierFiresListener() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -275,6 +282,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testInvalidateWhenValueInHigherTierFiresListener() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -333,6 +341,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testInvalidateAllCoversBothTiers() throws Exception {
     HigherCachingTier<String, String> higherTier = mock(HigherCachingTier.class);
     LowerCachingTier<String, String> lowerTier = mock(LowerCachingTier.class);
@@ -346,6 +355,7 @@ public class CompoundCachingTierTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testRankCachingTier() throws Exception {
     CompoundCachingTier.Provider provider = new CompoundCachingTier.Provider();
     HashSet<ResourceType<?>> resourceTypes = new HashSet<ResourceType<?>>();

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreFlushWhileShutdownTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreFlushWhileShutdownTest.java
@@ -61,17 +61,17 @@ public class TieredStoreFlushWhileShutdownTest {
     Store.Configuration<Number, String> configuration = new Store.Configuration<Number, String>() {
 
       @Override
-      public Class getKeyType() {
+      public Class<Number> getKeyType() {
         return Number.class;
       }
 
       @Override
-      public Class getValueType() {
-        return Serializable.class;
+      public Class<String> getValueType() {
+        return String.class;
       }
 
       @Override
-      public EvictionAdvisor getEvictionAdvisor() {
+      public EvictionAdvisor<? super Number, ? super String> getEvictionAdvisor() {
         return null;
       }
 
@@ -81,7 +81,7 @@ public class TieredStoreFlushWhileShutdownTest {
       }
 
       @Override
-      public Expiry getExpiry() {
+      public Expiry<? super Number, ? super String> getExpiry() {
         return Expirations.noExpiration();
       }
 
@@ -117,7 +117,7 @@ public class TieredStoreFlushWhileShutdownTest {
 
     DiskResourceService diskResourceService = serviceLocator.getService(DiskResourceService.class);
     PersistenceSpaceIdentifier persistenceSpace = diskResourceService.getPersistenceSpaceIdentifier("testTieredStoreReleaseFlushesEntries", cacheConfiguration);
-    Store<Number, String> tieredStore = tieredStoreProvider.createStore(configuration, new ServiceConfiguration[] {persistenceSpace});
+    Store<Number, String> tieredStore = tieredStoreProvider.createStore(configuration, persistenceSpace);
     tieredStoreProvider.initStore(tieredStore);
     for (int i = 0; i < 100; i++) {
       tieredStore.put(i, "hello");
@@ -140,11 +140,11 @@ public class TieredStoreFlushWhileShutdownTest {
 
     DiskResourceService diskResourceService1 = serviceLocator1.getService(DiskResourceService.class);
     PersistenceSpaceIdentifier persistenceSpace1 = diskResourceService1.getPersistenceSpaceIdentifier("testTieredStoreReleaseFlushesEntries", cacheConfiguration);
-    tieredStore = tieredStoreProvider.createStore(configuration, new ServiceConfiguration[] {persistenceSpace1});
+    tieredStore = tieredStoreProvider.createStore(configuration, persistenceSpace1);
     tieredStoreProvider.initStore(tieredStore);
 
     for(int i = 0; i < 20; i++) {
-      assertThat(tieredStore.get(i).hits(), is(21l));
+      assertThat(tieredStore.get(i).hits(), is(21L));
     }
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreSPITest.java
@@ -127,7 +127,8 @@ public class TieredStoreSPITest extends StoreSPITest<String, String> {
         Store.Configuration<String, String> config = new StoreConfigurationImpl<String, String>(getKeyType(), getValueType(),
             evictionAdvisor, getClass().getClassLoader(), expiry, buildResourcePools(capacity), 0, keySerializer, valueSerializer);
 
-        final Copier defaultCopier = new IdentityCopier();
+        @SuppressWarnings("unchecked")
+        final Copier<String> defaultCopier = new IdentityCopier();
         OnHeapStore<String, String> onHeapStore = new OnHeapStore<String, String>(config, timeSource, defaultCopier, defaultCopier, new NoopSizeOfEngine(), NullStoreEventDispatcher.<String, String>nullStoreEventDispatcher());
         try {
           CacheConfiguration cacheConfiguration = mock(CacheConfiguration.class);
@@ -330,6 +331,7 @@ public class TieredStoreSPITest extends StoreSPITest<String, String> {
 
   public static class FakeCachingTierProvider implements CachingTier.Provider {
     @Override
+    @SuppressWarnings("unchecked")
     public <K, V> CachingTier<K, V> createCachingTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       return mock(CachingTier.class);
     }
@@ -362,6 +364,7 @@ public class TieredStoreSPITest extends StoreSPITest<String, String> {
 
   public static class FakeAuthoritativeTierProvider implements AuthoritativeTier.Provider {
     @Override
+    @SuppressWarnings("unchecked")
     public <K, V> AuthoritativeTier<K, V> createAuthoritativeTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       return mock(AuthoritativeTier.class);
     }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreTest.java
@@ -91,6 +91,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetHitsCachingTier() throws Exception {
     when(numberCachingTier.getOrComputeIfAbsent(eq(1), any(Function.class))).thenReturn(newValueHolder("one"));
 
@@ -102,6 +103,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetHitsAuthoritativeTier() throws Exception {
     Store.ValueHolder<CharSequence> valueHolder = newValueHolder("one");
     when(numberAuthoritativeTier.getAndFault(eq(1))).thenReturn(valueHolder);
@@ -123,6 +125,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetMisses() throws Exception {
     when(numberAuthoritativeTier.getAndFault(eq(1))).thenReturn(null);
     when(numberCachingTier.getOrComputeIfAbsent(any(Number.class), any(Function.class))).then(new Answer<Store.ValueHolder<CharSequence>>() {
@@ -267,6 +270,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testCompute2Args() throws Exception {
     when(numberAuthoritativeTier.compute(any(Number.class), any(BiFunction.class))).then(new Answer<Store.ValueHolder<CharSequence>>() {
       @Override
@@ -291,6 +295,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testCompute3Args() throws Exception {
     when(numberAuthoritativeTier.compute(any(Number.class), any(BiFunction.class), any(NullaryFunction.class))).then(new Answer<Store.ValueHolder<CharSequence>>() {
       @Override
@@ -320,6 +325,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testComputeIfAbsent_computes() throws Exception {
     when(numberCachingTier.getOrComputeIfAbsent(any(Number.class), any(Function.class))).thenAnswer(new Answer<Store.ValueHolder<CharSequence>>() {
       @Override
@@ -352,6 +358,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testComputeIfAbsent_doesNotCompute() throws Exception {
     final Store.ValueHolder<CharSequence> valueHolder = newValueHolder("one");
     when(numberCachingTier.getOrComputeIfAbsent(any(Number.class), any(Function.class))).thenAnswer(new Answer<Store.ValueHolder<CharSequence>>() {
@@ -375,6 +382,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testBulkCompute2Args() throws Exception {
     when(numberAuthoritativeTier.bulkCompute(any(Set.class), any(Function.class))).thenAnswer(new Answer<Map<Number, Store.ValueHolder<CharSequence>>>() {
       @Override
@@ -419,6 +427,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testBulkCompute3Args() throws Exception {
     when(
         numberAuthoritativeTier.bulkCompute(any(Set.class), any(Function.class), any(NullaryFunction.class))).thenAnswer(new Answer<Map<Number, Store.ValueHolder<CharSequence>>>() {
@@ -469,6 +478,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testBulkComputeIfAbsent() throws Exception {
     when(numberAuthoritativeTier.bulkComputeIfAbsent(any(Set.class), any(Function.class))).thenAnswer(new Answer<Map<Number, Store.ValueHolder<CharSequence>>>() {
       @Override
@@ -548,6 +558,7 @@ public class TieredStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testReleaseStoreFlushes() throws Exception {
     TieredStore.Provider tieredStoreProvider = new TieredStore.Provider();
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreWith3TiersSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreWith3TiersSPITest.java
@@ -127,7 +127,8 @@ public class TieredStoreWith3TiersSPITest extends StoreSPITest<String, String> {
         Serializer<String> valueSerializer = new JavaSerializer<String>(getClass().getClassLoader());
         Store.Configuration<String, String> config = new StoreConfigurationImpl<String, String>(getKeyType(), getValueType(),
             evictionAdvisor, getClass().getClassLoader(), expiry, buildResourcePools(capacity), 0, keySerializer, valueSerializer);
-        final Copier defaultCopier = new IdentityCopier();
+        @SuppressWarnings("unchecked")
+        final Copier<String> defaultCopier = new IdentityCopier();
 
         StoreEventDispatcher<String, String> noOpEventDispatcher = NullStoreEventDispatcher.<String, String>nullStoreEventDispatcher();
         final OnHeapStore<String, String> onHeapStore = new OnHeapStore<String, String>(config, timeSource, defaultCopier, defaultCopier, new NoopSizeOfEngine(), noOpEventDispatcher);
@@ -355,6 +356,7 @@ public class TieredStoreWith3TiersSPITest extends StoreSPITest<String, String> {
 
   public static class FakeCachingTierProvider implements CachingTier.Provider {
     @Override
+    @SuppressWarnings("unchecked")
     public <K, V> CachingTier<K, V> createCachingTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       return mock(CachingTier.class);
     }
@@ -387,6 +389,7 @@ public class TieredStoreWith3TiersSPITest extends StoreSPITest<String, String> {
 
   public static class FakeAuthoritativeTierProvider implements AuthoritativeTier.Provider {
     @Override
+    @SuppressWarnings("unchecked")
     public <K, V> AuthoritativeTier<K, V> createAuthoritativeTier(Store.Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       return mock(AuthoritativeTier.class);
     }

--- a/impl/src/test/java/org/ehcache/impl/persistence/DefaultDiskResourceServiceTest.java
+++ b/impl/src/test/java/org/ehcache/impl/persistence/DefaultDiskResourceServiceTest.java
@@ -45,6 +45,7 @@ public class DefaultDiskResourceServiceTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     protected DefaultDiskResourceService service = new DefaultDiskResourceService();
+    @SuppressWarnings("unchecked")
     protected ServiceProvider<Service> serviceProvider = mock(ServiceProvider.class);
 
     @Before

--- a/impl/src/test/java/org/ehcache/impl/persistence/FileBasedStateRepositoryTest.java
+++ b/impl/src/test/java/org/ehcache/impl/persistence/FileBasedStateRepositoryTest.java
@@ -61,7 +61,9 @@ public class FileBasedStateRepositoryTest {
         assertThat(name, is(holderName));
         FileBasedStateRepository.Tuple loadedTuple = (FileBasedStateRepository.Tuple) ois.readObject();
         assertThat(loadedTuple.index, is(0));
-        assertThat((StateHolder<Long, String>)loadedTuple.holder, is(myHolder));
+        @SuppressWarnings("unchecked")
+        StateHolder<Long, String> stateHolder = (StateHolder<Long, String>) loadedTuple.holder;
+        assertThat(stateHolder, is(myHolder));
       } finally {
         ois.close();
       }

--- a/impl/src/test/java/org/ehcache/impl/serialization/AddedFieldTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/AddedFieldTest.java
@@ -41,6 +41,7 @@ public class AddedFieldTest {
 
   @Test
   public void addingSerializableField() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 
@@ -59,6 +60,7 @@ public class AddedFieldTest {
 
   @Test
   public void addingExternalizableField() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/AddedSuperClassTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/AddedSuperClassTest.java
@@ -35,6 +35,7 @@ public class AddedSuperClassTest {
 
   @Test
   public void testAddedSuperClass() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 
@@ -52,6 +53,7 @@ public class AddedSuperClassTest {
 
   @Test
   public void testAddedSuperClassNotHidden() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/ArrayPackageScopeTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/ArrayPackageScopeTest.java
@@ -37,6 +37,7 @@ public class ArrayPackageScopeTest {
 
   @Test
   public void testArrayPackageScope() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/BasicSerializationTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/BasicSerializationTest.java
@@ -40,6 +40,7 @@ public class BasicSerializationTest {
 
   @Test
   public void testSimpleObject() throws ClassNotFoundException {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> test = new CompactJavaSerializer(null);
     test.init(new TransientStateRepository());
 
@@ -52,6 +53,7 @@ public class BasicSerializationTest {
 
   @Test
   public void testComplexObject() throws ClassNotFoundException {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> test = new CompactJavaSerializer(null);
     test.init(new TransientStateRepository());
 
@@ -74,6 +76,7 @@ public class BasicSerializationTest {
 
   @Test
   public void testPrimitiveClasses() throws ClassNotFoundException {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 
@@ -89,6 +92,7 @@ public class BasicSerializationTest {
     int foo = rand.nextInt();
     float bar = rand.nextFloat();
 
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassLoaderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassLoaderTest.java
@@ -36,6 +36,7 @@ public class CompactJavaSerializerClassLoaderTest {
 
   @Test
   public void testThreadContextLoader() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 
@@ -53,6 +54,7 @@ public class CompactJavaSerializerClassLoaderTest {
   @Test
   public void testExplicitLoader() throws Exception {
     ClassLoader loader = newLoader();
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(loader);
     serializer.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassUnloadingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassUnloadingTest.java
@@ -52,6 +52,7 @@ public class CompactJavaSerializerClassUnloadingTest {
 
   @Test
   public void testClassUnloadingAfterSerialization() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
     serializer.init(new TransientStateRepository());
 
@@ -73,6 +74,7 @@ public class CompactJavaSerializerClassUnloadingTest {
   public void testClassUnloadingAfterSerializationAndDeserialization() throws Exception {
     Thread.currentThread().setContextClassLoader(specialObject.getClass().getClassLoader());
     try {
+      @SuppressWarnings("unchecked")
       StatefulSerializer<Serializable> serializer = new CompactJavaSerializer(null);
       serializer.init(new TransientStateRepository());
       specialObject = serializer.read(serializer.serialize(specialObject));

--- a/impl/src/test/java/org/ehcache/impl/serialization/EnumTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/EnumTest.java
@@ -36,6 +36,7 @@ public class EnumTest {
 
   @Test
   public void basicInstanceSerialization() throws ClassNotFoundException {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 
@@ -46,6 +47,7 @@ public class EnumTest {
 
   @Test
   public void classSerialization() throws ClassNotFoundException {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 
@@ -57,6 +59,7 @@ public class EnumTest {
 
   @Test
   public void shiftingInstanceSerialization() throws ClassNotFoundException {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/FieldTypeChangeTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/FieldTypeChangeTest.java
@@ -35,6 +35,7 @@ public class FieldTypeChangeTest {
 
   @Test
   public void fieldTypeChangeWithOkayObject() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 
@@ -51,6 +52,7 @@ public class FieldTypeChangeTest {
 
   @Test
   public void fieldTypeChangeWithIncompatibleObject() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/GetFieldTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/GetFieldTest.java
@@ -37,6 +37,7 @@ public class GetFieldTest {
 
   @Test
   public void testGetField() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/PutFieldTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/PutFieldTest.java
@@ -39,6 +39,7 @@ public class PutFieldTest {
 
   @Test
   public void testWithAllPrimitivesAndString() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 
@@ -66,6 +67,7 @@ public class PutFieldTest {
 
   @Test
   public void testWithTwoStrings() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 

--- a/impl/src/test/java/org/ehcache/impl/serialization/ReadObjectNoDataTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/ReadObjectNoDataTest.java
@@ -37,6 +37,7 @@ public class ReadObjectNoDataTest {
 
   @Test
   public void test() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
     ClassLoader loaderW = createClassNameRewritingLoader(C_W.class, B_W.class);

--- a/impl/src/test/java/org/ehcache/impl/serialization/SerializeAfterEvolutionTest.java
+++ b/impl/src/test/java/org/ehcache/impl/serialization/SerializeAfterEvolutionTest.java
@@ -33,6 +33,7 @@ public class SerializeAfterEvolutionTest {
 
   @Test
   public void test() throws Exception {
+    @SuppressWarnings("unchecked")
     StatefulSerializer<Serializable> s = new CompactJavaSerializer(null);
     s.init(new TransientStateRepository());
 


### PR DESCRIPTION
This PR takes care of all main and test source compiler warnings for the `api`, `core`, `core-spi-test` and `impl` modules.

I recommend focusing the review on the main source changes as they are the one that could have an impact I missed.

It also makes any new warning in any of these module an error thus preventing any to be introduced by accident.