### PR TITLE
Bump dependencies to the latest Terracotta release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,13 @@ ext {
   // Clustered
   terracottaPlatformVersion = '5.0.13.beta3'
   managementVersion = terracottaPlatformVersion
-  terracottaApisVersion = '1.0.13.beta'
-  terracottaCoreVersion = '5.0.13-beta'
+  terracottaApisVersion = '1.0.14.beta'
+  terracottaCoreVersion = '5.0.14-beta'
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
-  terracottaPassthroughTestingVersion = '1.0.13.beta'
+  terracottaPassthroughTestingVersion = '1.0.14.beta'
   entityTestLibVersion = terracottaPassthroughTestingVersion
-  galvanVersion = '1.0.13-beta'
+  galvanVersion = '1.0.14-beta'
 
   // Tools
   findbugsVersion = '3.0.1'


### PR DESCRIPTION
This will allow to use the Entity creation exception possibility.