### PR TITLE
Issue 1684: Correctly compute statistics and only compute basic Statistics in Ehcache (not rates, ratio, etc)

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -108,6 +108,7 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
   private final OperationObserver<StoreOperationOutcomes.ConditionalReplaceOutcome> conditionalReplaceObserver;
   // Needed for JSR-107 compatibility even if unused
   private final OperationObserver<StoreOperationOutcomes.EvictionOutcome> evictionObserver;
+  private final OperationObserver<StoreOperationOutcomes.ExpirationOutcome> expirationObserver;
   private final OperationObserver<AuthoritativeTierOperationOutcomes.GetAndFaultOutcome> getAndFaultObserver;
 
 
@@ -124,6 +125,7 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
     this.replaceObserver = operation(StoreOperationOutcomes.ReplaceOutcome.class).of(this).named("replace").tag(STATISTICS_TAG).build();
     this.conditionalReplaceObserver = operation(StoreOperationOutcomes.ConditionalReplaceOutcome.class).of(this).named("conditionalReplace").tag(STATISTICS_TAG).build();
     this.evictionObserver = operation(StoreOperationOutcomes.EvictionOutcome.class).of(this).named("eviction").tag(STATISTICS_TAG).build();
+    this.expirationObserver = operation(StoreOperationOutcomes.ExpirationOutcome.class).of(this).named("expiration").tag(STATISTICS_TAG).build();
     this.getAndFaultObserver = operation(AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.class).of(this).named("getAndFault").tag(STATISTICS_TAG).build();
 
     Set<String> tags = new HashSet<String>(Arrays.asList(STATISTICS_TAG, "tier"));
@@ -581,6 +583,12 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
       StatisticsManager.associate(evict).withParent(store);
       tieredOps.add(evict);
 
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      store, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", TIER_HEIGHT, "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(store);
+      tieredOps.add(expire);
+
       tierOperationStatistics.put(store, tieredOps);
       return store;
     }
@@ -754,6 +762,12 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
                       authoritativeTier, TierOperationOutcomes.EVICTION_TRANSLATION, "eviction", TIER_HEIGHT, "eviction", STATISTICS_TAG);
       StatisticsManager.associate(evict).withParent(authoritativeTier);
       tieredOps.add(evict);
