### PR TITLE
Bump to latest Terracotta version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,15 +28,15 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.0.14.beta'
+  terracottaPlatformVersion = '5.0.15.beta'
   managementVersion = terracottaPlatformVersion
-  terracottaApisVersion = '1.0.14.beta'
-  terracottaCoreVersion = '5.0.14-beta2'
+  terracottaApisVersion = '1.0.15.beta'
+  terracottaCoreVersion = '5.0.15-beta'
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
-  terracottaPassthroughTestingVersion = '1.0.14.beta'
+  terracottaPassthroughTestingVersion = '1.0.15.beta'
   entityTestLibVersion = terracottaPassthroughTestingVersion
-  galvanVersion = '1.0.14-beta2'
+  galvanVersion = '1.0.15-beta'
 
   // Tools
   findbugsVersion = '3.0.1'

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactory.java
@@ -27,9 +27,11 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.entity.EntityRef;
 import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityVersionMismatchException;
+import org.terracotta.exception.PermanentEntityException;
 
 import java.util.Map;
 import java.util.UUID;
@@ -140,6 +142,12 @@ public class EhcacheClientEntityFactory {
       } catch (EntityVersionMismatchException e) {
         LOGGER.error("Unable to create clustered tier manager for id {}", identifier, e);
         throw new AssertionError(e);
+      } catch (PermanentEntityException e) {
+        LOGGER.error("Unable to create entity - server indicates it is permanent", e);
+        throw new AssertionError(e);
+      } catch (EntityConfigurationException e) {
+        LOGGER.error("Unable to create entity - configuration exception", e);
+        throw new AssertionError(e);
       }
     } finally {
       if (localMaintenance != null) {
@@ -227,6 +235,9 @@ public class EhcacheClientEntityFactory {
         throw new AssertionError(e);
       } catch (EntityNotFoundException e) {
         throw new EhcacheEntityNotFoundException(e);
+      } catch (PermanentEntityException e) {
+        LOGGER.error("Unable to destroy entity - server says it is permanent", e);
+        throw new AssertionError(e);
       }
     } finally {
       if (localMaintenance != null) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLock.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLock.java
@@ -24,9 +24,11 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.entity.EntityRef;
 import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityVersionMismatchException;
+import org.terracotta.exception.PermanentEntityException;
 
 public class VoltronReadWriteLock {
 
@@ -86,6 +88,9 @@ public class VoltronReadWriteLock {
       throw new AssertionError(e);
     } catch (EntityNotFoundException e) {
       // Nothing to do
+    } catch (PermanentEntityException e) {
+      LOGGER.error("Failed to destroy lock entity - server says it is permanent", e);
+      throw new AssertionError(e);
     }
   }
 
@@ -131,6 +136,9 @@ public class VoltronReadWriteLock {
           LOGGER.debug("Created lock entity " + reference.getName());
         } catch (EntityAlreadyExistsException f) {
           //ignore
+        } catch (EntityConfigurationException e) {
+          LOGGER.error("Error creating lock entity - configuration exception", e);
+          throw new AssertionError(e);
         }
         try {
           return reference.fetchEntity();

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLock.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/lock/VoltronReadWriteLock.java
@@ -72,8 +72,7 @@ public class VoltronReadWriteLock {
       return new HoldImpl(client, type);
     } else {
       client.close();
-      //TODO Restore this clean up operation once https://github.com/Terracotta-OSS/terracotta-core/issues/379 is fixed
-//      tryDestroy();
+      tryDestroy();
       return null;
     }
   }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/AbstractClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/AbstractClientEntityFactory.java
@@ -23,9 +23,11 @@ import org.terracotta.connection.Connection;
 import org.terracotta.connection.entity.Entity;
 import org.terracotta.connection.entity.EntityRef;
 import org.terracotta.exception.EntityAlreadyExistsException;
+import org.terracotta.exception.EntityConfigurationException;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityVersionMismatchException;
+import org.terracotta.exception.PermanentEntityException;
 
 abstract class AbstractClientEntityFactory<E extends Entity, C> implements ClientEntityFactory<E, C> {
 
@@ -86,6 +88,9 @@ abstract class AbstractClientEntityFactory<E extends Entity, C> implements Clien
     } catch (EntityVersionMismatchException e) {
       LOGGER.error("Unable to create entity {} for id {}", entityType.getName(), entityIdentifier, e);
       throw new AssertionError(e);
+    } catch (EntityConfigurationException e) {
+      LOGGER.error("Unable to create entity - configuration exception", e);
+      throw new AssertionError(e);
     }
   }
 
@@ -108,6 +113,9 @@ abstract class AbstractClientEntityFactory<E extends Entity, C> implements Clien
       }
     } catch (EntityNotProvidedException e) {
       LOGGER.error("Unable to destroy entity {} for id {}", entityType.getName(), entityIdentifier, e);
+      throw new AssertionError(e);
+    } catch (PermanentEntityException e) {
+      LOGGER.error("Unable to destroy entity - server says it is permanent", e);
       throw new AssertionError(e);
     }
   }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
@@ -55,13 +55,17 @@ import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
+import org.terracotta.exception.PermanentEntityException;
 import org.terracotta.offheapresource.OffHeapResourcesProvider;
 import org.terracotta.offheapresource.config.MemoryUnit;
 import org.terracotta.offheapresource.config.OffheapResourcesType;
 import org.terracotta.offheapresource.config.ResourceType;
+import org.terracotta.passthrough.IAsynchronousServerCrasher;
 import org.terracotta.passthrough.PassthroughConnection;
 import org.terracotta.passthrough.PassthroughServer;
 import org.terracotta.passthrough.PassthroughServerRegistry;
+
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -142,6 +146,8 @@ public class UnitTestConnectionService implements ConnectionService {
     }
 
     SERVERS.put(keyURI, new ServerDescriptor(server));
+    // TODO rework that better
+    server.registerAsynchronousServerCrasher(mock(IAsynchronousServerCrasher.class));
     server.start(true, false);
     LOGGER.info("Started PassthroughServer at {}", keyURI);
   }
@@ -240,6 +246,8 @@ public class UnitTestConnectionService implements ConnectionService {
           LOGGER.error("Entity destroy failed: ", ex);
         } catch (EntityNotFoundException ex) {
           LOGGER.error("Entity destroy failed: ", ex);
+        } catch (PermanentEntityException ex) {
+          LOGGER.error("Entity destroy failed (permanent???): ", ex);
         }
       }
 

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicLifeCyclePassiveReplicationTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicLifeCyclePassiveReplicationTest.java
@@ -267,7 +267,6 @@ public class BasicLifeCyclePassiveReplicationTest {
   }
 
   @Test
-//  @Ignore("enable back once https://github.com/Terracotta-OSS/terracotta-core/issues/379 is fixed")
   public void testDestroyLockEntity() throws Exception {
     VoltronReadWriteLock lock1 = new VoltronReadWriteLock(CLUSTER.newConnection(), "my-lock");
     VoltronReadWriteLock.Hold hold1 = lock1.tryReadLock();


### PR DESCRIPTION
* Adapt to EntityRef.create and EntityRef.destroy API changes
* Adapt to the passthrough changes