### PR TITLE
Close #1624: fixes randomly failing ratio unit tests

### DIFF
--- a/management/src/test/java/org/ehcache/management/providers/statistics/HitRatioTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/HitRatioTest.java
@@ -170,7 +170,7 @@ public class HitRatioTest {
         Assert.assertThat(tierHitRatio, is(tierExpectedValues.get(i)));
       }
 
-      double hitRatio = StatsUtil.getExpectedValueFromRatioHistory("Cache:HitRatio", context, managementRegistry, cacheExpectedValue);
+      Double hitRatio = StatsUtil.getExpectedValueFromRatioHistory("Cache:HitRatio", context, managementRegistry, cacheExpectedValue);
       Assert.assertThat(hitRatio, is(cacheExpectedValue));
 
     }

--- a/management/src/test/java/org/ehcache/management/providers/statistics/MissRatioTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/MissRatioTest.java
@@ -155,7 +155,7 @@ public class MissRatioTest {
         Assert.assertThat(tierMissRatio, is(tierExpectedValues.get(i)));
       }
 
-      double hitRatio = StatsUtil.getExpectedValueFromRatioHistory("Cache:MissRatio", context, managementRegistry, cacheExpectedValue);
+      Double hitRatio = StatsUtil.getExpectedValueFromRatioHistory("Cache:MissRatio", context, managementRegistry, cacheExpectedValue);
       Assert.assertThat(hitRatio, is(cacheExpectedValue));
 
     }

--- a/management/src/test/java/org/ehcache/management/providers/statistics/StatsUtil.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/StatsUtil.java
@@ -99,14 +99,14 @@ public class StatsUtil {
          This should only occur if the stats value is different from your expectedResult, which may happen if the stats calculations
          change, the stats value isn't accessible or if you enter the wrong expectedResult.
   */
-  public static double getExpectedValueFromRatioHistory(String statName, Context context, ManagementRegistryService managementRegistry, double expectedResult) {
+  public static Double getExpectedValueFromRatioHistory(String statName, Context context, ManagementRegistryService managementRegistry, Double expectedResult) {
 
     StatisticQuery query = managementRegistry.withCapability("StatisticsCapability")
       .queryStatistics(Arrays.asList(statName))
       .on(context)
       .build();
 
-    double value = 0;
+    Double value = 0d;
     do {
       ResultSet<ContextualStatistics> counters = query.execute();
 
@@ -120,7 +120,7 @@ public class StatsUtil {
         int mostRecentIndex = ratioHistory.getValue().length - 1;
         value = ratioHistory.getValue()[mostRecentIndex].getValue();
       }
-    } while (!Thread.currentThread().isInterrupted() && value != expectedResult);
+    } while (!Thread.currentThread().isInterrupted() && !value.equals(expectedResult));
 
     assertThat(value, Matchers.is(expectedResult));
 
@@ -149,7 +149,7 @@ public class StatsUtil {
         .getStatistics();
 
       for (Map.Entry<String, Statistic<?, ?>> entry : statistics.entrySet()) {
-        if (((StatisticHistory<?, ?>) entry.getValue()).getValue().length == 0) {
+        if (((StatisticHistory<?, ?>) entry.getValue()).getValue().length < 2) {
           noSample = true;
           break;
         }


### PR DESCRIPTION
I added a Thread.sleep after the get calls to allow the ratio stats to be computed.

This is the original task:
https://github.com/ehcache/ehcache3/issues/1624