+
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      authoritativeTier, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", TIER_HEIGHT, "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(authoritativeTier);
+      tieredOps.add(expire);
 
       tierOperationStatistics.put(authoritativeTier, tieredOps);
       return authoritativeTier;

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
@@ -387,6 +387,10 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
     CLUSTERED_DESCRIPTORS.add(new StatisticDescriptor("Clustered:MappingCount", StatisticType.COUNTER_HISTORY));
     CLUSTERED_DESCRIPTORS.add(new StatisticDescriptor("Clustered:EvictionRate", StatisticType.RATE_HISTORY));
 
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //These decriptors are for the current statistics architecture, which is in the process of being replaced.
+    //When the new statistics architecture is finished they will be deletetd
+    //This is the task https://github.com/ehcache/ehcache3/issues/1684
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:HitRate", StatisticType.RATE_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:HitCount", StatisticType.COUNTER_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:HitRatio", StatisticType.RATIO_HISTORY));
@@ -395,6 +399,60 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ClearCount", StatisticType.COUNTER_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:MissCount", StatisticType.COUNTER_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:MissRatio", StatisticType.RATIO_HISTORY));
+    //TODO CACHE_DESCRIPTORS above will be deletetd once the following task is completed: https://github.com/ehcache/ehcache3/issues/1684
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //These descriptors are for the new statistis architecture.  These will remain.
+    //task https://github.com/ehcache/ehcache3/issues/1684
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitNoLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitWithLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:HitCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissPresentCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:SuccessCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyPresentCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissNoLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissWithLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:PutIfAbsent:PutCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissNotPresentCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyMissingCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Remove:SuccessCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:UpdatedCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:PutCount", StatisticType.COUNTER_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    CLUSTERED_DESCRIPTORS.add(new StatisticDescriptor("Clustered:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+    CLUSTERED_DESCRIPTORS.add(new StatisticDescriptor("Clustered:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+
+    //TODO *_DESCRIPTORS below for Rate will be deletetd when the new statistic architecture is completed
+    //task https://github.com/ehcache/ehcache3/issues/1684
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitNoLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitWithLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:HitRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissPresentRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:SuccessRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyPresentRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissNoLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissWithLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:PutIfAbsent:PutRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissNotPresentRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyMissingRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Remove:SuccessRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:UpdatedRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:PutRate", StatisticType.RATE_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    CLUSTERED_DESCRIPTORS.add(new StatisticDescriptor("Clustered:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    CLUSTERED_DESCRIPTORS.add(new StatisticDescriptor("Clustered:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
 
     POOL_DESCRIPTORS.add(new StatisticDescriptor("Pool:AllocatedSize", StatisticType.SIZE_HISTORY));
 

--- a/core/src/main/java/org/ehcache/core/statistics/TierOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/core/statistics/TierOperationOutcomes.java
@@ -70,6 +70,14 @@ public class TierOperationOutcomes {
     EVICTION_TRANSLATION = unmodifiableMap(translation);
   }
 
+  public static final Map<ExpirationOutcome, Set<StoreOperationOutcomes.ExpirationOutcome>> EXPIRATION_TRANSLATION;
+
+  static {
+    Map<ExpirationOutcome, Set<StoreOperationOutcomes.ExpirationOutcome>> translation = new EnumMap<ExpirationOutcome, Set<StoreOperationOutcomes.ExpirationOutcome>>(ExpirationOutcome.class);
+    translation.put(ExpirationOutcome.SUCCESS, of(StoreOperationOutcomes.ExpirationOutcome.SUCCESS));
+    EXPIRATION_TRANSLATION = unmodifiableMap(translation);
+  }
+
   public enum GetOutcome {
     HIT,
     MISS,
@@ -78,6 +86,10 @@ public class TierOperationOutcomes {
   public enum EvictionOutcome {
     SUCCESS,
     FAILURE
+  }
+
+  public enum ExpirationOutcome {
+    SUCCESS
   }
 
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -345,6 +345,12 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
       StatisticsManager.associate(evict).withParent(store);
       tieredOps.add(evict);
 
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      store, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(store);
+      tieredOps.add(expire);
+
       tierOperationStatistics.put(store, tieredOps);
       return store;
     }
@@ -488,6 +494,12 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
                       authoritativeTier, TierOperationOutcomes.EVICTION_TRANSLATION, "eviction", ResourceType.Core.DISK.getTierHeight(), "eviction", STATISTICS_TAG);
       StatisticsManager.associate(evict).withParent(authoritativeTier);
       tieredOps.add(evict);
+
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      authoritativeTier, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(authoritativeTier);
+      tieredOps.add(expire);
 
       tierOperationStatistics.put(authoritativeTier, tieredOps);
       return authoritativeTier;

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -1694,6 +1694,12 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       StatisticsManager.associate(evict).withParent(store);
       tieredOps.add(evict);
 
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      store, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(store);
+      tieredOps.add(expire);
+
       tierOperationStatistics.put(store, tieredOps);
       return store;
     }
@@ -1791,6 +1797,12 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
       StatisticsManager.associate(evict).withParent(cachingTier);
       tieredOps.add(evict);
 
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      cachingTier, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(cachingTier);
+      tieredOps.add(expire);
+
       this.tierOperationStatistics.put(cachingTier, tieredOps);
       return cachingTier;
     }
@@ -1827,6 +1839,12 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
                       higherCachingTier, TierOperationOutcomes.EVICTION_TRANSLATION, "eviction", ResourceType.Core.HEAP.getTierHeight(), "eviction", STATISTICS_TAG);
       StatisticsManager.associate(evict).withParent(higherCachingTier);
       tieredOps.add(evict);
+
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      higherCachingTier, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(higherCachingTier);
+      tieredOps.add(expire);
 
       tierOperationStatistics.put(higherCachingTier, tieredOps);
       return higherCachingTier;

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
@@ -164,6 +164,12 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
       StatisticsManager.associate(evict).withParent(store);
       tieredOps.add(evict);
 
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      store, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(store);
+      tieredOps.add(expire);
+
       tierOperationStatistics.put(store, tieredOps);
       return store;
     }
