### PR TITLE
Issue #1482: Use of runnel for client -> server messages

### DIFF
--- a/clustered/client/build.gradle
+++ b/clustered/client/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile project(':clustered:common'), "org.slf4j:slf4j-api:$parent.slf4jVersion"
   provided "org.terracotta:entity-client-api:$parent.entityApiVersion"
   provided "org.terracotta.management:monitoring-service-api:$parent.managementVersion" // provided in management-server jar
+  provided "org.terracotta:runnel:$parent.terracottaPlatformVersion"
 
   testCompile project(':api')
   testCompile project(':xml')

--- a/clustered/client/build.gradle
+++ b/clustered/client/build.gradle
@@ -21,7 +21,7 @@ apply plugin: EhDeploy
 dependencies {
   compileOnly project(':api')
   compileOnly project(':xml')
-  compile project(':clustered:common')
+  compile project(':clustered:common'), "org.slf4j:slf4j-api:$parent.slf4jVersion"
   provided "org.terracotta:entity-client-api:$parent.entityApiVersion"
   provided "org.terracotta.management:monitoring-service-api:$parent.managementVersion" // provided in management-server jar
 

--- a/clustered/clustered-dist/build.gradle
+++ b/clustered/clustered-dist/build.gradle
@@ -31,6 +31,8 @@ ext {
 dependencies {
   compile project(':clustered:client')
   compile project(':clustered:common')
+  // Needed because declared as provided in the different projects
+  compile "org.terracotta:runnel:$parent.terracottaPlatformVersion"
 }
 
 apply plugin: 'distribution'
@@ -51,6 +53,9 @@ dependencies {
     exclude group: 'org.terracotta', module: 'packaging-support'
     exclude group: 'org.terracotta.internal', module: 'tc-config-parser'
   }
+
+  // Needed because declared as provided in the different projects
+  serverLibs "org.terracotta:runnel:$parent.terracottaPlatformVersion"
 
   kit "org.terracotta.internal:terracotta-kit:$terracottaCoreVersion@zip"
 

--- a/clustered/common/build.gradle
+++ b/clustered/common/build.gradle
@@ -18,6 +18,7 @@ apply plugin: EhDeploy
 
 dependencies {
   provided "org.terracotta:entity-common-api:$parent.entityApiVersion"
+  provided "org.terracotta:runnel:$parent.terracottaPlatformVersion"
 }
 
 tasks.withType(JavaCompile) {

--- a/clustered/common/build.gradle
+++ b/clustered/common/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: EhDeploy
 
 dependencies {
+  compile "org.slf4j:slf4j-api:$parent.slf4jVersion"
   provided "org.terracotta:entity-common-api:$parent.entityApiVersion"
   provided "org.terracotta:runnel:$parent.terracottaPlatformVersion"
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ChainCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ChainCodec.java
@@ -19,93 +19,73 @@ package org.ehcache.clustered.common.internal.messages;
 import org.ehcache.clustered.common.internal.store.Chain;
 import org.ehcache.clustered.common.internal.store.Element;
 import org.ehcache.clustered.common.internal.store.SequencedElement;
+import org.ehcache.clustered.common.internal.store.Util;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.StructBuilder;
+import org.terracotta.runnel.decoding.StructArrayDecoder;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructArrayEncoder;
+import org.terracotta.runnel.encoding.StructEncoder;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.ehcache.clustered.common.internal.store.Util.getElement;
-import static org.ehcache.clustered.common.internal.store.Util.getChain;
-
 public class ChainCodec {
 
-  private static final byte NON_SEQUENCED_CHAIN = 0;
-  private static final byte SEQUENCED_CHAIN = 1;
-  private static final byte SEQ_NUM_OFFSET = 8;
-  private static final byte ELEMENT_PAYLOAD_OFFSET = 4;
+  private static final Struct ELEMENT_STRUCT = StructBuilder.newStructBuilder()
+    .int64("sequence", 10)
+    .byteBuffer("payload", 20)
+    .build();
 
-  //TODO: optimize too many bytebuffer allocation
+  static final Struct CHAIN_STRUCT = StructBuilder.newStructBuilder()
+    .structs("elements", 10, ELEMENT_STRUCT)
+    .build();
+
   public byte[] encode(Chain chain) {
-    ByteBuffer msg = null;
-    boolean firstIteration = true ;
+    StructEncoder encoder = CHAIN_STRUCT.encoder();
+
+    encode(encoder, chain);
+
+    ByteBuffer byteBuffer = encoder.encode();
+    return byteBuffer.array();
+  }
+
+  public void encode(StructEncoder encoder, Chain chain) {
+    StructArrayEncoder elementsEncoder = encoder.structs("elements");
     for (Element element : chain) {
-      if (firstIteration) {
-        firstIteration = false;
-        ByteBuffer buffer = ByteBuffer.allocate(1);
-        if (element instanceof SequencedElement) {
-          buffer.put(SEQUENCED_CHAIN);
-        } else {
-          buffer.put(NON_SEQUENCED_CHAIN);
-        }
-        buffer.flip();
-        msg = combine(buffer, encodeElement(element));
-        continue;
+      if (element instanceof SequencedElement) {
+        elementsEncoder.int64("sequence", ((SequencedElement) element).getSequenceNumber());
       }
-      if (msg == null) {
-        throw new IllegalArgumentException("Message cannot be null");
-      }
-      msg = combine(msg, encodeElement(element));
+      elementsEncoder.byteBuffer("payload", element.getPayload());
+      elementsEncoder.next();
     }
-    return msg != null ? msg.array() : new byte[0];
   }
 
   public Chain decode(byte[] payload) {
+    StructDecoder decoder = CHAIN_STRUCT.decoder(ByteBuffer.wrap(payload));
+    return decode(decoder);
+  }
+
+  public Chain decode(StructDecoder decoder) {
+    StructArrayDecoder elementsDecoder = decoder.structs("elements");
+
     final List<Element> elements = new ArrayList<Element>();
-    if (payload.length != 0) {
-      ByteBuffer buffer = ByteBuffer.wrap(payload);
-      boolean isSequenced = buffer.get() == 1;
-      if (isSequenced) {
-        while (buffer.hasRemaining()) {
-          long sequence = buffer.getLong();
-          elements.add(getElement(sequence, getElementPayLoad(buffer)));
-        }
+    for (int i = 0; i < elementsDecoder.length(); i++) {
+      Long sequence = elementsDecoder.int64("sequence");
+      ByteBuffer byteBuffer = elementsDecoder.byteBuffer("payload");
+      Element element;
+      if (sequence != null) {
+        element = Util.getElement(sequence, byteBuffer);
       } else {
-        while (buffer.hasRemaining()) {
-          elements.add(getElement(getElementPayLoad(buffer)));
-        }
+        element = Util.getElement(byteBuffer);
       }
+      elements.add(element);
+      elementsDecoder.next();
     }
-    return getChain(elements);
-  }
 
-  private static ByteBuffer combine(ByteBuffer buffer1, ByteBuffer buffer2) {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(buffer1.remaining() + buffer2.remaining());
-    byteBuffer.put(buffer1);
-    byteBuffer.put(buffer2);
-    byteBuffer.flip();
-    return byteBuffer;
-  }
+    elementsDecoder.end();
 
-  private static ByteBuffer encodeElement(Element element) {
-    ByteBuffer buffer = null;
-    if (element instanceof SequencedElement) {
-      buffer = ByteBuffer.allocate(SEQ_NUM_OFFSET + ELEMENT_PAYLOAD_OFFSET + element.getPayload().remaining());
-      buffer.putLong(((SequencedElement)element).getSequenceNumber());
-    } else {
-      buffer = ByteBuffer.allocate(ELEMENT_PAYLOAD_OFFSET + element.getPayload().remaining());
-    }
-    buffer.putInt(element.getPayload().remaining());
-    buffer.put(element.getPayload());
-    buffer.flip();
-    return buffer;
-  }
-
-  private static ByteBuffer getElementPayLoad(ByteBuffer buffer) {
-    int payloadSize = buffer.getInt();
-    buffer.limit(buffer.position() + payloadSize);
-    ByteBuffer elementPayload = buffer.slice();
-    buffer.position(buffer.limit());
-    buffer.limit(buffer.capacity());
-    return elementPayload;
+    return Util.getChain(elements);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheCodec.java
@@ -16,16 +16,30 @@
 
 package org.ehcache.clustered.common.internal.messages;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.MessageCodecException;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.decoding.Enm;
 
-import static org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage.Type.LIFECYCLE_OP;
-import static org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage.Type.REPLICATION_OP;
-import static org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage.Type.SERVER_STORE_OP;
-import static org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage.Type.STATE_REPO_OP;
-import static org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage.Type.SYNC_OP;
+import java.nio.ByteBuffer;
+
+import static java.nio.ByteBuffer.wrap;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.EHCACHE_MESSAGE_TYPES_ENUM_MAPPING;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_INDEX;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_NAME;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isLifecycleMessage;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isPassiveSynchroMessage;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isStateRepoOperationMessage;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isStoreOperationMessage;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
 
 public class EhcacheCodec implements MessageCodec<EhcacheEntityMessage, EhcacheEntityResponse> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheCodec.class);
+
+  static final Struct OP_CODE_DECODER = newStructBuilder().enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING).build();
 
   private static final MessageCodec<EhcacheEntityMessage, EhcacheEntityResponse> SERVER_INSTANCE =
       new EhcacheCodec(new ServerStoreOpCodec(), new LifeCycleMessageCodec(), new StateRepositoryOpCodec(), new ResponseCodec(), new PassiveReplicationMessageCodec());
@@ -51,33 +65,48 @@ public class EhcacheCodec implements MessageCodec<EhcacheEntityMessage, EhcacheE
 
   @Override
   public byte[] encodeMessage(EhcacheEntityMessage message) {
-    switch (message.getType()) {
-      case LIFECYCLE_OP:
-        return lifeCycleMessageCodec.encode((LifecycleMessage)message);
-      case SERVER_STORE_OP:
-        return serverStoreOpCodec.encode((ServerStoreOpMessage) message);
-      case STATE_REPO_OP:
-        return stateRepositoryOpCodec.encode((StateRepositoryOpMessage) message);
-      case REPLICATION_OP:
-        return passiveReplicationMessageCodec.encode((PassiveReplicationMessage)message);
-      default:
-        throw new IllegalArgumentException("Undefined message type: " + message.getType());
+    if (!(message instanceof EhcacheOperationMessage)) {
+      throw new AssertionError("Unexpected message type " + message.getClass());
     }
+    EhcacheOperationMessage operationMessage = (EhcacheOperationMessage) message;
+    if (isLifecycleMessage(operationMessage.getMessageType())) {
+      return lifeCycleMessageCodec.encode((LifecycleMessage) operationMessage);
+    } else if (isStoreOperationMessage(operationMessage.getMessageType())) {
+      return serverStoreOpCodec.encode((ServerStoreOpMessage) operationMessage);
+    } else if (isStateRepoOperationMessage(operationMessage.getMessageType())) {
+      return stateRepositoryOpCodec.encode((StateRepositoryOpMessage) operationMessage);
+    } else if (isPassiveSynchroMessage(operationMessage.getMessageType())) {
+      return passiveReplicationMessageCodec.encode((PassiveReplicationMessage) operationMessage);
+    }
+    throw new AssertionError("Unknown message type: " + operationMessage.getMessageType());
   }
 
   @Override
   public EhcacheEntityMessage decodeMessage(byte[] payload) throws MessageCodecException {
-    byte opCode = payload[0];
-    if (opCode <= LIFECYCLE_OP.getCode()) {
-        return lifeCycleMessageCodec.decode(payload);
-    } else if (opCode <= SERVER_STORE_OP.getCode()) {
-        return serverStoreOpCodec.decode(payload);
-    } else if (opCode <= STATE_REPO_OP.getCode()) {
-        return stateRepositoryOpCodec.decode(payload);
-    } else if (opCode > SYNC_OP.getCode() && opCode <= REPLICATION_OP.getCode()) {
-        return passiveReplicationMessageCodec.decode(payload);
+    ByteBuffer byteBuffer = wrap(payload);
+    Enm<EhcacheMessageType> opCodeEnm = OP_CODE_DECODER.decoder(byteBuffer).enm("opCode");
+
+    if (!opCodeEnm.isFound()) {
+      throw new AssertionError("Got a message without an opCode");
+    }
+    if (!opCodeEnm.isValid()) {
+      LOGGER.warn("Received message with unknown operation code - more recent version at the other end?");
+      return null;
+    }
+
+    byteBuffer.rewind();
+
+    EhcacheMessageType opCode = opCodeEnm.get();
+    if (isLifecycleMessage(opCode)) {
+        return lifeCycleMessageCodec.decode(opCode, byteBuffer);
+    } else if (isStoreOperationMessage(opCode)) {
+        return serverStoreOpCodec.decode(opCode, byteBuffer);
+    } else if (isStateRepoOperationMessage(opCode)) {
+        return stateRepositoryOpCodec.decode(opCode, byteBuffer);
+    } else if (isPassiveSynchroMessage(opCode)) {
+        return passiveReplicationMessageCodec.decode(opCode, byteBuffer);
     } else {
-      throw new UnsupportedOperationException("Undefined message code: " + opCode);
+      throw new UnsupportedOperationException("Undefined message code: " + opCodeEnm);
     }
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheEntityMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheEntityMessage.java
@@ -60,8 +60,10 @@ public abstract class EhcacheEntityMessage implements EntityMessage {
     }
   }
 
+  @Deprecated
   public abstract Type getType();
 
+  @Deprecated
   public abstract byte getOpCode();
 
   @Override

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheMessageType.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheMessageType.java
@@ -25,6 +25,8 @@ import static org.terracotta.runnel.EnumMappingBuilder.newEnumMappingBuilder;
 
 /**
  * EhcacheMessageType
+ *
+ * Whenever you edit this, you must think about enum mapping and helper methods
  */
 public enum EhcacheMessageType {
   // Lifecycle messages
@@ -48,9 +50,14 @@ public enum EhcacheMessageType {
   PUT_IF_ABSENT,
   ENTRY_SET,
 
+  // TODO server to server only, should not exist in common
   // Passive synchronization messages
   CHAIN_REPLICATION_OP,
-  CLIENT_ID_TRACK_OP;
+  CLIENT_ID_TRACK_OP,
+  CLEAR_INVALIDATION_COMPLETE,
+  INVALIDATION_COMPLETE,
+  CREATE_SERVER_STORE_REPLICATION,
+  DESTROY_SERVER_STORE_REPLICATION;
 
   public static final String MESSAGE_TYPE_FIELD_NAME = "opCode";
   public static final int MESSAGE_TYPE_FIELD_INDEX = 10;
@@ -75,6 +82,10 @@ public enum EhcacheMessageType {
 
     .mapping(CHAIN_REPLICATION_OP, 61)
     .mapping(CLIENT_ID_TRACK_OP, 62)
+    .mapping(CLEAR_INVALIDATION_COMPLETE, 63)
+    .mapping(INVALIDATION_COMPLETE, 64)
+    .mapping(CREATE_SERVER_STORE_REPLICATION, 65)
+    .mapping(DESTROY_SERVER_STORE_REPLICATION, 66)
     .build();
 
   public static final EnumSet<EhcacheMessageType> LIFECYCLE_MESSAGES = of(CONFIGURE, VALIDATE, CREATE_SERVER_STORE, VALIDATE_SERVER_STORE, RELEASE_SERVER_STORE, DESTROY_SERVER_STORE);
@@ -92,7 +103,7 @@ public enum EhcacheMessageType {
     return STATE_REPO_OPERATION_MESSAGES.contains(value);
   }
 
-  public static final EnumSet<EhcacheMessageType> PASSIVE_SYNC_MESSAGES = of(CHAIN_REPLICATION_OP, CLIENT_ID_TRACK_OP);
+  public static final EnumSet<EhcacheMessageType> PASSIVE_SYNC_MESSAGES = of(CHAIN_REPLICATION_OP, CLIENT_ID_TRACK_OP, CLEAR_INVALIDATION_COMPLETE, INVALIDATION_COMPLETE, CREATE_SERVER_STORE_REPLICATION, DESTROY_SERVER_STORE_REPLICATION);
   public static boolean isPassiveSynchroMessage(EhcacheMessageType value) {
     return PASSIVE_SYNC_MESSAGES.contains(value);
   }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheMessageType.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheMessageType.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+import org.terracotta.runnel.EnumMapping;
+
+import java.util.EnumSet;
+
+import static java.util.EnumSet.of;
+import static org.terracotta.runnel.EnumMappingBuilder.newEnumMappingBuilder;
+
+/**
+ * EhcacheMessageType
+ */
+public enum EhcacheMessageType {
+  // Lifecycle messages
+  CONFIGURE,
+  VALIDATE,
+  CREATE_SERVER_STORE,
+  VALIDATE_SERVER_STORE,
+  RELEASE_SERVER_STORE,
+  DESTROY_SERVER_STORE,
+
+  // ServerStore operation messages
+  GET_AND_APPEND,
+  APPEND,
+  REPLACE,
+  CLIENT_INVALIDATION_ACK,
+  CLEAR,
+  GET_STORE,
+
+  // StateRepository operation messages
+  GET_STATE_REPO,
+  PUT_IF_ABSENT,
+  ENTRY_SET,
+
+  // Passive synchronization messages
+  CHAIN_REPLICATION_OP,
+  CLIENT_ID_TRACK_OP;
+
+  public static final String MESSAGE_TYPE_FIELD_NAME = "opCode";
+  public static final int MESSAGE_TYPE_FIELD_INDEX = 10;
+  public static final EnumMapping<EhcacheMessageType> EHCACHE_MESSAGE_TYPES_ENUM_MAPPING = newEnumMappingBuilder(EhcacheMessageType.class)
+    .mapping(CONFIGURE, 1)
+    .mapping(VALIDATE, 2)
+    .mapping(CREATE_SERVER_STORE, 3)
+    .mapping(VALIDATE_SERVER_STORE, 4)
+    .mapping(RELEASE_SERVER_STORE, 5)
+    .mapping(DESTROY_SERVER_STORE, 6)
+
+    .mapping(GET_AND_APPEND, 21)
+    .mapping(APPEND, 22)
+    .mapping(REPLACE, 23)
+    .mapping(CLIENT_INVALIDATION_ACK, 24)
+    .mapping(CLEAR, 25)
+    .mapping(GET_STORE, 26)
+
+    .mapping(GET_STATE_REPO, 41)
+    .mapping(PUT_IF_ABSENT, 42)
+    .mapping(ENTRY_SET, 43)
+
+    .mapping(CHAIN_REPLICATION_OP, 61)
+    .mapping(CLIENT_ID_TRACK_OP, 62)
+    .build();
+
+  public static final EnumSet<EhcacheMessageType> LIFECYCLE_MESSAGES = of(CONFIGURE, VALIDATE, CREATE_SERVER_STORE, VALIDATE_SERVER_STORE, RELEASE_SERVER_STORE, DESTROY_SERVER_STORE);
+  public static boolean isLifecycleMessage(EhcacheMessageType value) {
+    return LIFECYCLE_MESSAGES.contains(value);
+  }
+
+  public static final EnumSet<EhcacheMessageType> STORE_OPERATION_MESSAGES = of(GET_AND_APPEND, APPEND, REPLACE, CLIENT_INVALIDATION_ACK, CLEAR, GET_STORE);
+  public static boolean isStoreOperationMessage(EhcacheMessageType value) {
+    return STORE_OPERATION_MESSAGES.contains(value);
+  }
+
+  public static final EnumSet<EhcacheMessageType> STATE_REPO_OPERATION_MESSAGES = of(GET_STATE_REPO, PUT_IF_ABSENT, ENTRY_SET);
+  public static boolean isStateRepoOperationMessage(EhcacheMessageType value) {
+    return STATE_REPO_OPERATION_MESSAGES.contains(value);
+  }
+
+  public static final EnumSet<EhcacheMessageType> PASSIVE_SYNC_MESSAGES = of(CHAIN_REPLICATION_OP, CLIENT_ID_TRACK_OP);
+  public static boolean isPassiveSynchroMessage(EhcacheMessageType value) {
+    return PASSIVE_SYNC_MESSAGES.contains(value);
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheOperationMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheOperationMessage.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+/**
+ * EhcacheOperationMessage
+ */
+public abstract class EhcacheOperationMessage extends EhcacheEntityMessage {
+
+  public abstract EhcacheMessageType getMessageType();
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheOperationMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheOperationMessage.java
@@ -22,4 +22,9 @@ package org.ehcache.clustered.common.internal.messages;
 public abstract class EhcacheOperationMessage extends EhcacheEntityMessage {
 
   public abstract EhcacheMessageType getMessageType();
+
+  @Override
+  public String toString() {
+    return getMessageType().toString();
+  }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodec.java
@@ -16,37 +16,319 @@
 
 package org.ehcache.clustered.common.internal.messages;
 
-import org.ehcache.clustered.common.internal.store.Util;
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.decoding.StructArrayDecoder;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructArrayEncoder;
+import org.terracotta.runnel.encoding.StructEncoder;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.EHCACHE_MESSAGE_TYPES_ENUM_MAPPING;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_INDEX;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_NAME;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.CONSISTENCY_ENUM_MAPPING;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.LSB_UUID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSB_UUID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSG_ID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.POOL_RESOURCE_NAME_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.POOL_SIZE_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.SERVER_STORE_NAME_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.STORE_CONFIG_CONSISTENCY_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.STORE_CONFIG_KEY_TYPE_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.STORE_CONFIG_VALUE_TYPE_FIELD;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
 
 class LifeCycleMessageCodec {
 
-  private static final byte OPCODE_SIZE = 1;
+  private static final String CONFIG_PRESENT_FIELD = "configPresent";
+  private static final String DEFAULT_RESOURCE_FIELD = "defaultResource";
+  private static final String POOLS_SUB_STRUCT = "pools";
+  private static final String POOL_NAME_FIELD = "poolName";
+
+  private static final Struct POOLS_STRUCT = newStructBuilder()
+    .string(POOL_NAME_FIELD, 10)
+    .int64(POOL_SIZE_FIELD, 20)
+    .string(POOL_RESOURCE_NAME_FIELD, 30).build();
+
+  private static final Struct CONFIGURE_MESSAGE_STRUCT = newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .bool(CONFIG_PRESENT_FIELD, 30)
+    .string(DEFAULT_RESOURCE_FIELD, 40)
+    .structs(POOLS_SUB_STRUCT, 50, POOLS_STRUCT)
+    .build();
+
+  private static final Struct VALIDATE_MESSAGE_STRUCT = CONFIGURE_MESSAGE_STRUCT;
+
+  private static final Struct CREATE_STORE_MESSAGE_STRUCT = newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .string(STORE_CONFIG_KEY_TYPE_FIELD, 40)
+    .string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD, 41)
+    .string(STORE_CONFIG_VALUE_TYPE_FIELD, 45)
+    .string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD, 46)
+    .enm(STORE_CONFIG_CONSISTENCY_FIELD, 50, CONSISTENCY_ENUM_MAPPING)
+    .int64(POOL_SIZE_FIELD, 60)
+    .string(POOL_RESOURCE_NAME_FIELD, 65)
+    .build();
+
+  private static final Struct VALIDATE_STORE_MESSAGE_STRUCT = CREATE_STORE_MESSAGE_STRUCT;
+
+  private static final Struct DESTROY_STORE_MESSAGE_STRUCT = newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .build();
+
+  private static final Struct RELEASE_STORE_MESSAGE_STRUCTU = DESTROY_STORE_MESSAGE_STRUCT;
+
+  private final MessageCodecUtils messageCodecUtils = new MessageCodecUtils();
 
   public byte[] encode(LifecycleMessage message) {
     //For configure message id serves as message creation timestamp
     if (message instanceof LifecycleMessage.ConfigureStoreManager) {
       message.setId(System.nanoTime());
     }
-    byte[] encodedMsg = Util.marshall(message);
-    ByteBuffer buffer = ByteBuffer.allocate(OPCODE_SIZE + encodedMsg.length);
-    buffer.put(message.getOpCode());
-    buffer.put(encodedMsg);
-    return buffer.array();
+
+    switch (message.getMessageType()) {
+      case CONFIGURE:
+        return encodeTierManagerConfigureMessage((LifecycleMessage.ConfigureStoreManager) message);
+      case VALIDATE:
+        return encodeTierManagerValidateMessage((LifecycleMessage.ValidateStoreManager) message);
+      case CREATE_SERVER_STORE:
+        return encodeCreateStoreMessage((LifecycleMessage.CreateServerStore) message);
+      case VALIDATE_SERVER_STORE:
+        return encodeValidateStoreMessage((LifecycleMessage.ValidateServerStore) message);
+      case DESTROY_SERVER_STORE:
+        return encodeDestroyStoreMessage((LifecycleMessage.DestroyServerStore) message);
+      case RELEASE_SERVER_STORE:
+        return encodeReleaseStoreMessage((LifecycleMessage.ReleaseServerStore) message);
+      default:
+        throw new IllegalArgumentException("Unknown lifecycle message: " + message.getClass());
+    }
   }
 
-  public EhcacheEntityMessage decode(byte[] payload) {
-    ByteBuffer message = ByteBuffer.wrap(payload);
-    byte[] encodedMsg = new byte[message.capacity() - OPCODE_SIZE];
-    byte opCode = message.get();
-    if (opCode == EhcacheEntityMessage.Type.LIFECYCLE_OP.getCode()) {
-      message.get(encodedMsg, 0, encodedMsg.length);
-      EhcacheEntityMessage entityMessage = (EhcacheEntityMessage) Util.unmarshall(encodedMsg);
-      return entityMessage;
+  private byte[] encodeReleaseStoreMessage(LifecycleMessage.ReleaseServerStore message) {
+    StructEncoder encoder = RELEASE_STORE_MESSAGE_STRUCTU.encoder();
+
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+    encoder.string(SERVER_STORE_NAME_FIELD, message.getName());
+    return encoder.encode().array();
+  }
+
+  private byte[] encodeDestroyStoreMessage(LifecycleMessage.DestroyServerStore message) {
+    StructEncoder encoder = DESTROY_STORE_MESSAGE_STRUCT.encoder();
+
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+    encoder.string(SERVER_STORE_NAME_FIELD, message.getName());
+    return encoder.encode().array();
+  }
+
+  private byte[] encodeCreateStoreMessage(LifecycleMessage.CreateServerStore message) {
+    StructEncoder encoder = CREATE_STORE_MESSAGE_STRUCT.encoder();
+    return encodeBaseServerStoreMessage(message, encoder);
+  }
+
+  private byte[] encodeValidateStoreMessage(LifecycleMessage.ValidateServerStore message) {
+    return encodeBaseServerStoreMessage(message, VALIDATE_STORE_MESSAGE_STRUCT.encoder());
+  }
+
+  private byte[] encodeBaseServerStoreMessage(LifecycleMessage.BaseServerStore message, StructEncoder encoder) {
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+
+    encoder.string(SERVER_STORE_NAME_FIELD, message.getName());
+    messageCodecUtils.encodeServerStoreConfiguration(encoder, message.getStoreConfiguration());
+    return encoder.encode().array();
+  }
+
+  private byte[] encodeTierManagerConfigureMessage(LifecycleMessage.ConfigureStoreManager message) {
+    return encodeTierManagerCreateOrValidate(message, message.getConfiguration(), CONFIGURE_MESSAGE_STRUCT.encoder());
+  }
+
+  private byte[] encodeTierManagerValidateMessage(LifecycleMessage.ValidateStoreManager message) {
+    return encodeTierManagerCreateOrValidate(message, message.getConfiguration(), VALIDATE_MESSAGE_STRUCT.encoder());
+  }
+
+  private byte[] encodeTierManagerCreateOrValidate(LifecycleMessage message, ServerSideConfiguration config, StructEncoder encoder) {
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+    encodeServerSideConfiguration(encoder, config);
+    return encoder.encode().array();
+  }
+
+  private void encodeServerSideConfiguration(StructEncoder encoder, ServerSideConfiguration configuration) {
+    if (configuration == null) {
+      encoder.bool(CONFIG_PRESENT_FIELD, false);
     } else {
-      throw new IllegalArgumentException("LifeCycleMessage operation not defined for : " + opCode);
+      encoder.bool(CONFIG_PRESENT_FIELD, true);
+      if (configuration.getDefaultServerResource() != null) {
+        encoder.string(DEFAULT_RESOURCE_FIELD, configuration.getDefaultServerResource());
+      }
+
+      if (!configuration.getResourcePools().isEmpty()) {
+        StructArrayEncoder poolsEncoder = encoder.structs(POOLS_SUB_STRUCT);
+        for (Map.Entry<String, ServerSideConfiguration.Pool> poolEntry : configuration.getResourcePools().entrySet()) {
+          poolsEncoder.string(POOL_NAME_FIELD, poolEntry.getKey())
+            .int64(POOL_SIZE_FIELD, poolEntry.getValue().getSize());
+          if (poolEntry.getValue().getServerResource() != null) {
+            poolsEncoder.string(POOL_RESOURCE_NAME_FIELD, poolEntry.getValue().getServerResource());
+          }
+          poolsEncoder.next();
+        }
+        poolsEncoder.end();
+      }
     }
+  }
+
+  private ServerSideConfiguration decodeServerSideConfiguration(StructDecoder decoder) {
+    boolean configPresent = decoder.bool(CONFIG_PRESENT_FIELD);
+
+    if (configPresent) {
+      String defaultResource = decoder.string(DEFAULT_RESOURCE_FIELD);
+
+      HashMap<String, ServerSideConfiguration.Pool> resourcePools = new HashMap<String, ServerSideConfiguration.Pool>();
+      StructArrayDecoder poolStructs = decoder.structs(POOLS_SUB_STRUCT);
+      if (poolStructs != null) {
+        for (int i = 0; i < poolStructs.length(); i++) {
+          String poolName = poolStructs.string(POOL_NAME_FIELD);
+          Long poolSize = poolStructs.int64(POOL_SIZE_FIELD);
+          String poolResourceName = poolStructs.string(POOL_RESOURCE_NAME_FIELD);
+          if (poolResourceName == null) {
+            resourcePools.put(poolName, new ServerSideConfiguration.Pool(poolSize));
+          } else {
+            resourcePools.put(poolName, new ServerSideConfiguration.Pool(poolSize, poolResourceName));
+          }
+          poolStructs.next();
+        }
+      }
+
+      ServerSideConfiguration serverSideConfiguration;
+      if (defaultResource == null) {
+        serverSideConfiguration = new ServerSideConfiguration(resourcePools);
+      } else {
+        serverSideConfiguration = new ServerSideConfiguration(defaultResource, resourcePools);
+      }
+      return serverSideConfiguration;
+    } else {
+      return null;
+    }
+  }
+
+  public EhcacheEntityMessage decode(EhcacheMessageType messageType, ByteBuffer messageBuffer) {
+
+    switch (messageType) {
+      case CONFIGURE:
+        return decodeConfigureMessage(messageBuffer);
+      case VALIDATE:
+        return decodeValidateMessage(messageBuffer);
+      case CREATE_SERVER_STORE:
+        return decodeCreateServerStoreMessage(messageBuffer);
+      case VALIDATE_SERVER_STORE:
+        return decodeValidateServerStoreMessage(messageBuffer);
+      case DESTROY_SERVER_STORE:
+        return decodeDestroyServerStoreMessage(messageBuffer);
+      case RELEASE_SERVER_STORE:
+        return decodeReleaseServerStoreMessage(messageBuffer);
+    }
+    throw new IllegalArgumentException("LifeCycleMessage operation not defined for : " + messageType);
+  }
+
+  private LifecycleMessage.ReleaseServerStore decodeReleaseServerStoreMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = RELEASE_STORE_MESSAGE_STRUCTU.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID cliendId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+
+    LifecycleMessage.ReleaseServerStore message = new LifecycleMessage.ReleaseServerStore(storeName, cliendId);
+    message.setId(msgId);
+    return message;
+  }
+
+  private LifecycleMessage.DestroyServerStore decodeDestroyServerStoreMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = DESTROY_STORE_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID cliendId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+
+    LifecycleMessage.DestroyServerStore message = new LifecycleMessage.DestroyServerStore(storeName, cliendId);
+    message.setId(msgId);
+    return message;
+  }
+
+  private LifecycleMessage.ValidateServerStore decodeValidateServerStoreMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = VALIDATE_STORE_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID cliendId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+    ServerStoreConfiguration config = messageCodecUtils.decodeServerStoreConfiguration(decoder);
+
+    LifecycleMessage.ValidateServerStore message = new LifecycleMessage.ValidateServerStore(storeName, config, cliendId);
+    message.setId(msgId);
+    return message;
+  }
+
+  private LifecycleMessage.CreateServerStore decodeCreateServerStoreMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = CREATE_STORE_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID cliendId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+    ServerStoreConfiguration config = messageCodecUtils.decodeServerStoreConfiguration(decoder);
+
+    LifecycleMessage.CreateServerStore message = new LifecycleMessage.CreateServerStore(storeName, config, cliendId);
+    message.setId(msgId);
+    return message;
+  }
+
+  private LifecycleMessage.ValidateStoreManager decodeValidateMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = VALIDATE_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID cliendId = messageCodecUtils.decodeUUID(decoder);
+
+    ServerSideConfiguration config = decodeServerSideConfiguration(decoder);
+
+    LifecycleMessage.ValidateStoreManager message = new LifecycleMessage.ValidateStoreManager(config, cliendId);
+    if (msgId != null) {
+      message.setId(msgId);
+    }
+    return message;
+  }
+
+  private LifecycleMessage.ConfigureStoreManager decodeConfigureMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = CONFIGURE_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID clientId = messageCodecUtils.decodeUUID(decoder);
+
+    ServerSideConfiguration config = decodeServerSideConfiguration(decoder);
+
+    LifecycleMessage.ConfigureStoreManager message = new LifecycleMessage.ConfigureStoreManager(config, clientId);
+    if (msgId != null) {
+      message.setId(msgId);
+    }
+    return message;
   }
 
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageFactory.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageFactory.java
@@ -25,27 +25,27 @@ public class LifeCycleMessageFactory {
 
   private UUID clientId;
 
-  public EhcacheEntityMessage validateStoreManager(ServerSideConfiguration configuration){
+  public LifecycleMessage validateStoreManager(ServerSideConfiguration configuration){
     return new LifecycleMessage.ValidateStoreManager(configuration, clientId);
   }
 
-  public EhcacheEntityMessage configureStoreManager(ServerSideConfiguration configuration) {
+  public LifecycleMessage configureStoreManager(ServerSideConfiguration configuration) {
     return new LifecycleMessage.ConfigureStoreManager(configuration, clientId);
   }
 
-  public EhcacheEntityMessage createServerStore(String name, ServerStoreConfiguration serverStoreConfiguration) {
+  public LifecycleMessage createServerStore(String name, ServerStoreConfiguration serverStoreConfiguration) {
     return new LifecycleMessage.CreateServerStore(name, serverStoreConfiguration, clientId);
   }
 
-  public EhcacheEntityMessage validateServerStore(String name, ServerStoreConfiguration serverStoreConfiguration) {
+  public LifecycleMessage validateServerStore(String name, ServerStoreConfiguration serverStoreConfiguration) {
     return new LifecycleMessage.ValidateServerStore(name, serverStoreConfiguration, clientId);
   }
 
-  public EhcacheEntityMessage releaseServerStore(String name) {
+  public LifecycleMessage releaseServerStore(String name) {
     return new LifecycleMessage.ReleaseServerStore(name, clientId);
   }
 
-  public EhcacheEntityMessage destroyServerStore(String name) {
+  public LifecycleMessage destroyServerStore(String name) {
     return new LifecycleMessage.DestroyServerStore(name, clientId);
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifecycleMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifecycleMessage.java
@@ -66,11 +66,6 @@ public abstract class LifecycleMessage extends EhcacheOperationMessage implement
 
   public abstract LifeCycleOp operation();
 
-  @Override
-  public String toString() {
-    return getType() + "#" + operation();
-  }
-
   public static class ValidateStoreManager extends LifecycleMessage {
     private static final long serialVersionUID = 5742152283115139745L;
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifecycleMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifecycleMessage.java
@@ -22,7 +22,7 @@ import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import java.io.Serializable;
 import java.util.UUID;
 
-public abstract class LifecycleMessage extends EhcacheEntityMessage implements Serializable {
+public abstract class LifecycleMessage extends EhcacheOperationMessage implements Serializable {
 
   public enum LifeCycleOp {
     CONFIGURE,
@@ -86,6 +86,11 @@ public abstract class LifecycleMessage extends EhcacheEntityMessage implements S
       return LifeCycleOp.VALIDATE;
     }
 
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.VALIDATE;
+    }
+
     public ServerSideConfiguration getConfiguration() {
       return configuration;
     }
@@ -104,6 +109,11 @@ public abstract class LifecycleMessage extends EhcacheEntityMessage implements S
     @Override
     public LifeCycleOp operation() {
       return LifeCycleOp.CONFIGURE;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CONFIGURE;
     }
 
     public ServerSideConfiguration getConfiguration() {
@@ -147,6 +157,11 @@ public abstract class LifecycleMessage extends EhcacheEntityMessage implements S
     public LifeCycleOp operation() {
       return LifeCycleOp.CREATE_SERVER_STORE;
     }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CREATE_SERVER_STORE;
+    }
   }
 
   /**
@@ -162,6 +177,11 @@ public abstract class LifecycleMessage extends EhcacheEntityMessage implements S
     @Override
     public LifeCycleOp operation() {
       return LifeCycleOp.VALIDATE_SERVER_STORE;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.VALIDATE_SERVER_STORE;
     }
   }
 
@@ -181,6 +201,11 @@ public abstract class LifecycleMessage extends EhcacheEntityMessage implements S
     @Override
     public LifeCycleOp operation() {
       return LifeCycleOp.RELEASE_SERVER_STORE;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.RELEASE_SERVER_STORE;
     }
 
     public String getName() {
@@ -204,6 +229,11 @@ public abstract class LifecycleMessage extends EhcacheEntityMessage implements S
     @Override
     public LifeCycleOp operation() {
       return LifeCycleOp.DESTROY_SERVER_STORE;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.DESTROY_SERVER_STORE;
     }
 
     public String getName() {

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/MessageCodecUtils.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/MessageCodecUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+import org.ehcache.clustered.common.Consistency;
+import org.ehcache.clustered.common.PoolAllocation;
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.terracotta.runnel.EnumMapping;
+import org.terracotta.runnel.decoding.Enm;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructEncoder;
+
+import java.util.UUID;
+
+import static org.terracotta.runnel.EnumMappingBuilder.newEnumMappingBuilder;
+
+/**
+ * MessageCodecUtils
+ */
+class MessageCodecUtils {
+
+  static final String MSG_ID_FIELD = "msgId";
+  static final String LSB_UUID_FIELD = "lsbUUID";
+  static final String MSB_UUID_FIELD = "msbUUID";
+  static final String SERVER_STORE_NAME_FIELD = "serverStoreName";
+  static final String KEY_FIELD = "key";
+  static final String STORE_CONFIG_KEY_TYPE_FIELD = "keyType";
+  static final String STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD = "keySerializerType";
+  static final String STORE_CONFIG_VALUE_TYPE_FIELD = "valueType";
+  static final String STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD = "valueSerializerType";
+  static final String STORE_CONFIG_CONSISTENCY_FIELD = "consistency";
+  static final String POOL_SIZE_FIELD = "poolSize";
+  static final String POOL_RESOURCE_NAME_FIELD = "resourceName";
+
+  static final EnumMapping<Consistency> CONSISTENCY_ENUM_MAPPING = newEnumMappingBuilder(Consistency.class)
+    .mapping(Consistency.EVENTUAL, 1)
+    .mapping(Consistency.STRONG, 2)
+    .build();
+
+  void encodeMandatoryFields(StructEncoder encoder, EhcacheOperationMessage message) {
+    encoder.enm(EhcacheMessageType.MESSAGE_TYPE_FIELD_NAME, message.getMessageType())
+      .int64(MSG_ID_FIELD, message.getId())
+      .int64(MSB_UUID_FIELD, message.getClientId().getMostSignificantBits())
+      .int64(LSB_UUID_FIELD, message.getClientId().getLeastSignificantBits());
+  }
+
+  UUID decodeUUID(StructDecoder decoder) {
+    return new UUID(decoder.int64(MSB_UUID_FIELD), decoder.int64(LSB_UUID_FIELD));
+  }
+
+  void encodeServerStoreConfiguration(StructEncoder encoder, ServerStoreConfiguration configuration) {
+    encoder.string(STORE_CONFIG_KEY_TYPE_FIELD, configuration.getStoredKeyType())
+      .string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD, configuration.getKeySerializerType())
+      .string(STORE_CONFIG_VALUE_TYPE_FIELD, configuration.getStoredValueType())
+      .string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD, configuration.getValueSerializerType());
+    if (configuration.getConsistency() != null) {
+      encoder.enm(STORE_CONFIG_CONSISTENCY_FIELD, configuration.getConsistency());
+    }
+
+    PoolAllocation poolAllocation = configuration.getPoolAllocation();
+    if (poolAllocation instanceof PoolAllocation.Dedicated) {
+      PoolAllocation.Dedicated dedicatedPool = (PoolAllocation.Dedicated) poolAllocation;
+      encoder.int64(POOL_SIZE_FIELD, dedicatedPool.getSize());
+      if (dedicatedPool.getResourceName() != null) {
+        encoder.string(POOL_RESOURCE_NAME_FIELD, dedicatedPool.getResourceName());
+      }
+    } else if (poolAllocation instanceof PoolAllocation.Shared) {
+      encoder.string(POOL_RESOURCE_NAME_FIELD, ((PoolAllocation.Shared) poolAllocation).getResourcePoolName());
+    }
+  }
+
+  ServerStoreConfiguration decodeServerStoreConfiguration(StructDecoder decoder) {
+    String keyType = decoder.string(STORE_CONFIG_KEY_TYPE_FIELD);
+    String keySerializer = decoder.string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD);
+    String valueType = decoder.string(STORE_CONFIG_VALUE_TYPE_FIELD);
+    String valueSerializer = decoder.string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD);
+    Enm<Consistency> consistencyEnm = decoder.enm(STORE_CONFIG_CONSISTENCY_FIELD);
+    Consistency consistency = Consistency.EVENTUAL;
+    if (consistencyEnm.isValid()) {
+      consistency = consistencyEnm.get();
+    }
+    Long poolSize = decoder.int64(POOL_SIZE_FIELD);
+    String poolResource = decoder.string(POOL_RESOURCE_NAME_FIELD);
+    PoolAllocation poolAllocation = new PoolAllocation.Unknown();
+    if (poolSize != null) {
+      poolAllocation = new PoolAllocation.Dedicated(poolResource, poolSize);
+    } else if (poolResource != null) {
+      poolAllocation = new PoolAllocation.Shared(poolResource);
+    }
+    return new ServerStoreConfiguration(poolAllocation, keyType, valueType, null, null, keySerializer, valueSerializer, consistency);
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/PassiveReplicationMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/PassiveReplicationMessage.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.clustered.common.internal.messages;
 
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.store.Chain;
 
 import java.util.UUID;
@@ -73,11 +74,6 @@ public abstract class PassiveReplicationMessage extends EhcacheOperationMessage 
   }
 
   @Override
-  public EhcacheMessageType getMessageType() {
-    return EhcacheMessageType.CLIENT_ID_TRACK_OP;
-  }
-
-  @Override
   public void setId(long id) {
     throw new UnsupportedOperationException("This method is not supported on replication message");
   }
@@ -102,6 +98,11 @@ public abstract class PassiveReplicationMessage extends EhcacheOperationMessage 
 
     public UUID getClientId() {
       return clientId;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CLIENT_ID_TRACK_OP;
     }
   }
 
@@ -172,6 +173,11 @@ public abstract class PassiveReplicationMessage extends EhcacheOperationMessage 
       return ReplicationOp.CLEAR_INVALIDATION_COMPLETE;
     }
 
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CLEAR_INVALIDATION_COMPLETE;
+    }
+
     public String getCacheId() {
       return cacheId;
     }
@@ -195,27 +201,65 @@ public abstract class PassiveReplicationMessage extends EhcacheOperationMessage 
       return ReplicationOp.INVALIDATION_COMPLETE;
     }
 
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.INVALIDATION_COMPLETE;
+    }
+
     public long getKey() {
       return key;
     }
   }
 
-  public static class ServerStoreLifeCycleReplicationMessage extends ClientIDTrackerMessage {
+  public static class CreateServerStoreReplicationMessage extends ClientIDTrackerMessage {
 
-    private final LifecycleMessage message;
+    private final String storeName;
+    private final ServerStoreConfiguration storeConfiguration;
 
-    public ServerStoreLifeCycleReplicationMessage(LifecycleMessage message) {
-      super(message.getId(), message.getClientId());
-      this.message = message;
+    public CreateServerStoreReplicationMessage(LifecycleMessage.CreateServerStore createMessage) {
+      this(createMessage.getId(), createMessage.getClientId(), createMessage.getName(), createMessage.getStoreConfiguration());
     }
 
-    public LifecycleMessage getMessage() {
-      return message;
+    public CreateServerStoreReplicationMessage(long msgId, UUID clientId, String storeName, ServerStoreConfiguration configuration) {
+      super(msgId, clientId);
+      this.storeName = storeName;
+      this.storeConfiguration = configuration;
+    }
+
+    public String getStoreName() {
+      return storeName;
+    }
+
+    public ServerStoreConfiguration getStoreConfiguration() {
+      return storeConfiguration;
     }
 
     @Override
-    public ReplicationOp operation() {
-      return ReplicationOp.SERVER_STORE_LIFECYCLE_REPLICATION_OP;
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CREATE_SERVER_STORE_REPLICATION;
+    }
+  }
+
+  public static class DestroyServerStoreReplicationMessage extends ClientIDTrackerMessage {
+
+    private final String storeName;
+
+    public DestroyServerStoreReplicationMessage(LifecycleMessage.DestroyServerStore destroyMessage) {
+      this(destroyMessage.getId(), destroyMessage.getClientId(), destroyMessage.getName());
+    }
+
+    public DestroyServerStoreReplicationMessage(long msgId, UUID clientId, String storeName) {
+      super(msgId, clientId);
+      this.storeName = storeName;
+    }
+
+    public String getStoreName() {
+      return storeName;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.DESTROY_SERVER_STORE_REPLICATION;
     }
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/PassiveReplicationMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/PassiveReplicationMessage.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 /**
  * This message is sent by the Active Entity to Passive Entity.
  */
-public abstract class PassiveReplicationMessage extends EhcacheEntityMessage {
+public abstract class PassiveReplicationMessage extends EhcacheOperationMessage {
 
   public enum ReplicationOp {
     CHAIN_REPLICATION_OP((byte) 41),
@@ -70,6 +70,11 @@ public abstract class PassiveReplicationMessage extends EhcacheEntityMessage {
   @Override
   public byte getOpCode() {
     return operation().getReplicationOpCode();
+  }
+
+  @Override
+  public EhcacheMessageType getMessageType() {
+    return EhcacheMessageType.CLIENT_ID_TRACK_OP;
   }
 
   @Override
@@ -123,6 +128,11 @@ public abstract class PassiveReplicationMessage extends EhcacheEntityMessage {
 
     public Chain getChain() {
       return chain;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CHAIN_REPLICATION_OP;
     }
 
     @Override

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreMessageFactory.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreMessageFactory.java
@@ -31,27 +31,27 @@ public class ServerStoreMessageFactory {
     this.clientId = clientId;
   }
 
-  public EhcacheEntityMessage getOperation(long key) {
+  public ServerStoreOpMessage.GetMessage getOperation(long key) {
     return new ServerStoreOpMessage.GetMessage(this.cacheId, key);
   }
 
-  public EhcacheEntityMessage getAndAppendOperation(long key, ByteBuffer payload) {
+  public ServerStoreOpMessage.GetAndAppendMessage getAndAppendOperation(long key, ByteBuffer payload) {
     return new ServerStoreOpMessage.GetAndAppendMessage(this.cacheId, key, payload, clientId);
   }
 
-  public EhcacheEntityMessage appendOperation(long key, ByteBuffer payload) {
+  public ServerStoreOpMessage.AppendMessage appendOperation(long key, ByteBuffer payload) {
     return new ServerStoreOpMessage.AppendMessage(this.cacheId, key, payload, clientId);
   }
 
-  public EhcacheEntityMessage replaceAtHeadOperation(long key, Chain expect, Chain update) {
+  public ServerStoreOpMessage.ReplaceAtHeadMessage replaceAtHeadOperation(long key, Chain expect, Chain update) {
     return new ServerStoreOpMessage.ReplaceAtHeadMessage(this.cacheId, key, expect, update, clientId);
   }
 
-  public EhcacheEntityMessage clientInvalidationAck(int invalidationId) {
+  public ServerStoreOpMessage.ClientInvalidationAck clientInvalidationAck(int invalidationId) {
     return new ServerStoreOpMessage.ClientInvalidationAck(this.cacheId, invalidationId);
   }
 
-  public EhcacheEntityMessage clearOperation() {
+  public ServerStoreOpMessage.ClearMessage clearOperation() {
     return new ServerStoreOpMessage.ClearMessage(this.cacheId, clientId);
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpCodec.java
@@ -16,173 +16,241 @@
 
 package org.ehcache.clustered.common.internal.messages;
 
-import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.AppendMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.ClearMessage;
+import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.ClientInvalidationAck;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.GetAndAppendMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.GetMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.ReplaceAtHeadMessage;
-import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.ClientInvalidationAck;
-import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.ServerStoreOp;
+import org.ehcache.clustered.common.internal.store.Chain;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.StructBuilder;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructEncoder;
+import org.terracotta.runnel.encoding.StructEncoderFunction;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
+import static org.ehcache.clustered.common.internal.messages.ChainCodec.CHAIN_STRUCT;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.EHCACHE_MESSAGE_TYPES_ENUM_MAPPING;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_INDEX;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_NAME;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.KEY_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.LSB_UUID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSB_UUID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSG_ID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.SERVER_STORE_NAME_FIELD;
+
 class ServerStoreOpCodec {
 
-  private static final byte STORE_OP_CODE_SIZE = 1;
-  private static final byte CACHE_ID_LEN_SIZE = 4;
-  private static final byte KEY_SIZE = 8;
-  private static final byte CHAIN_LEN_SIZE = 4;
-  private static final byte INVALIDATION_ID_LEN_SIZE = 4;
-  private static final byte MESSAGE_ID_SIZE = 24;
+  private static final Struct GET_AND_APPEND_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .int64(KEY_FIELD, 40)
+    .byteBuffer("payload", 50)
+    .build();
+
+  private static final Struct APPEND_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .int64(KEY_FIELD, 40)
+    .byteBuffer("payload", 50)
+    .build();
+
+  private static final Struct REPLACE_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .int64(KEY_FIELD, 40)
+    .struct("expect", 50, CHAIN_STRUCT)
+    .struct("update", 60, CHAIN_STRUCT)
+    .build();
+
+  private static final Struct CLIENT_INVALIDATION_ACK_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .int32("invalidationId", 40)
+    .build();
+
+  private static final Struct CLEAR_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .build();
+
+  private static final Struct GET_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .int64(KEY_FIELD, 40)
+    .build();
 
   private final ChainCodec chainCodec;
+  private final MessageCodecUtils messageCodecUtils = new MessageCodecUtils();
 
   ServerStoreOpCodec() {
     this.chainCodec = new ChainCodec();
   }
 
   public byte[] encode(ServerStoreOpMessage message) {
-    // TODO: improve data send over n/w by optimizing cache Id
-    ByteBuffer encodedMsg;
-    int cacheIdLen = message.getCacheId().length();
-    switch (message.operation()) {
-      case GET:
-        GetMessage getMessage = (GetMessage)message;
-        encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + KEY_SIZE + 2 * cacheIdLen);
-        encodedMsg.put(getMessage.getOpCode());
-        encodedMsg.putLong(getMessage.getKey());
-        CodecUtil.putStringAsCharArray(encodedMsg, getMessage.getCacheId());
-        return encodedMsg.array();
+    StructEncoder encoder = null;
+
+    switch (message.getMessageType()) {
+      case GET_STORE:
+        GetMessage getMessage = (GetMessage) message;
+        encoder = GET_MESSAGE_STRUCT.encoder();
+        return encoder
+          .enm(MESSAGE_TYPE_FIELD_NAME, message.getMessageType())
+          .int64(MSG_ID_FIELD, message.getId())
+          .string(SERVER_STORE_NAME_FIELD, getMessage.getCacheId())
+          .int64(KEY_FIELD, getMessage.getKey())
+          .encode()
+          .array();
       case APPEND:
-        AppendMessage appendMessage = (AppendMessage)message;
-        encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + CACHE_ID_LEN_SIZE + KEY_SIZE + MESSAGE_ID_SIZE + 2 * cacheIdLen + appendMessage
-            .getPayload()
-            .remaining());
-        putCacheIdKeyAndOpCode(encodedMsg, appendMessage, appendMessage.getKey());
-        encodedMsg.put(appendMessage.getPayload());
-        return encodedMsg.array();
+        AppendMessage appendMessage = (AppendMessage) message;
+        encoder = APPEND_MESSAGE_STRUCT.encoder();
+        messageCodecUtils.encodeMandatoryFields(encoder, message);
+        return encoder
+          .string(SERVER_STORE_NAME_FIELD, appendMessage.getCacheId())
+          .int64(KEY_FIELD, appendMessage.getKey())
+          .byteBuffer("payload", appendMessage.getPayload())
+          .encode()
+          .array();
       case GET_AND_APPEND:
-        GetAndAppendMessage getAndAppendMessage = (GetAndAppendMessage)message;
-        encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + CACHE_ID_LEN_SIZE + KEY_SIZE + MESSAGE_ID_SIZE + 2 * cacheIdLen +
-                                         getAndAppendMessage.getPayload().remaining());
-        putCacheIdKeyAndOpCode(encodedMsg, getAndAppendMessage, getAndAppendMessage.getKey());
-        encodedMsg.put(getAndAppendMessage.getPayload());
-        return encodedMsg.array();
+        GetAndAppendMessage getAndAppendMessage = (GetAndAppendMessage) message;
+        encoder = GET_AND_APPEND_MESSAGE_STRUCT.encoder();
+        messageCodecUtils.encodeMandatoryFields(encoder, message);
+        return encoder
+          .string(SERVER_STORE_NAME_FIELD, getAndAppendMessage.getCacheId())
+          .int64(KEY_FIELD, getAndAppendMessage.getKey())
+          .byteBuffer("payload", getAndAppendMessage.getPayload())
+          .encode()
+          .array();
       case REPLACE:
-        ReplaceAtHeadMessage replaceAtHeadMessage = (ReplaceAtHeadMessage)message;
-        byte[] encodedExpectedChain = chainCodec.encode(replaceAtHeadMessage.getExpect());
-        byte[] encodedUpdatedChain = chainCodec.encode(replaceAtHeadMessage.getUpdate());
-        encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + CACHE_ID_LEN_SIZE + KEY_SIZE + MESSAGE_ID_SIZE + 2 * cacheIdLen +
-                                         CHAIN_LEN_SIZE + encodedExpectedChain.length + encodedUpdatedChain.length);
-        putCacheIdKeyAndOpCode(encodedMsg, replaceAtHeadMessage, replaceAtHeadMessage.getKey());
-        encodedMsg.putInt(encodedExpectedChain.length);
-        encodedMsg.put(encodedExpectedChain);
-        encodedMsg.put(encodedUpdatedChain);
-        return encodedMsg.array();
+        final ReplaceAtHeadMessage replaceAtHeadMessage = (ReplaceAtHeadMessage) message;
+        encoder = REPLACE_MESSAGE_STRUCT.encoder();
+        messageCodecUtils.encodeMandatoryFields(encoder, message);
+        return encoder
+          .string(SERVER_STORE_NAME_FIELD, replaceAtHeadMessage.getCacheId())
+          .int64(KEY_FIELD, replaceAtHeadMessage.getKey())
+          .struct("expect", new StructEncoderFunction() {
+            @Override
+            public void encode(StructEncoder encoder) {
+              Chain expect = replaceAtHeadMessage.getExpect();
+              chainCodec.encode(encoder, expect);
+            }
+          })
+          .struct("update", new StructEncoderFunction() {
+            @Override
+            public void encode(StructEncoder encoder) {
+              Chain update = replaceAtHeadMessage.getUpdate();
+              chainCodec.encode(encoder, update);
+            }
+          })
+          .encode()
+          .array();
       case CLIENT_INVALIDATION_ACK:
-        ClientInvalidationAck clientInvalidationAck = (ClientInvalidationAck)message;
-        encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + INVALIDATION_ID_LEN_SIZE + 2 * cacheIdLen);
-        encodedMsg.put(clientInvalidationAck.getOpCode());
-        encodedMsg.putInt(clientInvalidationAck.getInvalidationId());
-        CodecUtil.putStringAsCharArray(encodedMsg, clientInvalidationAck.getCacheId());
-        return encodedMsg.array();
+        ClientInvalidationAck clientInvalidationAckMessage = (ClientInvalidationAck) message;
+        encoder = CLIENT_INVALIDATION_ACK_MESSAGE_STRUCT.encoder();
+        return encoder
+          .enm(MESSAGE_TYPE_FIELD_NAME, message.getMessageType())
+          .int64(MSG_ID_FIELD, message.getId())
+          .string(SERVER_STORE_NAME_FIELD, clientInvalidationAckMessage.getCacheId())
+          .int32("invalidationId", clientInvalidationAckMessage.getInvalidationId())
+          .encode()
+          .array();
       case CLEAR:
-        ClearMessage clearMessage = (ClearMessage)message;
-        encodedMsg = ByteBuffer.allocate(STORE_OP_CODE_SIZE + MESSAGE_ID_SIZE + 2 * cacheIdLen);
-        encodedMsg.put(clearMessage.getOpCode());
-        encodedMsg.put(ClusteredEhcacheIdentity.serialize(message.getClientId()));
-        encodedMsg.putLong(message.getId());
-        CodecUtil.putStringAsCharArray(encodedMsg, clearMessage.getCacheId());
-        return encodedMsg.array();
+        ClearMessage clearMessage = (ClearMessage) message;
+        encoder = CLEAR_MESSAGE_STRUCT.encoder();
+        messageCodecUtils.encodeMandatoryFields(encoder, message);
+        return encoder
+          .string(SERVER_STORE_NAME_FIELD, clearMessage.getCacheId())
+          .encode()
+          .array();
       default:
-        throw new UnsupportedOperationException("This operation is not supported : " + message.operation());
+        throw new RuntimeException("Unhandled message operation : " + message.operation());
     }
   }
 
-  // This assumes correct allocation and puts extracts common code
-  private static void putCacheIdKeyAndOpCode(ByteBuffer byteBuffer, ServerStoreOpMessage message, long key) {
-    byteBuffer.put(message.getOpCode());
-    byteBuffer.put(ClusteredEhcacheIdentity.serialize(message.getClientId()));
-    byteBuffer.putLong(message.getId());
-    byteBuffer.putInt(message.getCacheId().length());
-    CodecUtil.putStringAsCharArray(byteBuffer, message.getCacheId());
-    byteBuffer.putLong(key);
-  }
-
-  public EhcacheEntityMessage decode(byte[] payload) {
-    ByteBuffer msg = ByteBuffer.wrap(payload);
-    byte opCode = msg.get();
-    ServerStoreOp storeOp = ServerStoreOp.getServerStoreOp(opCode);
-
-    long key;
-    String cacheId;
-    UUID clientId;
-    long msgId;
-
-    EhcacheEntityMessage decodecMsg;
-    switch (storeOp) {
-      case GET:
-        key = msg.getLong();
-        cacheId = CodecUtil.getStringFromBuffer(msg, msg.remaining() / 2);
-        return new GetMessage(cacheId, key);
-      case GET_AND_APPEND:
-        clientId = getClientId(msg);
-        msgId = msg.getLong();
-        cacheId = readStringFromBufferWithSize(msg);
-        key = msg.getLong();
-        decodecMsg = new GetAndAppendMessage(cacheId, key, msg.slice().asReadOnlyBuffer(), clientId);
-        decodecMsg.setId(msgId);
-        return decodecMsg;
-      case APPEND:
-        clientId = getClientId(msg);
-        msgId = msg.getLong();
-        cacheId = readStringFromBufferWithSize(msg);
-        key = msg.getLong();
-        decodecMsg = new AppendMessage(cacheId, key, msg.slice().asReadOnlyBuffer(), clientId);
-        decodecMsg.setId(msgId);
-        return decodecMsg;
-      case REPLACE:
-        clientId = getClientId(msg);
-        msgId = msg.getLong();
-        cacheId = readStringFromBufferWithSize(msg);
-        key = msg.getLong();
-        int expectChainLen = msg.getInt();
-        byte[] encodedExpectChain = new byte[expectChainLen];
-        msg.get(encodedExpectChain);
-        int updateChainLen = msg.remaining();
-        byte[] encodedUpdateChain = new byte[updateChainLen];
-        msg.get(encodedUpdateChain);
-        decodecMsg = new ReplaceAtHeadMessage(cacheId, key, chainCodec.decode(encodedExpectChain),
-            chainCodec.decode(encodedUpdateChain), clientId);
-        decodecMsg.setId(msgId);
-        return decodecMsg;
-      case CLIENT_INVALIDATION_ACK:
-        int invalidationId = msg.getInt();
-        cacheId = CodecUtil.getStringFromBuffer(msg, msg.remaining() / 2);
-        return new ClientInvalidationAck(cacheId, invalidationId);
-      case CLEAR:
-        clientId = getClientId(msg);
-        msgId = msg.getLong();
-        cacheId = CodecUtil.getStringFromBuffer(msg, msg.remaining() / 2);
-        decodecMsg = new ClearMessage(cacheId, clientId);
-        decodecMsg.setId(msgId);
-        return decodecMsg;
+  public EhcacheEntityMessage decode(EhcacheMessageType opCode, ByteBuffer messageBuffer) {
+    StructDecoder decoder;
+    switch (opCode) {
+      case GET_STORE: {
+        decoder = GET_MESSAGE_STRUCT.decoder(messageBuffer);
+        Long msgId = decoder.int64(MSG_ID_FIELD);
+        String cacheId = decoder.string(SERVER_STORE_NAME_FIELD);
+        Long key = decoder.int64(KEY_FIELD);
+        GetMessage message = new GetMessage(cacheId, key);
+        message.setId(msgId);
+        return message;
+      }
+      case GET_AND_APPEND: {
+        decoder = GET_AND_APPEND_MESSAGE_STRUCT.decoder(messageBuffer);
+        Long msgId = decoder.int64(MSG_ID_FIELD);
+        UUID uuid = messageCodecUtils.decodeUUID(decoder);
+        String cacheId = decoder.string(SERVER_STORE_NAME_FIELD);
+        Long key = decoder.int64(KEY_FIELD);
+        ByteBuffer payload = decoder.byteBuffer("payload");
+        GetAndAppendMessage message = new GetAndAppendMessage(cacheId, key, payload, uuid);
+        message.setId(msgId);
+        return message;
+      }
+      case APPEND: {
+        decoder = APPEND_MESSAGE_STRUCT.decoder(messageBuffer);
+        Long msgId = decoder.int64(MSG_ID_FIELD);
+        UUID uuid = messageCodecUtils.decodeUUID(decoder);
+        String cacheId = decoder.string(SERVER_STORE_NAME_FIELD);
+        Long key = decoder.int64(KEY_FIELD);
+        ByteBuffer payload = decoder.byteBuffer("payload");
+        AppendMessage message = new AppendMessage(cacheId, key, payload, uuid);
+        message.setId(msgId);
+        return message;
+      }
+      case REPLACE: {
+        decoder = REPLACE_MESSAGE_STRUCT.decoder(messageBuffer);
+        Long msgId = decoder.int64(MSG_ID_FIELD);
+        UUID uuid = messageCodecUtils.decodeUUID(decoder);
+        String cacheId = decoder.string(SERVER_STORE_NAME_FIELD);
+        Long key = decoder.int64(KEY_FIELD);
+        Chain expect = chainCodec.decode(decoder.struct("expect"));
+        Chain update = chainCodec.decode(decoder.struct("update"));
+        ReplaceAtHeadMessage message = new ReplaceAtHeadMessage(cacheId, key, expect, update, uuid);
+        message.setId(msgId);
+        return message;
+      }
+      case CLIENT_INVALIDATION_ACK: {
+        decoder = CLIENT_INVALIDATION_ACK_MESSAGE_STRUCT.decoder(messageBuffer);
+        Long msgId = decoder.int64(MSG_ID_FIELD);
+        String cacheId = decoder.string(SERVER_STORE_NAME_FIELD);
+        Integer invalidationId = decoder.int32("invalidationId");
+        ClientInvalidationAck message = new ClientInvalidationAck(cacheId, invalidationId);
+        message.setId(msgId);
+        return message;
+      }
+      case CLEAR: {
+        decoder = CLEAR_MESSAGE_STRUCT.decoder(messageBuffer);
+        Long msgId = decoder.int64(MSG_ID_FIELD);
+        UUID uuid = messageCodecUtils.decodeUUID(decoder);
+        String cacheId = decoder.string(SERVER_STORE_NAME_FIELD);
+        ClearMessage message = new ClearMessage(cacheId, uuid);
+        message.setId(msgId);
+        return message;
+      }
       default:
-        throw new UnsupportedOperationException("This operation code is not supported : " + opCode);
+        throw new RuntimeException("Unhandled message operation : " + opCode);
     }
-  }
-
-  private static String readStringFromBufferWithSize(ByteBuffer buffer) {
-    int length = buffer.getInt();
-    return CodecUtil.getStringFromBuffer(buffer, length);
-  }
-
-  private static UUID getClientId(ByteBuffer payload) {
-    long msb = payload.getLong();
-    long lsb = payload.getLong();
-    return new UUID(msb, lsb);
   }
 
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpMessage.java
@@ -107,11 +107,6 @@ public abstract class ServerStoreOpMessage extends EhcacheOperationMessage {
     return operation().getStoreOpCode();
   }
 
-  @Override
-  public String toString() {
-    return getType() + "#" + operation();
-  }
-
   public static abstract class KeyBasedServerStoreOpMessage extends ServerStoreOpMessage  implements ConcurrentEntityMessage {
 
     private final long key;

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpMessage.java
@@ -21,7 +21,7 @@ import org.ehcache.clustered.common.internal.store.Chain;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
+public abstract class ServerStoreOpMessage extends EhcacheOperationMessage {
   public enum ServerStoreOp {
 
     GET_AND_APPEND((byte) 11),
@@ -99,6 +99,7 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     return Type.SERVER_STORE_OP;
   }
 
+  @Deprecated
   public abstract ServerStoreOp operation();
 
   @Override
@@ -140,6 +141,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     public ServerStoreOp operation() {
       return ServerStoreOp.GET;
     }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.GET_STORE;
+    }
   }
 
   public static class GetAndAppendMessage extends KeyBasedServerStoreOpMessage {
@@ -155,6 +161,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public ServerStoreOp operation() {
       return ServerStoreOp.GET_AND_APPEND;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.GET_AND_APPEND;
     }
 
     public ByteBuffer getPayload() {
@@ -178,6 +189,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
       return ServerStoreOp.APPEND;
     }
 
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.APPEND;
+    }
+
     public ByteBuffer getPayload() {
       return payload;
     }
@@ -199,6 +215,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public ServerStoreOp operation() {
       return ServerStoreOp.REPLACE;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.REPLACE;
     }
 
     public Chain getExpect() {
@@ -227,6 +248,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     public ServerStoreOp operation() {
       return ServerStoreOp.CLIENT_INVALIDATION_ACK;
     }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CLIENT_INVALIDATION_ACK;
+    }
   }
 
   public static class ClearMessage extends ServerStoreOpMessage {
@@ -239,6 +265,11 @@ public abstract class ServerStoreOpMessage extends EhcacheEntityMessage {
     @Override
     public ServerStoreOp operation() {
       return ServerStoreOp.CLEAR;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.CLEAR;
     }
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpCodec.java
@@ -17,31 +17,171 @@
 package org.ehcache.clustered.common.internal.messages;
 
 import org.ehcache.clustered.common.internal.store.Util;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructEncoder;
 
 import java.nio.ByteBuffer;
+import java.util.UUID;
 
-public class StateRepositoryOpCodec {
+import static java.nio.ByteBuffer.wrap;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.EHCACHE_MESSAGE_TYPES_ENUM_MAPPING;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_INDEX;
+import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.MESSAGE_TYPE_FIELD_NAME;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.KEY_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.LSB_UUID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSB_UUID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSG_ID_FIELD;
+import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.SERVER_STORE_NAME_FIELD;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
 
-  private static final byte OPCODE_SIZE = 1;
+class StateRepositoryOpCodec {
+
+  private static final String MAP_ID_FIELD = "mapId";
+  private static final String VALUE_FIELD = "value";
+
+  private static final Struct GET_MESSAGE_STRUCT = newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .string(MAP_ID_FIELD, 35)
+    .byteBuffer(KEY_FIELD, 40)
+    .build();
+
+  private static final Struct PUT_IF_ABSENT_MESSAGE_STRUCT = newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .string(MAP_ID_FIELD, 35)
+    .byteBuffer(KEY_FIELD, 40)
+    .byteBuffer(VALUE_FIELD, 45)
+    .build();
+
+  private static final Struct ENTRY_SET_MESSAGE_STRUCT = newStructBuilder()
+    .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
+    .int64(MSG_ID_FIELD, 15)
+    .int64(MSB_UUID_FIELD, 20)
+    .int64(LSB_UUID_FIELD, 21)
+    .string(SERVER_STORE_NAME_FIELD, 30)
+    .string(MAP_ID_FIELD, 35)
+    .build();
+
+  private final MessageCodecUtils messageCodecUtils = new MessageCodecUtils();
 
   public byte[] encode(StateRepositoryOpMessage message) {
-    byte[] encodedMsg = Util.marshall(message);
-    ByteBuffer buffer = ByteBuffer.allocate(OPCODE_SIZE + encodedMsg.length);
-    buffer.put(message.getOpCode());
-    buffer.put(encodedMsg);
-    return buffer.array();
+
+    switch (message.getMessageType()) {
+      case GET_STATE_REPO:
+        return encodeGetMessage((StateRepositoryOpMessage.GetMessage) message);
+      case PUT_IF_ABSENT:
+        return encodePutIfAbsentMessage((StateRepositoryOpMessage.PutIfAbsentMessage) message);
+      case ENTRY_SET:
+        return encodeEntrySetMessage((StateRepositoryOpMessage.EntrySetMessage) message);
+      default:
+        throw new IllegalArgumentException("Unsupported StateRepositoryOpMessage " + message.getClass());
+    }
   }
 
-  public StateRepositoryOpMessage decode(byte[] payload) {
-    ByteBuffer message = ByteBuffer.wrap(payload);
-    byte[] encodedMsg = new byte[message.capacity() - OPCODE_SIZE];
-    byte opCode = message.get();
-    if (opCode == EhcacheEntityMessage.Type.STATE_REPO_OP.getCode()) {
-      message.get(encodedMsg, 0, encodedMsg.length);
-      StateRepositoryOpMessage entityMessage = (StateRepositoryOpMessage) Util.unmarshall(encodedMsg);
-      return entityMessage;
-    } else {
-      throw new UnsupportedOperationException("State repository operation not defined for : " + opCode);
+  private byte[] encodeEntrySetMessage(StateRepositoryOpMessage.EntrySetMessage message) {
+    StructEncoder encoder = ENTRY_SET_MESSAGE_STRUCT.encoder();
+
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+    encoder.string(SERVER_STORE_NAME_FIELD, message.getCacheId());
+    encoder.string(MAP_ID_FIELD, message.getCacheId());
+
+    return encoder.encode().array();
+  }
+
+  private byte[] encodePutIfAbsentMessage(StateRepositoryOpMessage.PutIfAbsentMessage message) {
+    StructEncoder encoder = PUT_IF_ABSENT_MESSAGE_STRUCT.encoder();
+
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+    encoder.string(SERVER_STORE_NAME_FIELD, message.getCacheId());
+    encoder.string(MAP_ID_FIELD, message.getCacheId());
+    // TODO this needs to change - serialization needs to happen in the StateRepo not here, though we need the hashcode for server side comparison.
+    encoder.byteBuffer(KEY_FIELD, wrap(Util.marshall(message.getKey())));
+    encoder.byteBuffer(VALUE_FIELD, wrap(Util.marshall(message.getValue())));
+
+    return encoder.encode().array();
+  }
+
+  private byte[] encodeGetMessage(StateRepositoryOpMessage.GetMessage message) {
+    StructEncoder encoder = GET_MESSAGE_STRUCT.encoder();
+
+    messageCodecUtils.encodeMandatoryFields(encoder, message);
+    encoder.string(SERVER_STORE_NAME_FIELD, message.getCacheId());
+    encoder.string(MAP_ID_FIELD, message.getCacheId());
+    // TODO this needs to change - serialization needs to happen in the StateRepo not here, though we need the hashcode for server side comparison.
+    encoder.byteBuffer(KEY_FIELD, wrap(Util.marshall(message.getKey())));
+
+    return encoder.encode().array();
+  }
+
+  public StateRepositoryOpMessage decode(EhcacheMessageType messageType, ByteBuffer messageBuffer) {
+    switch (messageType) {
+      case GET_STATE_REPO:
+        return decodeGetMessage(messageBuffer);
+      case PUT_IF_ABSENT:
+        return decodePutIfAbsentMessage(messageBuffer);
+      case ENTRY_SET:
+        return decodeEntrySetMessage(messageBuffer);
+      default:
+        throw new IllegalArgumentException("Unsupported StateRepositoryOpMessage " + messageType);
     }
+  }
+
+  private StateRepositoryOpMessage.EntrySetMessage decodeEntrySetMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = ENTRY_SET_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID clientId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+    String mapId = decoder.string(MAP_ID_FIELD);
+
+    StateRepositoryOpMessage.EntrySetMessage message = new StateRepositoryOpMessage.EntrySetMessage(storeName, mapId, clientId);
+    message.setId(msgId);
+    return message;
+  }
+
+  private StateRepositoryOpMessage.PutIfAbsentMessage decodePutIfAbsentMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = PUT_IF_ABSENT_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID clientId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+    String mapId = decoder.string(MAP_ID_FIELD);
+
+    ByteBuffer keyBuffer = decoder.byteBuffer(KEY_FIELD);
+    Object key = Util.unmarshall(keyBuffer);
+
+    ByteBuffer valueBuffer = decoder.byteBuffer(VALUE_FIELD);
+    Object value = Util.unmarshall(valueBuffer);
+
+    StateRepositoryOpMessage.PutIfAbsentMessage message = new StateRepositoryOpMessage.PutIfAbsentMessage(storeName, mapId, key, value, clientId);
+    message.setId(msgId);
+    return message;
+  }
+
+  private StateRepositoryOpMessage.GetMessage decodeGetMessage(ByteBuffer messageBuffer) {
+    StructDecoder decoder = GET_MESSAGE_STRUCT.decoder(messageBuffer);
+
+    Long msgId = decoder.int64(MSG_ID_FIELD);
+    UUID clientId = messageCodecUtils.decodeUUID(decoder);
+
+    String storeName = decoder.string(SERVER_STORE_NAME_FIELD);
+    String mapId = decoder.string(MAP_ID_FIELD);
+
+    ByteBuffer keyBuffer = decoder.byteBuffer(KEY_FIELD);
+    Object key = Util.unmarshall(keyBuffer);
+
+    StateRepositoryOpMessage.GetMessage getMessage = new StateRepositoryOpMessage.GetMessage(storeName, mapId, key, clientId);
+    getMessage.setId(msgId);
+    return getMessage;
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpMessage.java
@@ -19,7 +19,7 @@ package org.ehcache.clustered.common.internal.messages;
 import java.io.Serializable;
 import java.util.UUID;
 
-public abstract class StateRepositoryOpMessage extends EhcacheEntityMessage implements Serializable {
+public abstract class StateRepositoryOpMessage extends EhcacheOperationMessage implements Serializable {
 
   public enum StateRepositoryOp {
     GET,
@@ -107,6 +107,11 @@ public abstract class StateRepositoryOpMessage extends EhcacheEntityMessage impl
     public StateRepositoryOp operation() {
       return StateRepositoryOp.GET;
     }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.GET_STATE_REPO;
+    }
   }
 
   public static class PutIfAbsentMessage extends KeyBasedMessage {
@@ -126,6 +131,11 @@ public abstract class StateRepositoryOpMessage extends EhcacheEntityMessage impl
     public StateRepositoryOp operation() {
       return StateRepositoryOp.PUT_IF_ABSENT;
     }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.PUT_IF_ABSENT;
+    }
   }
 
   public static class EntrySetMessage extends StateRepositoryOpMessage {
@@ -137,6 +147,11 @@ public abstract class StateRepositoryOpMessage extends EhcacheEntityMessage impl
     @Override
     public StateRepositoryOp operation() {
       return StateRepositoryOp.ENTRY_SET;
+    }
+
+    @Override
+    public EhcacheMessageType getMessageType() {
+      return EhcacheMessageType.ENTRY_SET;
     }
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpMessage.java
@@ -77,11 +77,6 @@ public abstract class StateRepositoryOpMessage extends EhcacheOperationMessage i
     return getType().getCode();
   }
 
-  @Override
-  public String toString() {
-    return getType() + "#" + operation();
-  }
-
   private static abstract class KeyBasedMessage extends StateRepositoryOpMessage {
 
     private final Object key;

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/util/ByteBufferInputStream.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/util/ByteBufferInputStream.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+// TODO remove once it comes with Runnel
+public class ByteBufferInputStream extends InputStream {
+
+  private final ByteBuffer buffer;
+
+  public ByteBufferInputStream(ByteBuffer buffer) {
+    this.buffer = buffer.slice();
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (buffer.hasRemaining()) {
+      return 0xff & buffer.get();
+    } else {
+      return -1;
+    }
+  }
+
+  @Override
+  public int read(byte b[], int off, int len) {
+    len = min(len, buffer.remaining());
+    buffer.get(b, off, len);
+    return len;
+  }
+
+  @Override
+  public long skip(long n) {
+    n = min(buffer.remaining(), max(n, 0));
+    buffer.position((int) (buffer.position() + n));
+    return n;
+  }
+
+  @Override
+  public synchronized int available() {
+    return buffer.remaining();
+  }
+}

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodecTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+import org.ehcache.clustered.common.Consistency;
+import org.ehcache.clustered.common.PoolAllocation;
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static java.nio.ByteBuffer.wrap;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+/**
+ * LifeCycleMessageCodecTest
+ */
+public class LifeCycleMessageCodecTest {
+
+  private static final long MESSAGE_ID = 42L;
+  private static final UUID CLIENT_ID = UUID.randomUUID();
+
+  private final LifeCycleMessageFactory factory = new LifeCycleMessageFactory();
+  private final LifeCycleMessageCodec codec = new LifeCycleMessageCodec();
+
+  @Before
+  public void setUp() {
+    factory.setClientId(CLIENT_ID);
+  }
+
+  @Test
+  public void testConfigureStoreManager() throws Exception {
+    ServerSideConfiguration configuration = getServerSideConfiguration();
+    LifecycleMessage message = factory.configureStoreManager(configuration);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.ConfigureStoreManager decodedMessage = (LifecycleMessage.ConfigureStoreManager) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CONFIGURE));
+    assertThat(decodedMessage.getConfiguration().getDefaultServerResource(), is(configuration.getDefaultServerResource()));
+    assertThat(decodedMessage.getConfiguration().getResourcePools(), is(configuration.getResourcePools()));
+  }
+
+  @Test
+  public void testValidateStoreManager() throws Exception {
+    ServerSideConfiguration configuration = getServerSideConfiguration();
+    LifecycleMessage message = factory.validateStoreManager(configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.ValidateStoreManager decodedMessage = (LifecycleMessage.ValidateStoreManager) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.VALIDATE));
+    assertThat(decodedMessage.getConfiguration().getDefaultServerResource(), is(configuration.getDefaultServerResource()));
+    assertThat(decodedMessage.getConfiguration().getResourcePools(), is(configuration.getResourcePools()));
+  }
+
+  @Test
+  public void testCreateServerStoreDedicated() throws Exception {
+    PoolAllocation.Dedicated dedicated = new PoolAllocation.Dedicated("dedicate", 420000L);
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(dedicated, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    LifecycleMessage message = factory.createServerStore("store1", configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.CreateServerStore decodedMessage = (LifecycleMessage.CreateServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CREATE_SERVER_STORE));
+    validateCommonServerStoreConfig(decodedMessage, configuration);
+    PoolAllocation.Dedicated decodedPoolAllocation = (PoolAllocation.Dedicated) decodedMessage.getStoreConfiguration().getPoolAllocation();
+    assertThat(decodedPoolAllocation.getResourceName(), is(dedicated.getResourceName()));
+    assertThat(decodedPoolAllocation.getSize(), is(dedicated.getSize()));
+  }
+
+  @Test
+  public void testCreateServerStoreShared() throws Exception {
+    PoolAllocation.Shared shared = new PoolAllocation.Shared("shared");
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(shared, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    LifecycleMessage message = factory.createServerStore("store1", configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.CreateServerStore decodedMessage = (LifecycleMessage.CreateServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CREATE_SERVER_STORE));
+    validateCommonServerStoreConfig(decodedMessage, configuration);
+    PoolAllocation.Shared decodedPoolAllocation = (PoolAllocation.Shared) decodedMessage.getStoreConfiguration().getPoolAllocation();
+    assertThat(decodedPoolAllocation.getResourcePoolName(), is(shared.getResourcePoolName()));
+  }
+
+  @Test
+  public void testCreateServerStoreUnknown() throws Exception {
+    PoolAllocation.Unknown unknown = new PoolAllocation.Unknown();
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(unknown, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    LifecycleMessage message = factory.createServerStore("store1", configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.CreateServerStore decodedMessage = (LifecycleMessage.CreateServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CREATE_SERVER_STORE));
+    validateCommonServerStoreConfig(decodedMessage, configuration);
+    assertThat(decodedMessage.getStoreConfiguration().getPoolAllocation(), instanceOf(PoolAllocation.Unknown.class));
+  }
+
+  @Test
+  public void testValidateServerStoreDedicated() throws Exception {
+    PoolAllocation.Dedicated dedicated = new PoolAllocation.Dedicated("dedicate", 420000L);
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(dedicated, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    LifecycleMessage message = factory.validateServerStore("store1", configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.ValidateServerStore decodedMessage = (LifecycleMessage.ValidateServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.VALIDATE_SERVER_STORE));
+    validateCommonServerStoreConfig(decodedMessage, configuration);
+    PoolAllocation.Dedicated decodedPoolAllocation = (PoolAllocation.Dedicated) decodedMessage.getStoreConfiguration().getPoolAllocation();
+    assertThat(decodedPoolAllocation.getResourceName(), is(dedicated.getResourceName()));
+    assertThat(decodedPoolAllocation.getSize(), is(dedicated.getSize()));
+  }
+
+  @Test
+  public void testValidateServerStoreShared() throws Exception {
+    PoolAllocation.Shared shared = new PoolAllocation.Shared("shared");
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(shared, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    LifecycleMessage message = factory.validateServerStore("store1", configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.ValidateServerStore decodedMessage = (LifecycleMessage.ValidateServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.VALIDATE_SERVER_STORE));
+    validateCommonServerStoreConfig(decodedMessage, configuration);
+    PoolAllocation.Shared decodedPoolAllocation = (PoolAllocation.Shared) decodedMessage.getStoreConfiguration().getPoolAllocation();
+    assertThat(decodedPoolAllocation.getResourcePoolName(), is(shared.getResourcePoolName()));
+  }
+
+  @Test
+  public void testValidateServerStoreUnknown() throws Exception {
+    PoolAllocation.Unknown unknown = new PoolAllocation.Unknown();
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(unknown, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    LifecycleMessage message = factory.validateServerStore("store1", configuration);
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.ValidateServerStore decodedMessage = (LifecycleMessage.ValidateServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.VALIDATE_SERVER_STORE));
+    validateCommonServerStoreConfig(decodedMessage, configuration);
+    assertThat(decodedMessage.getStoreConfiguration().getPoolAllocation(), instanceOf(PoolAllocation.Unknown.class));
+  }
+
+  @Test
+  public void testReleaseServerStore() throws Exception {
+    LifecycleMessage message = factory.releaseServerStore("store1");
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.ReleaseServerStore decodedMessage = (LifecycleMessage.ReleaseServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.RELEASE_SERVER_STORE));
+    assertThat(decodedMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getName(), is("store1"));
+  }
+
+  @Test
+  public void testDestroyServerStore() throws Exception {
+    LifecycleMessage message = factory.destroyServerStore("store1");
+    message.setId(MESSAGE_ID);
+
+    byte[] encoded = codec.encode(message);
+    LifecycleMessage.DestroyServerStore decodedMessage = (LifecycleMessage.DestroyServerStore) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.DESTROY_SERVER_STORE));
+    assertThat(decodedMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getName(), is("store1"));
+  }
+
+  private void validateCommonServerStoreConfig(LifecycleMessage.BaseServerStore decodedMessage, ServerStoreConfiguration initialConfiguration) {
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedMessage.getName(), is("store1"));
+    assertThat(decodedMessage.getStoreConfiguration().getStoredKeyType(), is(initialConfiguration.getStoredKeyType()));
+    assertThat(decodedMessage.getStoreConfiguration().getStoredValueType(), is(initialConfiguration.getStoredValueType()));
+    assertThat(decodedMessage.getStoreConfiguration().getActualKeyType(), nullValue());
+    assertThat(decodedMessage.getStoreConfiguration().getActualValueType(), nullValue());
+    assertThat(decodedMessage.getStoreConfiguration().getConsistency(), is(initialConfiguration.getConsistency()));
+    assertThat(decodedMessage.getStoreConfiguration().getKeySerializerType(), is(initialConfiguration.getKeySerializerType()));
+    assertThat(decodedMessage.getStoreConfiguration().getValueSerializerType(), is(initialConfiguration.getValueSerializerType()));
+  }
+
+  private ServerSideConfiguration getServerSideConfiguration() {
+    return new ServerSideConfiguration("default", Collections.singletonMap("shared", new ServerSideConfiguration.Pool(100, "other")));
+  }
+
+}

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/PassiveReplicationMessageCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/PassiveReplicationMessageCodecTest.java
@@ -16,6 +16,9 @@
 
 package org.ehcache.clustered.common.internal.messages;
 
+import org.ehcache.clustered.common.Consistency;
+import org.ehcache.clustered.common.PoolAllocation;
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ChainReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClearInvalidationCompleteMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClientIDTrackerMessage;
@@ -25,25 +28,28 @@ import org.junit.Test;
 
 import java.util.UUID;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.ehcache.clustered.common.internal.store.Util.createPayload;
 import static org.ehcache.clustered.common.internal.store.Util.getChain;
 import static org.ehcache.clustered.common.internal.store.Util.chainsEqual;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 
 public class PassiveReplicationMessageCodecTest {
 
+  private static final long MESSAGE_ID = 42L;
+  private PassiveReplicationMessageCodec codec = new PassiveReplicationMessageCodec();
+
   @Test
   public void testClientIDTrackerMessageCodec() {
     ClientIDTrackerMessage clientIDTrackerMessage = new ClientIDTrackerMessage(200L, UUID.randomUUID());
 
-    PassiveReplicationMessageCodec passiveReplicationMessageCodec = new PassiveReplicationMessageCodec();
-
-    PassiveReplicationMessage decodedMsg = (PassiveReplicationMessage)passiveReplicationMessageCodec.decode(passiveReplicationMessageCodec
-        .encode(clientIDTrackerMessage));
+    byte[] encoded = codec.encode(clientIDTrackerMessage);
+    PassiveReplicationMessage decodedMsg = (PassiveReplicationMessage) codec.decode(EhcacheMessageType.CLIENT_ID_TRACK_OP, wrap(encoded));
 
     assertThat(decodedMsg.getClientId(), is(clientIDTrackerMessage.getClientId()));
     assertThat(decodedMsg.getId(), is(clientIDTrackerMessage.getId()));
@@ -55,10 +61,8 @@ public class PassiveReplicationMessageCodecTest {
     Chain chain = getChain(false, createPayload(2L), createPayload(20L));
     ChainReplicationMessage chainReplicationMessage = new ChainReplicationMessage("test", 2L, chain, 200L, UUID.randomUUID());
 
-    PassiveReplicationMessageCodec passiveReplicationMessageCodec = new PassiveReplicationMessageCodec();
-
-    ChainReplicationMessage decodedMsg = (ChainReplicationMessage)passiveReplicationMessageCodec.decode(passiveReplicationMessageCodec
-        .encode(chainReplicationMessage));
+    byte[] encoded = codec.encode(chainReplicationMessage);
+    ChainReplicationMessage decodedMsg = (ChainReplicationMessage) codec.decode(EhcacheMessageType.CHAIN_REPLICATION_OP, wrap(encoded));
 
     assertThat(decodedMsg.getCacheId(), is(chainReplicationMessage.getCacheId()));
     assertThat(decodedMsg.getClientId(), is(chainReplicationMessage.getClientId()));
@@ -72,12 +76,11 @@ public class PassiveReplicationMessageCodecTest {
   public void testClearInvalidationCompleteMessage() {
     ClearInvalidationCompleteMessage clearInvalidationCompleteMessage = new ClearInvalidationCompleteMessage("test");
 
-    PassiveReplicationMessageCodec messageCodec = new PassiveReplicationMessageCodec();
+    byte[] encoded = codec.encode(clearInvalidationCompleteMessage);
+    ClearInvalidationCompleteMessage decoded = (ClearInvalidationCompleteMessage) codec.decode(EhcacheMessageType.CLEAR_INVALIDATION_COMPLETE, wrap(encoded));
 
-    ClearInvalidationCompleteMessage decoded = (ClearInvalidationCompleteMessage)messageCodec.decode(messageCodec.encode(clearInvalidationCompleteMessage));
-
-    assertThat(decoded.getOpCode(), equalTo(clearInvalidationCompleteMessage.getOpCode()));
-    assertThat(decoded.getCacheId(), equalTo(clearInvalidationCompleteMessage.getCacheId()));
+    assertThat(decoded.getMessageType(), is(EhcacheMessageType.CLEAR_INVALIDATION_COMPLETE));
+    assertThat(decoded.getCacheId(), is(clearInvalidationCompleteMessage.getCacheId()));
 
   }
 
@@ -86,13 +89,81 @@ public class PassiveReplicationMessageCodecTest {
 
     InvalidationCompleteMessage invalidationCompleteMessage = new InvalidationCompleteMessage("test", 20L);
 
-    PassiveReplicationMessageCodec messageCodec = new PassiveReplicationMessageCodec();
+    byte[] encoded = codec.encode(invalidationCompleteMessage);
+    InvalidationCompleteMessage decoded = (InvalidationCompleteMessage) codec.decode(EhcacheMessageType.INVALIDATION_COMPLETE, wrap(encoded));
 
-    InvalidationCompleteMessage decoded = (InvalidationCompleteMessage)messageCodec.decode(messageCodec.encode(invalidationCompleteMessage));
-
-    assertThat(decoded.getOpCode(), equalTo(invalidationCompleteMessage.getOpCode()));
+    assertThat(decoded.getMessageType(), is(EhcacheMessageType.INVALIDATION_COMPLETE));
     assertThat(decoded.getCacheId(), equalTo(invalidationCompleteMessage.getCacheId()));
     assertThat(decoded.getKey(), equalTo(invalidationCompleteMessage.getKey()));
+  }
+
+  @Test
+  public void testCreateServerStoreReplicationDedicated() throws Exception {
+    UUID clientId = UUID.randomUUID();
+    PoolAllocation.Dedicated dedicated = new PoolAllocation.Dedicated("dedicate", 420000L);
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(dedicated, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    PassiveReplicationMessage.CreateServerStoreReplicationMessage message = new PassiveReplicationMessage.CreateServerStoreReplicationMessage(MESSAGE_ID, clientId, "storeId", configuration);
+
+    byte[] encoded = codec.encode(message);
+    PassiveReplicationMessage.CreateServerStoreReplicationMessage decodedMessage = (PassiveReplicationMessage.CreateServerStoreReplicationMessage) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CREATE_SERVER_STORE_REPLICATION));
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getClientId(), is(clientId));
+    assertThat(decodedMessage.getStoreName(), is("storeId"));
+    assertThat(decodedMessage.getStoreConfiguration().getStoredKeyType(), is(configuration.getStoredKeyType()));
+    assertThat(decodedMessage.getStoreConfiguration().getStoredValueType(), is(configuration.getStoredValueType()));
+    assertThat(decodedMessage.getStoreConfiguration().getActualKeyType(), nullValue());
+    assertThat(decodedMessage.getStoreConfiguration().getActualValueType(), nullValue());
+    assertThat(decodedMessage.getStoreConfiguration().getConsistency(), is(configuration.getConsistency()));
+    assertThat(decodedMessage.getStoreConfiguration().getKeySerializerType(), is(configuration.getKeySerializerType()));
+    assertThat(decodedMessage.getStoreConfiguration().getValueSerializerType(), is(configuration.getValueSerializerType()));
+    PoolAllocation.Dedicated decodedPoolAllocation = (PoolAllocation.Dedicated) decodedMessage.getStoreConfiguration().getPoolAllocation();
+    assertThat(decodedPoolAllocation.getResourceName(), is(dedicated.getResourceName()));
+    assertThat(decodedPoolAllocation.getSize(), is(dedicated.getSize()));
+  }
+
+  @Test
+  public void testCreateServerStoreReplicationShared() throws Exception {
+    UUID clientId = UUID.randomUUID();
+    PoolAllocation.Shared shared = new PoolAllocation.Shared("shared");
+    ServerStoreConfiguration configuration = new ServerStoreConfiguration(shared, "java.lang.Long", "java.lang.String", null, null,
+      "org.ehcache.impl.serialization.LongSerializer", "org.ehcache.impl.serialization.StringSerializer",
+      Consistency.STRONG);
+    PassiveReplicationMessage.CreateServerStoreReplicationMessage message = new PassiveReplicationMessage.CreateServerStoreReplicationMessage(MESSAGE_ID, clientId, "storeId", configuration);
+
+    byte[] encoded = codec.encode(message);
+    PassiveReplicationMessage.CreateServerStoreReplicationMessage decodedMessage = (PassiveReplicationMessage.CreateServerStoreReplicationMessage) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CREATE_SERVER_STORE_REPLICATION));
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getClientId(), is(clientId));
+    assertThat(decodedMessage.getStoreName(), is("storeId"));
+    assertThat(decodedMessage.getStoreConfiguration().getStoredKeyType(), is(configuration.getStoredKeyType()));
+    assertThat(decodedMessage.getStoreConfiguration().getStoredValueType(), is(configuration.getStoredValueType()));
+    assertThat(decodedMessage.getStoreConfiguration().getActualKeyType(), nullValue());
+    assertThat(decodedMessage.getStoreConfiguration().getActualValueType(), nullValue());
+    assertThat(decodedMessage.getStoreConfiguration().getConsistency(), is(configuration.getConsistency()));
+    assertThat(decodedMessage.getStoreConfiguration().getKeySerializerType(), is(configuration.getKeySerializerType()));
+    assertThat(decodedMessage.getStoreConfiguration().getValueSerializerType(), is(configuration.getValueSerializerType()));
+    PoolAllocation.Shared decodedPoolAllocation = (PoolAllocation.Shared) decodedMessage.getStoreConfiguration().getPoolAllocation();
+    assertThat(decodedPoolAllocation.getResourcePoolName(), is(shared.getResourcePoolName()));
+  }
+
+  @Test
+  public void testDestroyServerStoreReplication() throws Exception {
+    UUID clientId = UUID.randomUUID();
+    PassiveReplicationMessage.DestroyServerStoreReplicationMessage message = new PassiveReplicationMessage.DestroyServerStoreReplicationMessage(MESSAGE_ID, clientId, "storeId");
+
+    byte[] encoded = codec.encode(message);
+    PassiveReplicationMessage.DestroyServerStoreReplicationMessage decodedMessage = (PassiveReplicationMessage.DestroyServerStoreReplicationMessage) codec.decode(message.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.DESTROY_SERVER_STORE_REPLICATION));
+    assertThat(decodedMessage.getId(), is(MESSAGE_ID));
+    assertThat(decodedMessage.getClientId(), is(clientId));
+    assertThat(decodedMessage.getStoreName(), is("storeId"));
   }
 
 }

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpCodecTest.java
@@ -21,95 +21,130 @@ import org.junit.Test;
 
 import java.util.UUID;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.ehcache.clustered.common.internal.store.Util.createPayload;
 import static org.ehcache.clustered.common.internal.store.Util.getChain;
 import static org.ehcache.clustered.common.internal.store.Util.readPayLoad;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class ServerStoreOpCodecTest {
 
-  private static final ServerStoreMessageFactory MESSAGE_FACTORY = new ServerStoreMessageFactory("test", UUID.randomUUID());
+  private static final UUID CLIENT_ID = UUID.randomUUID();
+  private static final ServerStoreMessageFactory MESSAGE_FACTORY = new ServerStoreMessageFactory("test", CLIENT_ID);
   private static final ServerStoreOpCodec STORE_OP_CODEC = new ServerStoreOpCodec();
 
   @Test
   public void testAppendMessageCodec() {
 
-    EhcacheEntityMessage appendMessage = MESSAGE_FACTORY.appendOperation(1L, createPayload(1L));
+    ServerStoreOpMessage.AppendMessage appendMessage = MESSAGE_FACTORY.appendOperation(1L, createPayload(1L));
+    appendMessage.setId(42L);
 
-    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)appendMessage));
+    byte[] encoded = STORE_OP_CODEC.encode(appendMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(appendMessage.getMessageType(), wrap(encoded));
     ServerStoreOpMessage.AppendMessage decodedAppendMessage = (ServerStoreOpMessage.AppendMessage) decodedMsg;
 
     assertThat(decodedAppendMessage.getCacheId(), is("test"));
     assertThat(decodedAppendMessage.getKey(), is(1L));
     assertThat(readPayLoad(decodedAppendMessage.getPayload()), is(1L));
-    assertThat(decodedAppendMessage.getId(), is(-1L));
-    assertEquals(appendMessage.getClientId(), decodedAppendMessage.getClientId());
+    assertThat(decodedAppendMessage.getId(), is(42L));
+    assertThat(decodedAppendMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedAppendMessage.getMessageType(), is(EhcacheMessageType.APPEND));
   }
 
   @Test
   public void testGetMessageCodec() {
-    EhcacheEntityMessage getMessage = MESSAGE_FACTORY.getOperation(2L);
+    ServerStoreOpMessage getMessage = MESSAGE_FACTORY.getOperation(2L);
+    getMessage.setId(42L);
 
-    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)getMessage));
+    byte[] encoded = STORE_OP_CODEC.encode(getMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(getMessage.getMessageType(), wrap(encoded));
     ServerStoreOpMessage.GetMessage decodedGetMessage = (ServerStoreOpMessage.GetMessage) decodedMsg;
 
     assertThat(decodedGetMessage.getCacheId(), is("test"));
     assertThat(decodedGetMessage.getKey(), is(2L));
+    assertThat(decodedGetMessage.getId(), is(42L));
+    assertThat(decodedGetMessage.getMessageType(), is(EhcacheMessageType.GET_STORE));
+    try {
+      decodedGetMessage.getClientId();
+      fail("AssertionError expected");
+    } catch (AssertionError error) {
+      assertThat(error.getMessage(), containsString("Client Id is not supported"));
+    }
 
   }
 
   @Test
   public void testGetAndAppendMessageCodec() {
-    EhcacheEntityMessage getAndAppendMessage = MESSAGE_FACTORY.getAndAppendOperation(10L, createPayload(10L));
+    ServerStoreOpMessage getAndAppendMessage = MESSAGE_FACTORY.getAndAppendOperation(10L, createPayload(10L));
+    getAndAppendMessage.setId(123L);
 
-    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)getAndAppendMessage));
+    byte[] encoded = STORE_OP_CODEC.encode(getAndAppendMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(getAndAppendMessage.getMessageType(), wrap(encoded));
     ServerStoreOpMessage.GetAndAppendMessage decodedGetAndAppendMessage = (ServerStoreOpMessage.GetAndAppendMessage) decodedMsg;
 
     assertThat(decodedGetAndAppendMessage.getCacheId(), is("test"));
     assertThat(decodedGetAndAppendMessage.getKey(), is(10L));
     assertThat(readPayLoad(decodedGetAndAppendMessage.getPayload()), is(10L));
-    assertThat(decodedGetAndAppendMessage.getId(), is(-1L));
-    assertEquals(getAndAppendMessage.getClientId(), decodedGetAndAppendMessage.getClientId());
+    assertThat(decodedGetAndAppendMessage.getId(), is(123L));
+    assertThat(decodedGetAndAppendMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedGetAndAppendMessage.getMessageType(), is(EhcacheMessageType.GET_AND_APPEND));
   }
 
   @Test
   public void testReplaceAtHeadMessageCodec() {
-    EhcacheEntityMessage replaceAtHeadMessage = MESSAGE_FACTORY.replaceAtHeadOperation(10L,
+    ServerStoreOpMessage replaceAtHeadMessage = MESSAGE_FACTORY.replaceAtHeadOperation(10L,
         getChain(true, createPayload(10L), createPayload(100L), createPayload(1000L)),
         getChain(false, createPayload(2000L)));
+    replaceAtHeadMessage.setId(42L);
 
-    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(STORE_OP_CODEC.encode((ServerStoreOpMessage)replaceAtHeadMessage));
+    byte[] encoded = STORE_OP_CODEC.encode(replaceAtHeadMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(replaceAtHeadMessage.getMessageType(), wrap(encoded));
     ServerStoreOpMessage.ReplaceAtHeadMessage decodedReplaceAtHeadMessage = (ServerStoreOpMessage.ReplaceAtHeadMessage) decodedMsg;
 
     assertThat(decodedReplaceAtHeadMessage.getCacheId(), is("test"));
     assertThat(decodedReplaceAtHeadMessage.getKey(), is(10L));
-    assertThat(decodedReplaceAtHeadMessage.getId(), is(-1L));
+    assertThat(decodedReplaceAtHeadMessage.getId(), is(42L));
     Util.assertChainHas(decodedReplaceAtHeadMessage.getExpect(), 10L, 100L, 1000L);
     Util.assertChainHas(decodedReplaceAtHeadMessage.getUpdate(), 2000L);
-    assertEquals(replaceAtHeadMessage.getClientId(), decodedReplaceAtHeadMessage.getClientId());
+    assertThat(decodedReplaceAtHeadMessage.getClientId(), is(CLIENT_ID));
+    assertThat(decodedReplaceAtHeadMessage.getMessageType(), is(EhcacheMessageType.REPLACE));
   }
 
   @Test
   public void testClearMessageCodec() throws Exception {
-    EhcacheEntityMessage clearMessage = MESSAGE_FACTORY.clearOperation();
-    byte[] encodedBytes = STORE_OP_CODEC.encode((ServerStoreOpMessage)clearMessage);
-    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(encodedBytes);
-    assertThat(((ServerStoreOpMessage)decodedMsg).getCacheId(), is("test"));
-    assertThat(decodedMsg.getId(), is(-1L));
-    assertEquals(clearMessage.getClientId(), decodedMsg.getClientId());
+    ServerStoreOpMessage clearMessage = MESSAGE_FACTORY.clearOperation();
+    clearMessage.setId(42L);
+
+    byte[] encoded = STORE_OP_CODEC.encode(clearMessage);
+    ServerStoreOpMessage decodedMsg = (ServerStoreOpMessage) STORE_OP_CODEC.decode(clearMessage.getMessageType(), wrap(encoded));
+
+    assertThat(decodedMsg.getCacheId(), is("test"));
+    assertThat(decodedMsg.getId(), is(42L));
+    assertThat(decodedMsg.getClientId(), is(CLIENT_ID));
+    assertThat(decodedMsg.getMessageType(), is(EhcacheMessageType.CLEAR));
   }
 
   @Test
   public void testClientInvalidationAckMessageCodec() throws Exception {
-    EhcacheEntityMessage invalidationAckMessage = MESSAGE_FACTORY.clientInvalidationAck(123);
-    byte[] encodedBytes = STORE_OP_CODEC.encode((ServerStoreOpMessage)invalidationAckMessage);
-    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(encodedBytes);
+    ServerStoreOpMessage invalidationAckMessage = MESSAGE_FACTORY.clientInvalidationAck(123);
+    invalidationAckMessage.setId(456L);
+
+    byte[] encoded = STORE_OP_CODEC.encode(invalidationAckMessage);
+    EhcacheEntityMessage decodedMsg = STORE_OP_CODEC.decode(invalidationAckMessage.getMessageType(), wrap(encoded));
     ServerStoreOpMessage.ClientInvalidationAck decodedInvalidationAckMessage = (ServerStoreOpMessage.ClientInvalidationAck)decodedMsg;
 
     assertThat(decodedInvalidationAckMessage.getCacheId(), is("test"));
     assertThat(decodedInvalidationAckMessage.getInvalidationId(), is(123));
+    assertThat(decodedInvalidationAckMessage.getId(), is(456L));
+    assertThat(decodedInvalidationAckMessage.getMessageType(), is(EhcacheMessageType.CLIENT_INVALIDATION_ACK));
+    try {
+      decodedInvalidationAckMessage.getClientId();
+      fail("AssertionError expected");
+    } catch (AssertionError error) {
+      assertThat(error.getMessage(), containsString("Client Id is not supported"));
+    }
   }
 }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/TerminatedServerTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/TerminatedServerTest.java
@@ -515,7 +515,7 @@ public class TerminatedServerTest {
       }.run();
       fail("Expecting StoreAccessTimeoutException");
     } catch (StoreAccessTimeoutException e) {
-      assertThat(e.getMessage(), containsString("Timeout exceeded for SERVER_STORE_OP#GET_AND_APPEND"));
+      assertThat(e.getMessage(), containsString("Timeout exceeded for GET_AND_APPEND"));
     }
   }
 
@@ -551,7 +551,7 @@ public class TerminatedServerTest {
       }.run();
       fail("Expecting StoreAccessTimeoutException");
     } catch (StoreAccessTimeoutException e) {
-      assertThat(e.getMessage(), containsString("Timeout exceeded for SERVER_STORE_OP#GET_AND_APPEND"));
+      assertThat(e.getMessage(), containsString("Timeout exceeded for GET_AND_APPEND"));
     }
   }
 
@@ -588,7 +588,7 @@ public class TerminatedServerTest {
       }.run();
       fail("Expecting StoreAccessTimeoutException");
     } catch (StoreAccessTimeoutException e) {
-      assertThat(e.getMessage(), containsString("Timeout exceeded for SERVER_STORE_OP#GET_AND_APPEND"));
+      assertThat(e.getMessage(), containsString("Timeout exceeded for GET_AND_APPEND"));
     }
   }
 
@@ -625,7 +625,7 @@ public class TerminatedServerTest {
       }.run();
       fail("Expecting StoreAccessTimeoutException");
     } catch (StoreAccessTimeoutException e) {
-      assertThat(e.getMessage(), containsString("Timeout exceeded for SERVER_STORE_OP#CLEAR"));
+      assertThat(e.getMessage(), containsString("Timeout exceeded for CLEAR"));
     }
   }
 

--- a/clustered/server/build.gradle
+++ b/clustered/server/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile"org.terracotta.management.dist:management-common:$parent.managementVersion"
   provided "org.terracotta:entity-server-api:$parent.entityApiVersion"
   provided "org.terracotta:standard-cluster-services:$parent.terracottaApisVersion"
+  provided "org.terracotta:runnel:$parent.terracottaPlatformVersion"
 }
 
 compileJava {

--- a/clustered/server/build.gradle
+++ b/clustered/server/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   compile ("org.terracotta:statistics:$parent.statisticVersion") {
     exclude group:'org.slf4j', module:'slf4j-api'
   }
-  compile project(':clustered:common')
+  compile project(':clustered:common'), "org.slf4j:slf4j-api:$parent.slf4jVersion"
   compile group: 'org.terracotta', name: 'offheap-resource', version: parent.offheapResourceVersion
   compile group: 'org.terracotta', name: 'offheap-store', version: parent.offheapVersion
   compile group: 'org.slf4j', name: 'slf4j-api', version: parent.slf4jVersion

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -47,6 +47,7 @@ import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponseFactory;
 import org.ehcache.clustered.common.internal.messages.LifecycleMessage;
+import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClearInvalidationCompleteMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClientIDTrackerMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.InvalidationCompleteMessage;
@@ -770,7 +771,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
     serverStore.setEvictionListener(key -> invalidateHashAfterEviction(name, key));
     attachStore(clientDescriptor, name);
     try {
-      entityMessenger.messageSelfAndDeferRetirement(createServerStore, new ClientIDTrackerMessage.ServerStoreLifeCycleReplicationMessage(createServerStore));
+      entityMessenger.messageSelfAndDeferRetirement(createServerStore, new PassiveReplicationMessage.CreateServerStoreReplicationMessage(createServerStore));
     } catch (MessageCodecException e) {
       throw new AssertionError("Codec error", e);
     }
@@ -861,7 +862,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
 
     storeClientMap.remove(name);
     try {
-      entityMessenger.messageSelfAndDeferRetirement(destroyServerStore, new ClientIDTrackerMessage.ServerStoreLifeCycleReplicationMessage(destroyServerStore));
+      entityMessenger.messageSelfAndDeferRetirement(destroyServerStore, new PassiveReplicationMessage.DestroyServerStoreReplicationMessage(destroyServerStore));
     } catch (MessageCodecException e) {
       throw new AssertionError("Codec error", e);
     }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -58,8 +58,8 @@ import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage.KeyBa
 import org.ehcache.clustered.common.internal.messages.StateRepositoryOpMessage;
 import org.ehcache.clustered.common.internal.store.Chain;
 import org.ehcache.clustered.common.internal.store.ServerStore;
-import org.ehcache.clustered.server.internal.messages.EntityDataSyncMessage;
-import org.ehcache.clustered.server.internal.messages.EntityStateSyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheDataSyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheStateSyncMessage;
 import org.ehcache.clustered.server.management.Management;
 import org.ehcache.clustered.server.state.EhcacheStateService;
 import org.ehcache.clustered.server.state.InvalidationTracker;
@@ -353,14 +353,14 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
         storeConfigs.put(storeName, store.getStoreConfiguration());
       }
 
-      syncChannel.synchronizeToPassive(new EntityStateSyncMessage(configuration, storeConfigs, trackedClients));
+      syncChannel.synchronizeToPassive(new EhcacheStateSyncMessage(configuration, storeConfigs, trackedClients));
     } else {
       ehcacheStateService.getStores().stream()
         .forEach(name -> {
           ServerStoreImpl store = ehcacheStateService.getStore(name);
           store.getSegments().get(concurrencyKey - DATA_CONCURRENCY_KEY_OFFSET).keySet().stream()
             .forEach(key -> {
-              syncChannel.synchronizeToPassive(new EntityDataSyncMessage(name, key, store.get(key)));
+              syncChannel.synchronizeToPassive(new EhcacheDataSyncMessage(name, key, store.get(key)));
             });
         });
     }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheExecutionStrategy.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheExecutionStrategy.java
@@ -21,7 +21,7 @@ import org.ehcache.clustered.common.internal.messages.LifecycleMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage;
 import org.ehcache.clustered.common.internal.messages.StateRepositoryOpMessage;
-import org.ehcache.clustered.server.internal.messages.EntitySyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheSyncMessage;
 import org.terracotta.entity.ExecutionStrategy;
 
 /**
@@ -56,7 +56,7 @@ class EhcacheExecutionStrategy implements ExecutionStrategy<EhcacheEntityMessage
       return Location.ACTIVE;
     } else if (message instanceof PassiveReplicationMessage) {
       return Location.PASSIVE;
-    } else if (message instanceof EntitySyncMessage) {
+    } else if (message instanceof EhcacheSyncMessage) {
       throw new AssertionError("Unexpected use of ExecutionStrategy for sync messages");
     }
     throw new AssertionError("Unknown message type: " + message.getClass());

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
@@ -37,9 +37,9 @@ import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ServerStoreLifeCycleReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage;
 import org.ehcache.clustered.common.internal.messages.StateRepositoryOpMessage;
-import org.ehcache.clustered.server.internal.messages.EntityDataSyncMessage;
-import org.ehcache.clustered.server.internal.messages.EntityStateSyncMessage;
-import org.ehcache.clustered.server.internal.messages.EntitySyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheDataSyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheStateSyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheSyncMessage;
 import org.ehcache.clustered.server.management.Management;
 import org.ehcache.clustered.server.state.ClientMessageTracker;
 import org.ehcache.clustered.server.state.EhcacheStateService;
@@ -86,7 +86,7 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
           ehcacheStateService.getStateRepositoryManager().invoke((StateRepositoryOpMessage)message);
           break;
         case SYNC_OP:
-          invokeSyncOperation((EntitySyncMessage) message);
+          invokeSyncOperation((EhcacheSyncMessage) message);
           break;
         case REPLICATION_OP:
           invokeRetirementMessages((PassiveReplicationMessage)message);
@@ -220,10 +220,10 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
     }
   }
 
-  private void invokeSyncOperation(EntitySyncMessage message) throws ClusterException {
+  private void invokeSyncOperation(EhcacheSyncMessage message) throws ClusterException {
     switch (message.operation()) {
       case STATE:
-        EntityStateSyncMessage stateSyncMessage = (EntityStateSyncMessage) message;
+        EhcacheStateSyncMessage stateSyncMessage = (EhcacheStateSyncMessage) message;
 
         ehcacheStateService.configure(stateSyncMessage.getConfiguration());
         management.sharedPoolsConfigured();
@@ -238,7 +238,7 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
         stateSyncMessage.getTrackedClients().stream().forEach(id -> ehcacheStateService.getClientMessageTracker().add(id));
         break;
       case DATA:
-        EntityDataSyncMessage dataSyncMessage = (EntityDataSyncMessage) message;
+        EhcacheDataSyncMessage dataSyncMessage = (EhcacheDataSyncMessage) message;
         ehcacheStateService.getStore(dataSyncMessage.getCacheId()).put(dataSyncMessage.getKey(), dataSyncMessage.getChain());
         break;
       default:

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
@@ -34,7 +34,6 @@ import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ChainReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClearInvalidationCompleteMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.InvalidationCompleteMessage;
-import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ServerStoreLifeCycleReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpMessage;
 import org.ehcache.clustered.common.internal.messages.StateRepositoryOpMessage;
 import org.ehcache.clustered.server.internal.messages.EhcacheDataSyncMessage;
@@ -56,6 +55,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
+import static org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ReplicationOp.CLIENTID_TRACK_OP;
+import static org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ReplicationOp.SERVER_STORE_LIFECYCLE_REPLICATION_OP;
 
 class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> {
 
@@ -117,7 +119,7 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
 
   private void invokeRetirementMessages(PassiveReplicationMessage message) throws ClusterException {
 
-    switch (message.operation()) {
+    switch (message.getMessageType()) {
       case CHAIN_REPLICATION_OP:
         LOGGER.debug("Chain Replication message for msgId {} & client Id {}", message.getId(), message.getClientId());
         ChainReplicationMessage retirementMessage = (ChainReplicationMessage)message;
@@ -130,7 +132,7 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
         ehcacheStateService.getClientMessageTracker().applied(message.getId(), message.getClientId());
         trackHashInvalidationForEventualCache(retirementMessage);
         break;
-      case CLIENTID_TRACK_OP:
+      case CLIENT_ID_TRACK_OP:
         LOGGER.debug("PassiveReplicationMessage message for msgId {} & client Id {}", message.getId(), message.getClientId());
         ehcacheStateService.getClientMessageTracker().add(message.getClientId());
         break;
@@ -140,8 +142,15 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
       case CLEAR_INVALIDATION_COMPLETE:
         ehcacheStateService.getInvalidationTracker(((ClearInvalidationCompleteMessage)message).getCacheId()).setClearInProgress(false);
         break;
-      case SERVER_STORE_LIFECYCLE_REPLICATION_OP:
-        invokeRetiredServerStoreLifecycleMessage((ServerStoreLifeCycleReplicationMessage)message);
+      case CREATE_SERVER_STORE_REPLICATION:
+        ehcacheStateService.getClientMessageTracker().applied(message.getId(), message.getClientId());
+        PassiveReplicationMessage.CreateServerStoreReplicationMessage createMessage = (PassiveReplicationMessage.CreateServerStoreReplicationMessage) message;
+        createServerStore(createMessage.getStoreName(), createMessage.getStoreConfiguration());
+        break;
+      case DESTROY_SERVER_STORE_REPLICATION:
+        ehcacheStateService.getClientMessageTracker().applied(message.getId(), message.getClientId());
+        PassiveReplicationMessage.DestroyServerStoreReplicationMessage destroyMessage = (PassiveReplicationMessage.DestroyServerStoreReplicationMessage) message;
+        destroyServerStore(destroyMessage.getStoreName());
         break;
       default:
         throw new IllegalMessageException("Unknown Retirement Message : " + message);
@@ -170,23 +179,6 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
       });
     }
   }
-
-  private void invokeRetiredServerStoreLifecycleMessage(ServerStoreLifeCycleReplicationMessage storeLifeCycleReplicationMessage) throws ClusterException {
-
-    LifecycleMessage message = storeLifeCycleReplicationMessage.getMessage();
-    ehcacheStateService.getClientMessageTracker().applied(message.getId(), message.getClientId());
-    switch (message.operation()) {
-      case CREATE_SERVER_STORE:
-        createServerStore((CreateServerStore)message);
-        break;
-      case DESTROY_SERVER_STORE:
-        destroyServerStore((DestroyServerStore)message);
-        break;
-      default:
-        throw new IllegalMessageException("Unknown Replicated ServerStore operation : " + message);
-    }
-  }
-
 
   private void invokeServerStoreOperation(ServerStoreOpMessage message) throws ClusterException {
     ServerStoreImpl cacheStore = ehcacheStateService.getStore(message.getCacheId());
@@ -278,37 +270,32 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
     clientMessageTracker.applied(message.getId(), message.getClientId());
   }
 
-  private void createServerStore(CreateServerStore createServerStore) throws ClusterException {
+  private void createServerStore(String storeName, ServerStoreConfiguration configuration) throws ClusterException {
     if (!ehcacheStateService.isConfigured()) {
       throw new LifecycleException("Clustered Tier Manager is not configured");
     }
-    if(createServerStore.getStoreConfiguration().getPoolAllocation() instanceof PoolAllocation.Unknown) {
+    if(configuration.getPoolAllocation() instanceof PoolAllocation.Unknown) {
       throw new LifecycleException("Clustered tier can't be created with an Unknown resource pool");
     }
 
-    final String name = createServerStore.getName();    // client cache identifier/name
+    LOGGER.info("Creating new clustered tier '{}'", storeName);
 
-    LOGGER.info("Creating new clustered tier '{}'", name);
-
-    ServerStoreConfiguration storeConfiguration = createServerStore.getStoreConfiguration();
-    ehcacheStateService.createStore(name, storeConfiguration);
-    if(storeConfiguration.getConsistency() == Consistency.EVENTUAL) {
-      ehcacheStateService.addInvalidationtracker(name);
+    ehcacheStateService.createStore(storeName, configuration);
+    if(configuration.getConsistency() == Consistency.EVENTUAL) {
+      ehcacheStateService.addInvalidationtracker(storeName);
     }
-    management.serverStoreCreated(name);
+    management.serverStoreCreated(storeName);
   }
 
-  private void destroyServerStore(DestroyServerStore destroyServerStore) throws ClusterException {
+  private void destroyServerStore(String storeName) throws ClusterException {
     if (!ehcacheStateService.isConfigured()) {
       throw new LifecycleException("Clustered Tier Manager is not configured");
     }
 
-    String name = destroyServerStore.getName();
-
-    LOGGER.info("Destroying clustered tier '{}'", name);
-    management.serverStoreDestroyed(name);
-    ehcacheStateService.destroyServerStore(name);
-    ehcacheStateService.removeInvalidationtracker(name);
+    LOGGER.info("Destroying clustered tier '{}'", storeName);
+    management.serverStoreDestroyed(storeName);
+    ehcacheStateService.destroyServerStore(storeName);
+    ehcacheStateService.removeInvalidationtracker(storeName);
   }
 
   @Override

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheDataSyncMessage.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheDataSyncMessage.java
@@ -21,13 +21,13 @@ import org.ehcache.clustered.common.internal.store.Chain;
 import com.tc.classloader.CommonComponent;
 
 @CommonComponent
-public class EntityDataSyncMessage extends EntitySyncMessage {
+public class EhcacheDataSyncMessage extends EhcacheSyncMessage {
 
   private final String cacheId;
   private final long key;
   private final Chain chain;
 
-  public EntityDataSyncMessage(final String cacheId, final long key, final Chain chain) {
+  public EhcacheDataSyncMessage(final String cacheId, final long key, final Chain chain) {
     this.cacheId = cacheId;
     this.key = key;
     this.chain = chain;

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheStateSyncMessage.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheStateSyncMessage.java
@@ -21,23 +21,21 @@ import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 
 import com.tc.classloader.CommonComponent;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 @CommonComponent
-public class EntityStateSyncMessage extends EntitySyncMessage implements Serializable {
+public class EhcacheStateSyncMessage extends EhcacheSyncMessage implements Serializable {
 
   private final ServerSideConfiguration configuration;
   private final Map<String, ServerStoreConfiguration> storeConfigs;
   private final Set<UUID> trackedClients;
 
-  public EntityStateSyncMessage(final ServerSideConfiguration configuration,
-                                       final Map<String, ServerStoreConfiguration> storeConfigs,
-                                       final Set<UUID> trackedClients) {
+  public EhcacheStateSyncMessage(final ServerSideConfiguration configuration,
+                                 final Map<String, ServerStoreConfiguration> storeConfigs,
+                                 final Set<UUID> trackedClients) {
     this.configuration = configuration;
     this.storeConfigs = storeConfigs;
     this.trackedClients = trackedClients;

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessage.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessage.java
@@ -23,7 +23,7 @@ import com.tc.classloader.CommonComponent;
 import java.util.UUID;
 
 @CommonComponent
-public abstract class EntitySyncMessage extends EhcacheEntityMessage {
+public abstract class EhcacheSyncMessage extends EhcacheEntityMessage {
 
   @CommonComponent
   public enum SyncOp {

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
@@ -42,7 +42,6 @@ import org.ehcache.clustered.common.internal.messages.LifecycleMessage.DestroySe
 import org.ehcache.clustered.common.internal.messages.LifecycleMessage.ValidateStoreManager;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClientIDTrackerMessage;
-import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ServerStoreLifeCycleReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreMessageFactory;
 import org.ehcache.clustered.server.internal.messages.EhcacheStateSyncMessage;
 import org.ehcache.clustered.server.state.ClientMessageTracker;
@@ -2762,7 +2761,7 @@ public class EhcacheActiveEntityTest {
                 .build()));
 
     verify(entityMessenger, times(0)).messageSelf(any());
-    verify(entityMessenger, times(1)).messageSelfAndDeferRetirement(any(CreateServerStore.class), any(ServerStoreLifeCycleReplicationMessage.class));
+    verify(entityMessenger, times(1)).messageSelfAndDeferRetirement(any(CreateServerStore.class), any(PassiveReplicationMessage.class));
 
   }
 
@@ -2835,7 +2834,7 @@ public class EhcacheActiveEntityTest {
         MESSAGE_FACTORY.destroyServerStore("test"));
 
     verify(entityMessenger, times(0)).messageSelf(any());
-    verify(entityMessenger, times(1)).messageSelfAndDeferRetirement(any(DestroyServerStore.class), any(ServerStoreLifeCycleReplicationMessage.class));
+    verify(entityMessenger, times(1)).messageSelfAndDeferRetirement(any(DestroyServerStore.class), any(PassiveReplicationMessage.class));
 
   }
 

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
@@ -44,7 +44,7 @@ import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClientIDTrackerMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ServerStoreLifeCycleReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.ServerStoreMessageFactory;
-import org.ehcache.clustered.server.internal.messages.EntityStateSyncMessage;
+import org.ehcache.clustered.server.internal.messages.EhcacheStateSyncMessage;
 import org.ehcache.clustered.server.state.ClientMessageTracker;
 import org.ehcache.clustered.server.state.EhcacheStateService;
 import org.ehcache.clustered.server.state.InvalidationTracker;
@@ -2640,10 +2640,10 @@ public class EhcacheActiveEntityTest {
     PassiveSynchronizationChannel<EhcacheEntityMessage> syncChannel = mock(PassiveSynchronizationChannel.class);
     activeEntity.synchronizeKeyToPassive(syncChannel, 1);
 
-    ArgumentCaptor<EntityStateSyncMessage> captor = ArgumentCaptor.forClass(EntityStateSyncMessage.class);
+    ArgumentCaptor<EhcacheStateSyncMessage> captor = ArgumentCaptor.forClass(EhcacheStateSyncMessage.class);
     verify(syncChannel).synchronizeToPassive(captor.capture());
 
-    EntityStateSyncMessage capturedSyncMessage = captor.getValue();
+    EhcacheStateSyncMessage capturedSyncMessage = captor.getValue();
     ServerSideConfiguration configuration = capturedSyncMessage.getConfiguration();
     assertThat(configuration.getDefaultServerResource(), is("serverResource1"));
     assertThat(configuration.getResourcePools().keySet(), containsInAnyOrder("primary", "secondary"));

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcachePassiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcachePassiveEntityTest.java
@@ -23,9 +23,9 @@ import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage;
 import org.ehcache.clustered.common.internal.messages.LifeCycleMessageFactory;
+import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ClientIDTrackerMessage;
 import org.ehcache.clustered.common.internal.messages.LifecycleMessage;
-import org.ehcache.clustered.common.internal.messages.PassiveReplicationMessage.ServerStoreLifeCycleReplicationMessage;
 import org.ehcache.clustered.server.state.EhcacheStateService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -256,7 +256,7 @@ public class EhcachePassiveEntityTest {
             .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
             .build());
     passiveEntity.invoke(createServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)createServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore)createServerStore));
 
     assertThat(registry.getStoreManagerService()
         .getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
@@ -296,7 +296,7 @@ public class EhcachePassiveEntityTest {
             .shared("primary")
             .build());
     passiveEntity.invoke(createServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)createServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore)createServerStore));
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("cacheAlias"));
 
     assertThat(registry.getStoreManagerService()
@@ -332,7 +332,7 @@ public class EhcachePassiveEntityTest {
             .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
             .build());
     passiveEntity.invoke(createServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)createServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) createServerStore));
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("dedicatedCache"));
     assertThat(registry.getStoreManagerService().getDedicatedResourcePoolIds(), containsInAnyOrder("dedicatedCache"));
 
@@ -347,7 +347,7 @@ public class EhcachePassiveEntityTest {
             .shared("secondary")
             .build());
     passiveEntity.invoke(sharedServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)sharedServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) sharedServerStore));
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("dedicatedCache", "sharedCache"));
 
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("dedicatedCache", "sharedCache"));
@@ -355,7 +355,7 @@ public class EhcachePassiveEntityTest {
 
     EhcacheEntityMessage destroySharedCache = MESSAGE_FACTORY.destroyServerStore("sharedCache");
     passiveEntity.invoke(destroySharedCache);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)destroySharedCache));
+    passiveEntity.invoke(new PassiveReplicationMessage.DestroyServerStoreReplicationMessage((LifecycleMessage.DestroyServerStore) destroySharedCache));
 
     assertThat(registry.getResource("serverResource1").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(4L + 4L)));
     assertThat(registry.getResource("serverResource2").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(8L)));
@@ -364,7 +364,7 @@ public class EhcachePassiveEntityTest {
 
     EhcacheEntityMessage destroyDedicatedCache = MESSAGE_FACTORY.destroyServerStore("dedicatedCache");
     passiveEntity.invoke(destroyDedicatedCache);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)destroyDedicatedCache));
+    passiveEntity.invoke(new PassiveReplicationMessage.DestroyServerStoreReplicationMessage((LifecycleMessage.DestroyServerStore) destroyDedicatedCache));
 
     assertThat(registry.getStoreManagerService().getStores(), is(Matchers.<String>empty()));
     assertThat(registry.getStoreManagerService().getDedicatedResourcePoolIds(), is(Matchers.<String>empty()));
@@ -400,7 +400,7 @@ public class EhcachePassiveEntityTest {
             .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
             .build());
     passiveEntity.invoke(createServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)createServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) createServerStore));
     assertThat(registry.getStoreManagerService()
         .getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
     assertThat(registry.getStoreManagerService().getDedicatedResourcePoolIds(), containsInAnyOrder("dedicatedCache"));
@@ -411,7 +411,7 @@ public class EhcachePassiveEntityTest {
             .shared("primary")
             .build());
     passiveEntity.invoke(sharedServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)sharedServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) sharedServerStore));
     assertThat(registry.getStoreManagerService()
         .getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
     assertThat(registry.getStoreManagerService().getDedicatedResourcePoolIds(), containsInAnyOrder("dedicatedCache"));
@@ -422,7 +422,7 @@ public class EhcachePassiveEntityTest {
             .dedicated("serverResource2", 4, MemoryUnit.MEGABYTES)
             .build());
     passiveEntity.invoke(createServerStore2);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)createServerStore2));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) createServerStore2));
     assertThat(registry.getStoreManagerService()
         .getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
     assertThat(registry.getStoreManagerService()
@@ -471,7 +471,7 @@ public class EhcachePassiveEntityTest {
             .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
             .build());
     passiveEntity.invoke(createServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)createServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) createServerStore));
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("dedicatedCache"));
 
     assertThat(registry.getResource("serverResource1").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(4L + 4L)));
@@ -482,7 +482,7 @@ public class EhcachePassiveEntityTest {
             .shared("secondary")
             .build());
     passiveEntity.invoke(sharedServerStore);
-    passiveEntity.invoke(new ServerStoreLifeCycleReplicationMessage((LifecycleMessage)sharedServerStore));
+    passiveEntity.invoke(new PassiveReplicationMessage.CreateServerStoreReplicationMessage((LifecycleMessage.CreateServerStore) sharedServerStore));
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("dedicatedCache", "sharedCache"));
 
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("dedicatedCache", "sharedCache"));

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessageCodecTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessageCodecTest.java
@@ -72,9 +72,9 @@ public class EhcacheSyncMessageCodecTest {
     clientIds.add(clientId1);
     clientIds.add(clientId2);
 
-    EntityStateSyncMessage message = new EntityStateSyncMessage(serverSideConfig, storeConfigs, clientIds);
+    EhcacheStateSyncMessage message = new EhcacheStateSyncMessage(serverSideConfig, storeConfigs, clientIds);
     EhcacheSyncMessageCodec codec = new EhcacheSyncMessageCodec();
-    EntityStateSyncMessage decodedMessage = (EntityStateSyncMessage) codec.decode(0, codec.encode(0, message));
+    EhcacheStateSyncMessage decodedMessage = (EhcacheStateSyncMessage) codec.decode(0, codec.encode(0, message));
 
     assertThat(decodedMessage.getConfiguration().getDefaultServerResource(), is("default-pool"));
     assertThat(decodedMessage.getConfiguration().getResourcePools(), is(sharedPools));
@@ -120,9 +120,9 @@ public class EhcacheSyncMessageCodecTest {
   @Test
   public void testDataSyncMessageEncodeDecode() throws Exception {
     EhcacheSyncMessageCodec codec = new EhcacheSyncMessageCodec();
-    EntityDataSyncMessage message = new EntityDataSyncMessage("foo", 123L,
+    EhcacheDataSyncMessage message = new EhcacheDataSyncMessage("foo", 123L,
         getChain(true, createPayload(10L), createPayload(100L), createPayload(1000L)));
-    EntityDataSyncMessage decoded = (EntityDataSyncMessage) codec.decode(0, codec.encode(0, message));
+    EhcacheDataSyncMessage decoded = (EhcacheDataSyncMessage) codec.decode(0, codec.encode(0, message));
     assertThat(decoded.getCacheId(), is(message.getCacheId()));
     assertThat(decoded.getKey(), is(message.getKey()));
     assertThat(chainsEqual(decoded.getChain(), message.getChain()), is(true));


### PR DESCRIPTION
This PR introduces runnel in Ehcache and covers all client -> server messages and the replication messages from active -> passive.

Follow up PRs will take care or responses and passive sync messages.