### PR TITLE
Upgrade to new tc-platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.13.beta2'
+  terracottaPlatformVersion = '5.0.13.beta3'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.0.13.beta'
   terracottaCoreVersion = '5.0.13-beta'

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -674,9 +674,6 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
    */
   @Override
   public void destroy() {
-
-    management.close();
-
     /*
      * Ensure the allocated stores are closed out.
      */

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
@@ -303,7 +303,6 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
 
   @Override
   public void destroy() {
-    management.close();
     ehcacheStateService.destroy();
   }
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/Management.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/Management.java
@@ -97,13 +97,6 @@ public class Management {
     }
   }
 
-  public void close() {
-    if (managementRegistry != null) {
-      LOGGER.trace("close()");
-      managementRegistry.close();
-    }
-  }
-
   public void clientConnected(ClientDescriptor clientDescriptor, ClientState clientState) {
     if (managementRegistry != null) {
       LOGGER.trace("clientConnected({})", clientDescriptor);


### PR DESCRIPTION
to fix management service lifecycle, closing entity requested services from the monitoring service when the entity is gone, to avoid having ehcache knowing it needs to close the management service

In 5.0.13.beta3, I got rid of all weak references and do the cleanup of client descriptors and consumer services thanks to some listeners on the topology changes (when client disconnects and entities are destroyed). This change allows also to get rid of the close() methods that were required before.