@@ -256,6 +262,12 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
       StatisticsManager.associate(evict).withParent(authoritativeTier);
       tieredOps.add(evict);
 
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      authoritativeTier, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(authoritativeTier);
+      tieredOps.add(expire);
+
       tierOperationStatistics.put(authoritativeTier, tieredOps);
       return authoritativeTier;
     }
@@ -286,6 +298,12 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
                       lowerCachingTier, TierOperationOutcomes.EVICTION_TRANSLATION, "eviction", ResourceType.Core.OFFHEAP.getTierHeight(), "eviction", STATISTICS_TAG);
       StatisticsManager.associate(evict).withParent(lowerCachingTier);
       tieredOps.add(evict);
+
+      MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome> expire =
+              new MappedOperationStatistic<StoreOperationOutcomes.ExpirationOutcome, TierOperationOutcomes.ExpirationOutcome>(
+                      lowerCachingTier, TierOperationOutcomes.EXPIRATION_TRANSLATION, "expiration", ResourceType.Core.HEAP.getTierHeight(), "expiration", STATISTICS_TAG);
+      StatisticsManager.associate(expire).withParent(lowerCachingTier);
+      tieredOps.add(expire);
 
       tierOperationStatistics.put(lowerCachingTier, tieredOps);
       return lowerCachingTier;

