### PR TITLE
Bumping stats tests timeouts

### DIFF
--- a/management/src/test/java/org/ehcache/management/providers/statistics/EvictionTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/EvictionTest.java
@@ -98,7 +98,7 @@ public class EvictionTest {
   public final TemporaryFolder diskPath = new TemporaryFolder();
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(10);
+  public final Timeout globalTimeout = Timeout.seconds(60);
 
   public EvictionTest(Builder<? extends ResourcePools> resources, int iterations, List<Long> expected, byte[] value, List<String> stats) {
     this.resources = resources.build();

--- a/management/src/test/java/org/ehcache/management/providers/statistics/HitCountTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/HitCountTest.java
@@ -51,7 +51,7 @@ import org.terracotta.management.model.context.Context;
 public class HitCountTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(10);
+  public final Timeout globalTimeout = Timeout.seconds(60);
 
   @Rule
   public final TemporaryFolder diskPath = new TemporaryFolder();

--- a/management/src/test/java/org/ehcache/management/providers/statistics/HitRatioTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/HitRatioTest.java
@@ -56,7 +56,7 @@ import static org.hamcrest.CoreMatchers.is;
 public class HitRatioTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(30);
+  public final Timeout globalTimeout = Timeout.seconds(60);
 
   @Rule
   public final TemporaryFolder diskPath = new TemporaryFolder();

--- a/management/src/test/java/org/ehcache/management/providers/statistics/MissCountTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/MissCountTest.java
@@ -50,7 +50,7 @@ import org.terracotta.management.model.context.Context;
 public class MissCountTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(10);
+  public final Timeout globalTimeout = Timeout.seconds(60);
 
   @Rule
   public final TemporaryFolder diskPath = new TemporaryFolder();

--- a/management/src/test/java/org/ehcache/management/providers/statistics/MissRatioTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/MissRatioTest.java
@@ -52,7 +52,7 @@ import org.terracotta.management.model.context.Context;
 public class MissRatioTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(10);
+  public final Timeout globalTimeout = Timeout.seconds(60);
 
   @Rule
   public final TemporaryFolder diskPath = new TemporaryFolder();


### PR DESCRIPTION
As an attempt to restore build stability.

However if that does not cut it then the tests will need to be looked with more care.