--- a/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
@@ -75,6 +75,75 @@ class StandardEhcacheStatistics extends ExposedCacheBinding {
     statisticsRegistry.registerCounter("MaxMappingCount", descriptor("maxMappings", singleton("tier")));
     statisticsRegistry.registerSize("AllocatedByteSize", descriptor("allocatedMemory", singleton("tier")));
     statisticsRegistry.registerSize("OccupiedByteSize", descriptor("occupiedMemory", singleton("tier")));
+
+    //new stats architecture changes.  The above registrations will be removed once the following task is completed: https://github.com/ehcache/ehcache3/issues/1684
+    registerStatCacheOutcomes();
+    registerStatTierOutcomes();
+  }
+
+  private void registerStatCacheOutcomes() {
+    //TODO Statistics library needs StatisticsRegistry.registerOperation(...) method.  Once created replace all calls to registerCompoundOperations(...) with it.
+    //use the following format to define a cache operation: Cache:operation:outcome
+
+    //register Cache outcomes for Hit stat calculations
+    statisticsRegistry.registerCompoundOperations("Cache:Get:HitNoLoader", OperationStatisticDescriptor.descriptor("get", singleton("cache"), CacheOperationOutcomes.GetOutcome.class), of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER));
+    statisticsRegistry.registerCompoundOperations("Cache:Get:HitWithLoader", OperationStatisticDescriptor.descriptor("get", singleton("cache"), CacheOperationOutcomes.GetOutcome.class), of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
+    statisticsRegistry.registerCompoundOperations("Cache:Replace:Hit", OperationStatisticDescriptor.descriptor("replace", singleton("cache"), CacheOperationOutcomes.ReplaceOutcome.class), of(CacheOperationOutcomes.ReplaceOutcome.HIT));
+    statisticsRegistry.registerCompoundOperations("Cache:Replace:MissPresent", OperationStatisticDescriptor.descriptor("replace", singleton("cache"), CacheOperationOutcomes.ReplaceOutcome.class), of(CacheOperationOutcomes.ReplaceOutcome.MISS_PRESENT));
+    statisticsRegistry.registerCompoundOperations("Cache:ConditionalRemove:Success", OperationStatisticDescriptor.descriptor("conditionalRemove", singleton("cache"), CacheOperationOutcomes.ConditionalRemoveOutcome.class), of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS));
+    statisticsRegistry.registerCompoundOperations("Cache:ConditionalRemove:FailureKeyPresent", OperationStatisticDescriptor.descriptor("conditionalRemove", singleton("cache"), CacheOperationOutcomes.ConditionalRemoveOutcome.class), of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));
+    //TODO register BulkOps outcomes
+    //statisticsRegistry.registerCompoundOperations("Cache:BulkOps:GetAllHits", OperationStatisticDescriptor.descriptor("getAll", singleton("cache"), BulkOps.class), of(BulkOps.GET_ALL_HITS));
+
+    //register Cache outcomes for Miss stat calculations
+    statisticsRegistry.registerCompoundOperations("Cache:Get:MissNoLoader", OperationStatisticDescriptor.descriptor("get", singleton("cache"), CacheOperationOutcomes.GetOutcome.class), of(CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER));
+    statisticsRegistry.registerCompoundOperations("Cache:Get:MissWithLoader", OperationStatisticDescriptor.descriptor("get", singleton("cache"), CacheOperationOutcomes.GetOutcome.class), of(CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER));
+    statisticsRegistry.registerCompoundOperations("Cache:PutIfAbsent:Put", OperationStatisticDescriptor.descriptor("putIfAbsent", singleton("cache"), CacheOperationOutcomes.PutIfAbsentOutcome.class), of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT));
+    statisticsRegistry.registerCompoundOperations("Cache:Replace:MissNotPresent", OperationStatisticDescriptor.descriptor("replace", singleton("cache"), CacheOperationOutcomes.ReplaceOutcome.class), of(CacheOperationOutcomes.ReplaceOutcome.MISS_NOT_PRESENT));
+    statisticsRegistry.registerCompoundOperations("Cache:ConditionalRemove:FailureKeyMissing", OperationStatisticDescriptor.descriptor("conditionalRemove", singleton("cache"), CacheOperationOutcomes.ConditionalRemoveOutcome.class), of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
+    //TODO register BulkOps outcomes
+    //statisticsRegistry.registerCompoundOperations("Cache:BulkOps:GetAllMiss", OperationStatisticDescriptor.descriptor("getAll", singleton("cache"), BulkOps.class), of(BulkOps.GET_ALL_MISS));
+
+    //register Cache outcomes for Remove stat calculations
+    statisticsRegistry.registerCompoundOperations("Cache:Remove:Success", OperationStatisticDescriptor.descriptor("remove", singleton("cache"), CacheOperationOutcomes.RemoveOutcome.class), of(CacheOperationOutcomes.RemoveOutcome.SUCCESS));
+    //"Cache:ConditionalRemove:Success" already registered
+    //TODO register BulkOps outcomes
+    //statisticsRegistry.registerCompoundOperations("Cache:BulkOps:RemoveAll", OperationStatisticDescriptor.descriptor("removeAll", singleton("cache"), BulkOps.class), of(BulkOps.REMOVE_ALL));
+
+    //register Cache outcomes for Replace stat calculations
+    //"Cache:Replace:Hit" already registered
+    statisticsRegistry.registerCompoundOperations("Cache:Put:Updated", OperationStatisticDescriptor.descriptor("put", singleton("cache"), CacheOperationOutcomes.PutOutcome.class), of(CacheOperationOutcomes.PutOutcome.UPDATED));
+
+    //register Cache outcomes for Put stat calculations
+    statisticsRegistry.registerCompoundOperations("Cache:Put:Put", OperationStatisticDescriptor.descriptor("put", singleton("cache"), CacheOperationOutcomes.PutOutcome.class), of(CacheOperationOutcomes.PutOutcome.PUT));
+    //"Cache:Put:Updated" already registered
+    //"Cache:PutIfAbsent:Put" already registered
+    //"Cache:Replace:Hit" already registered
+    //TODO register BulkOps outcomes
+    //statisticsRegistry.registerCompoundOperations("Cache:BulkOps:PutAll", OperationStatisticDescriptor.descriptor("putAll", singleton("cache"), CacheOperationOutcomes.PutAllOutcome.class), of(CacheOperationOutcomes.PutAllOutcome.SUCCESS));
+  }
+
+  private void registerStatTierOutcomes() {
+
+    //use the following format to define a tier operation: operation:outcome
+    //The tier will be pre-appended
+
+    //TODO register Tier outcomes for Hit stat calculations
+
+    //TODO register Tier outcomes for Miss stat calculations
+
+    //TODO register Tier outcomes for Remove stat calculations
+
+    //TODO register Tier outcomes for Replace stat calculations
+
+    //TODO register Tier outcomes for Put stat calculations
+
+    //register Tier outcomes for Eviction.  Evictions only occur in the authoritative tier and there is no Cache level eviction outcome.
+    statisticsRegistry.registerCompoundOperations("Eviction:Success", OperationStatisticDescriptor.descriptor("eviction", singleton("tier"), TierOperationOutcomes.EvictionOutcome.class), of(TierOperationOutcomes.EvictionOutcome.SUCCESS));
+
+    //register Tier outcomes for Expiration
+    statisticsRegistry.registerCompoundOperations("Expiration:Success", OperationStatisticDescriptor.descriptor("expiration", singleton("tier"), TierOperationOutcomes.ExpirationOutcome.class), of(TierOperationOutcomes.ExpirationOutcome.SUCCESS));
+
   }
 
   Statistic<?, ?> queryStatistic(String fullStatisticName, long since) {

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
@@ -205,6 +205,11 @@ public class DefaultManagementRegistryServiceTest {
       assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getDescriptors(), hasSize(4));
 
       Collection<? extends Descriptor> descriptors = new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getDescriptors();
+      System.out.println("descriptorDiskStoreTest descriptors: ");
+      for (Descriptor descriptor : descriptors) {
+        System.out.println("descriptor: " + descriptor.toString());
+      }
+
       Collection<Descriptor> allDescriptors = new ArrayList<Descriptor>();
       allDescriptors.addAll(ONHEAP_DESCRIPTORS);
       allDescriptors.addAll(DISK_DESCRIPTORS);
@@ -565,6 +570,10 @@ public class DefaultManagementRegistryServiceTest {
     DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:MappingCount", StatisticType.COUNTER_HISTORY));
     DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:MissRate", StatisticType.RATE_HISTORY));
 
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //These decriptors are for the current statistics architecture, which is in the process of being replaced.
+    //When the new statistics architecture is finished they will be deletetd
+    //This is the task https://github.com/ehcache/ehcache3/issues/1684
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:HitRate", StatisticType.RATE_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:HitCount", StatisticType.COUNTER_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:HitRatio", StatisticType.RATIO_HISTORY));
@@ -573,6 +582,55 @@ public class DefaultManagementRegistryServiceTest {
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ClearCount", StatisticType.COUNTER_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:MissCount", StatisticType.COUNTER_HISTORY));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:MissRatio", StatisticType.RATIO_HISTORY));
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //These descriptors are for the new statistis architecture.  These will remain.
+    //task https://github.com/ehcache/ehcache3/issues/1684
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitNoLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitWithLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:HitCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissPresentCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:SuccessCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyPresentCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissNoLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissWithLoaderCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:PutIfAbsent:PutCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissNotPresentCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyMissingCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Remove:SuccessCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:UpdatedCount", StatisticType.COUNTER_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:PutCount", StatisticType.COUNTER_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Eviction:SuccessCount", StatisticType.COUNTER_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Expiration:SuccessCount", StatisticType.COUNTER_HISTORY));
+
+    //TODO *_DESCRIPTORS below for Rate will be deletetd when the new statistic architecture is completed
+    //task https://github.com/ehcache/ehcache3/issues/1684
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitNoLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:HitWithLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:HitRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissPresentRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:SuccessRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyPresentRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissNoLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Get:MissWithLoaderRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:PutIfAbsent:PutRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Replace:MissNotPresentRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ConditionalRemove:FailureKeyMissingRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Remove:SuccessRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:UpdatedRate", StatisticType.RATE_HISTORY));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:Put:PutRate", StatisticType.RATE_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Eviction:SuccessRate", StatisticType.RATE_HISTORY));
+    ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    OFFHEAP_DESCRIPTORS.add(new StatisticDescriptor("OffHeap:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    DISK_DESCRIPTORS.add(new StatisticDescriptor("Disk:Expiration:SuccessRate", StatisticType.RATE_HISTORY));
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
 
   }
 


### PR DESCRIPTION
This issue is associated with issue: https://github.com/ehcache/ehcache3/issues/1684

It is the 2nd step in the todo list.  This code registers the Cache tier outcomes: Hit, Miss, Remove, Replace and Put.  I still need to register the Cache outcomes for Eviction and Expiry.  In addition, I need to register the Cache bulk operations.  Once the Cache tier outcomes are working I will continue with registering the outcomes for each tier.