### PR TITLE
Closes #1678 Refactor codecs to reuse configuration encoding and decoding logic for extensibility

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityService.java
@@ -19,10 +19,15 @@ package org.ehcache.clustered.client.internal;
 import java.util.UUID;
 
 import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
+import org.ehcache.clustered.common.internal.messages.CommonConfigCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 
+import org.ehcache.clustered.common.internal.messages.LifeCycleMessageCodec;
+import org.ehcache.clustered.common.internal.messages.ResponseCodec;
+import org.ehcache.clustered.common.internal.messages.ServerStoreOpCodec;
+import org.ehcache.clustered.common.internal.messages.StateRepositoryOpCodec;
 import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.EntityClientService;
 import org.terracotta.entity.MessageCodec;
@@ -51,6 +56,7 @@ public class EhcacheClientEntityService implements EntityClientService<EhcacheCl
 
   @Override
   public MessageCodec<EhcacheEntityMessage, EhcacheEntityResponse> getMessageCodec() {
-    return EhcacheCodec.messageCodec();
+    return new EhcacheCodec(new ServerStoreOpCodec(), new LifeCycleMessageCodec(new CommonConfigCodec()),
+      new StateRepositoryOpCodec(), new ResponseCodec());
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/CommonConfigCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/CommonConfigCodec.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.clustered.common.internal.messages;
+
+import org.ehcache.clustered.common.Consistency;
+import org.ehcache.clustered.common.PoolAllocation;
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.terracotta.runnel.EnumMapping;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.StructBuilder;
+import org.terracotta.runnel.decoding.Enm;
+import org.terracotta.runnel.decoding.PrimitiveDecodingSupport;
+import org.terracotta.runnel.decoding.StructArrayDecoder;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.PrimitiveEncodingSupport;
+import org.terracotta.runnel.encoding.StructArrayEncoder;
+import org.terracotta.runnel.encoding.StructEncoder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.terracotta.runnel.EnumMappingBuilder.newEnumMappingBuilder;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
+
+/**
+ * Encodes and decodes configuration objects such as {@link ServerSideConfiguration} and {@link ServerStoreConfiguration}.
+ * <p>
+ * This class is made extensible and hence must remain public.
+ */
+@SuppressWarnings("WeakerAccess")
+public class CommonConfigCodec implements ConfigCodec {
+
+  private static final String STORE_CONFIG_KEY_TYPE_FIELD = "keyType";
+  private static final String STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD = "keySerializerType";
+  private static final String STORE_CONFIG_VALUE_TYPE_FIELD = "valueType";
+  private static final String STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD = "valueSerializerType";
+  private static final String STORE_CONFIG_CONSISTENCY_FIELD = "consistency";
+  private static final String POOL_SIZE_FIELD = "poolSize";
+  private static final String POOL_RESOURCE_NAME_FIELD = "resourceName";
+  private static final String DEFAULT_RESOURCE_FIELD = "defaultResource";
+  private static final String POOLS_SUB_STRUCT = "pools";
+  private static final String POOL_NAME_FIELD = "poolName";
+
+  private static final EnumMapping<Consistency> CONSISTENCY_ENUM_MAPPING = newEnumMappingBuilder(Consistency.class)
+    .mapping(Consistency.EVENTUAL, 1)
+    .mapping(Consistency.STRONG, 2)
+    .build();
+
+  private static final Struct POOLS_STRUCT = newStructBuilder()
+    .string(POOL_NAME_FIELD, 10)
+    .int64(POOL_SIZE_FIELD, 20)
+    .string(POOL_RESOURCE_NAME_FIELD, 30).build();
+
+  @Override
+  public InjectTuple injectServerStoreConfiguration(StructBuilder baseBuilder, final int index) {
+    final StructBuilder structBuilder = baseBuilder.string(STORE_CONFIG_KEY_TYPE_FIELD, index)
+      .string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD, index + 10)
+      .string(STORE_CONFIG_VALUE_TYPE_FIELD, index + 11)
+      .string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD, index + 15)
+      .enm(STORE_CONFIG_CONSISTENCY_FIELD, index + 16, CONSISTENCY_ENUM_MAPPING)
+      .int64(POOL_SIZE_FIELD, index + 20)
+      .string(POOL_RESOURCE_NAME_FIELD, index + 30);
+
+    return new InjectTuple() {
+      @Override
+      public int getLastIndex() {
+        return index + 30;
+      }
+
+      @Override
+      public StructBuilder getUpdatedBuilder() {
+        return structBuilder;
+      }
+    };
+  }
+
+  @Override
+  public InjectTuple injectServerSideConfiguration(StructBuilder baseBuilder, final int index) {
+    final StructBuilder structBuilder = baseBuilder.string(DEFAULT_RESOURCE_FIELD, index + 10)
+      .structs(POOLS_SUB_STRUCT, index + 20, POOLS_STRUCT);
+
+    return new InjectTuple() {
+      @Override
+      public int getLastIndex() {
+        return index + 20;
+      }
+
+      @Override
+      public StructBuilder getUpdatedBuilder() {
+        return structBuilder;
+      }
+    };
+  }
+
+  @Override
+  public void encodeServerStoreConfiguration(PrimitiveEncodingSupport<?> encoder, ServerStoreConfiguration configuration) {
+    encoder.string(STORE_CONFIG_KEY_TYPE_FIELD, configuration.getStoredKeyType())
+      .string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD, configuration.getKeySerializerType())
+      .string(STORE_CONFIG_VALUE_TYPE_FIELD, configuration.getStoredValueType())
+      .string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD, configuration.getValueSerializerType());
+    if (configuration.getConsistency() != null) {
+      encoder.enm(STORE_CONFIG_CONSISTENCY_FIELD, configuration.getConsistency());
+    }
+
+    PoolAllocation poolAllocation = configuration.getPoolAllocation();
+    if (poolAllocation instanceof PoolAllocation.Dedicated) {
+      PoolAllocation.Dedicated dedicatedPool = (PoolAllocation.Dedicated) poolAllocation;
+      encoder.int64(POOL_SIZE_FIELD, dedicatedPool.getSize());
+      if (dedicatedPool.getResourceName() != null) {
+        encoder.string(POOL_RESOURCE_NAME_FIELD, dedicatedPool.getResourceName());
+      }
+    } else if (poolAllocation instanceof PoolAllocation.Shared) {
+      encoder.string(POOL_RESOURCE_NAME_FIELD, ((PoolAllocation.Shared) poolAllocation).getResourcePoolName());
+    }
+  }
+
+  @Override
+  public ServerStoreConfiguration decodeServerStoreConfiguration(PrimitiveDecodingSupport decoder) {
+    String keyType = decoder.string(STORE_CONFIG_KEY_TYPE_FIELD);
+    String keySerializer = decoder.string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD);
+    String valueType = decoder.string(STORE_CONFIG_VALUE_TYPE_FIELD);
+    String valueSerializer = decoder.string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD);
+    Enm<Consistency> consistencyEnm = decoder.enm(STORE_CONFIG_CONSISTENCY_FIELD);
+    Consistency consistency = Consistency.EVENTUAL;
+    if (consistencyEnm.isValid()) {
+      consistency = consistencyEnm.get();
+    }
+    Long poolSize = decoder.int64(POOL_SIZE_FIELD);
+    String poolResource = decoder.string(POOL_RESOURCE_NAME_FIELD);
+    PoolAllocation poolAllocation = new PoolAllocation.Unknown();
+    if (poolSize != null) {
+      poolAllocation = new PoolAllocation.Dedicated(poolResource, poolSize);
+    } else if (poolResource != null) {
+      poolAllocation = new PoolAllocation.Shared(poolResource);
+    }
+    return new ServerStoreConfiguration(poolAllocation, keyType, valueType, null, null, keySerializer, valueSerializer, consistency);
+  }
+
+  @Override
+  public void encodeServerSideConfiguration(StructEncoder<?> encoder, ServerSideConfiguration configuration) {
+    if (configuration.getDefaultServerResource() != null) {
+      encoder.string(DEFAULT_RESOURCE_FIELD, configuration.getDefaultServerResource());
+    }
+
+    if (!configuration.getResourcePools().isEmpty()) {
+      StructArrayEncoder<? extends StructEncoder<?>> poolsEncoder = encoder.structs(POOLS_SUB_STRUCT);
+      for (Map.Entry<String, ServerSideConfiguration.Pool> poolEntry : configuration.getResourcePools().entrySet()) {
+        poolsEncoder.string(POOL_NAME_FIELD, poolEntry.getKey())
+          .int64(POOL_SIZE_FIELD, poolEntry.getValue().getSize());
+        if (poolEntry.getValue().getServerResource() != null) {
+          poolsEncoder.string(POOL_RESOURCE_NAME_FIELD, poolEntry.getValue().getServerResource());
+        }
+        poolsEncoder.next();
+      }
+      poolsEncoder.end();
+    }
+  }
+
+  @Override
+  public ServerSideConfiguration decodeServerSideConfiguration(StructDecoder<?> decoder) {
+    String defaultResource = decoder.string(DEFAULT_RESOURCE_FIELD);
+
+    HashMap<String, ServerSideConfiguration.Pool> resourcePools = new HashMap<String, ServerSideConfiguration.Pool>();
+    StructArrayDecoder<? extends StructDecoder<?>> poolsDecoder = decoder.structs(POOLS_SUB_STRUCT);
+    if (poolsDecoder != null) {
+      for (int i = 0; i < poolsDecoder.length(); i++) {
+        String poolName = poolsDecoder.string(POOL_NAME_FIELD);
+        Long poolSize = poolsDecoder.int64(POOL_SIZE_FIELD);
+        String poolResourceName = poolsDecoder.string(POOL_RESOURCE_NAME_FIELD);
+        if (poolResourceName == null) {
+          resourcePools.put(poolName, new ServerSideConfiguration.Pool(poolSize));
+        } else {
+          resourcePools.put(poolName, new ServerSideConfiguration.Pool(poolSize, poolResourceName));
+        }
+        poolsDecoder.next();
+      }
+    }
+
+    ServerSideConfiguration serverSideConfiguration;
+    if (defaultResource == null) {
+      serverSideConfiguration = new ServerSideConfiguration(resourcePools);
+    } else {
+      serverSideConfiguration = new ServerSideConfiguration(defaultResource, resourcePools);
+    }
+    return serverSideConfiguration;
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ConfigCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ConfigCodec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.terracotta.runnel.StructBuilder;
+import org.terracotta.runnel.decoding.PrimitiveDecodingSupport;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.PrimitiveEncodingSupport;
+import org.terracotta.runnel.encoding.StructEncoder;
+
+/**
+ *  Interface that allows extensions to codec.
+ */
+public interface ConfigCodec {
+  InjectTuple injectServerSideConfiguration(StructBuilder baseBuilder, int index);
+  void encodeServerSideConfiguration(StructEncoder<?> encoder, ServerSideConfiguration configuration);
+  ServerSideConfiguration decodeServerSideConfiguration(StructDecoder<?> decoder);
+
+  InjectTuple injectServerStoreConfiguration(StructBuilder baseBuilder, int index);
+  void encodeServerStoreConfiguration(PrimitiveEncodingSupport<?> encoder, ServerStoreConfiguration configuration);
+  ServerStoreConfiguration decodeServerStoreConfiguration(PrimitiveDecodingSupport decoder);
+
+  interface InjectTuple {
+    int getLastIndex();
+    StructBuilder getUpdatedBuilder();
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheCodec.java
@@ -40,19 +40,12 @@ public class EhcacheCodec implements MessageCodec<EhcacheEntityMessage, EhcacheE
 
   public static final Struct OP_CODE_DECODER = newStructBuilder().enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING).build();
 
-  private static final EhcacheCodec SERVER_INSTANCE =
-      new EhcacheCodec(new ServerStoreOpCodec(), new LifeCycleMessageCodec(), new StateRepositoryOpCodec(), new ResponseCodec());
-
   private final ServerStoreOpCodec serverStoreOpCodec;
   private final LifeCycleMessageCodec lifeCycleMessageCodec;
   private final StateRepositoryOpCodec stateRepositoryOpCodec;
   private final ResponseCodec responseCodec;
 
-  public static EhcacheCodec messageCodec() {
-    return SERVER_INSTANCE;
-  }
-
-  EhcacheCodec(ServerStoreOpCodec serverStoreOpCodec, LifeCycleMessageCodec lifeCycleMessageCodec,
+  public EhcacheCodec(ServerStoreOpCodec serverStoreOpCodec, LifeCycleMessageCodec lifeCycleMessageCodec,
                StateRepositoryOpCodec stateRepositoryOpCodec, ResponseCodec responseCodec) {
     this.serverStoreOpCodec = serverStoreOpCodec;
     this.lifeCycleMessageCodec = lifeCycleMessageCodec;

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/MessageCodecUtils.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/MessageCodecUtils.java
@@ -40,21 +40,6 @@ public class MessageCodecUtils {
   public static final String MSB_UUID_FIELD = "msbUUID";
   public static final String SERVER_STORE_NAME_FIELD = "serverStoreName";
   public static final String KEY_FIELD = "key";
-  public static final String DEFAULT_RESOURCE_FIELD = "defaultResource";
-  public static final String STORE_CONFIG_KEY_TYPE_FIELD = "keyType";
-  public static final String STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD = "keySerializerType";
-  public static final String STORE_CONFIG_VALUE_TYPE_FIELD = "valueType";
-  public static final String STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD = "valueSerializerType";
-  public static final String STORE_CONFIG_CONSISTENCY_FIELD = "consistency";
-  public static final String POOLS_SUB_STRUCT = "pools";
-  public static final String POOL_NAME_FIELD = "poolName";
-  public static final String POOL_SIZE_FIELD = "poolSize";
-  public static final String POOL_RESOURCE_NAME_FIELD = "resourceName";
-
-  public static final EnumMapping<Consistency> CONSISTENCY_ENUM_MAPPING = newEnumMappingBuilder(Consistency.class)
-    .mapping(Consistency.EVENTUAL, 1)
-    .mapping(Consistency.STRONG, 2)
-    .build();
 
   public void encodeMandatoryFields(StructEncoder<Void> encoder, EhcacheOperationMessage message) {
     encoder.enm(EhcacheMessageType.MESSAGE_TYPE_FIELD_NAME, message.getMessageType())
@@ -65,47 +50,5 @@ public class MessageCodecUtils {
 
   public UUID decodeUUID(StructDecoder<Void> decoder) {
     return new UUID(decoder.int64(MSB_UUID_FIELD), decoder.int64(LSB_UUID_FIELD));
-  }
-
-  public void encodeServerStoreConfiguration(PrimitiveEncodingSupport<?> encoder, ServerStoreConfiguration configuration) {
-    encoder.string(STORE_CONFIG_KEY_TYPE_FIELD, configuration.getStoredKeyType())
-      .string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD, configuration.getKeySerializerType())
-      .string(STORE_CONFIG_VALUE_TYPE_FIELD, configuration.getStoredValueType())
-      .string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD, configuration.getValueSerializerType());
-    if (configuration.getConsistency() != null) {
-      encoder.enm(STORE_CONFIG_CONSISTENCY_FIELD, configuration.getConsistency());
-    }
-
-    PoolAllocation poolAllocation = configuration.getPoolAllocation();
-    if (poolAllocation instanceof PoolAllocation.Dedicated) {
-      PoolAllocation.Dedicated dedicatedPool = (PoolAllocation.Dedicated) poolAllocation;
-      encoder.int64(POOL_SIZE_FIELD, dedicatedPool.getSize());
-      if (dedicatedPool.getResourceName() != null) {
-        encoder.string(POOL_RESOURCE_NAME_FIELD, dedicatedPool.getResourceName());
-      }
-    } else if (poolAllocation instanceof PoolAllocation.Shared) {
-      encoder.string(POOL_RESOURCE_NAME_FIELD, ((PoolAllocation.Shared) poolAllocation).getResourcePoolName());
-    }
-  }
-
-  public ServerStoreConfiguration decodeServerStoreConfiguration(PrimitiveDecodingSupport decoder) {
-    String keyType = decoder.string(STORE_CONFIG_KEY_TYPE_FIELD);
-    String keySerializer = decoder.string(STORE_CONFIG_KEY_SERIALIZER_TYPE_FIELD);
-    String valueType = decoder.string(STORE_CONFIG_VALUE_TYPE_FIELD);
-    String valueSerializer = decoder.string(STORE_CONFIG_VALUE_SERIALIZER_TYPE_FIELD);
-    Enm<Consistency> consistencyEnm = decoder.enm(STORE_CONFIG_CONSISTENCY_FIELD);
-    Consistency consistency = Consistency.EVENTUAL;
-    if (consistencyEnm.isValid()) {
-      consistency = consistencyEnm.get();
-    }
-    Long poolSize = decoder.int64(POOL_SIZE_FIELD);
-    String poolResource = decoder.string(POOL_RESOURCE_NAME_FIELD);
-    PoolAllocation poolAllocation = new PoolAllocation.Unknown();
-    if (poolSize != null) {
-      poolAllocation = new PoolAllocation.Dedicated(poolResource, poolSize);
-    } else if (poolResource != null) {
-      poolAllocation = new PoolAllocation.Shared(poolResource);
-    }
-    return new ServerStoreConfiguration(poolAllocation, keyType, valueType, null, null, keySerializer, valueSerializer, consistency);
   }
 }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ResponseCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ResponseCodec.java
@@ -41,7 +41,7 @@ import static org.ehcache.clustered.common.internal.messages.EhcacheResponseType
 import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.KEY_FIELD;
 import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.SERVER_STORE_NAME_FIELD;
 
-class ResponseCodec {
+public class ResponseCodec {
 
   private static final String EXCEPTION_FIELD = "exception";
   private static final String INVALIDATION_ID_FIELD = "invalidationId";
@@ -93,7 +93,7 @@ class ResponseCodec {
 
   private final ChainCodec chainCodec;
 
-  ResponseCodec() {
+  public ResponseCodec() {
     this.chainCodec = new ChainCodec();
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/ServerStoreOpCodec.java
@@ -42,7 +42,7 @@ import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.M
 import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.MSG_ID_FIELD;
 import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.SERVER_STORE_NAME_FIELD;
 
-class ServerStoreOpCodec {
+public class ServerStoreOpCodec {
 
   private static final Struct GET_AND_APPEND_MESSAGE_STRUCT = StructBuilder.newStructBuilder()
     .enm(MESSAGE_TYPE_FIELD_NAME, MESSAGE_TYPE_FIELD_INDEX, EHCACHE_MESSAGE_TYPES_ENUM_MAPPING)
@@ -100,7 +100,7 @@ class ServerStoreOpCodec {
   private final ChainCodec chainCodec;
   private final MessageCodecUtils messageCodecUtils = new MessageCodecUtils();
 
-  ServerStoreOpCodec() {
+  public ServerStoreOpCodec() {
     this.chainCodec = new ChainCodec();
   }
 

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/StateRepositoryOpCodec.java
@@ -35,7 +35,7 @@ import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.M
 import static org.ehcache.clustered.common.internal.messages.MessageCodecUtils.SERVER_STORE_NAME_FIELD;
 import static org.terracotta.runnel.StructBuilder.newStructBuilder;
 
-class StateRepositoryOpCodec {
+public class StateRepositoryOpCodec {
 
   private static final String MAP_ID_FIELD = "mapId";
   private static final String VALUE_FIELD = "value";

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/CommonConfigCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/CommonConfigCodecTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.junit.Test;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.encoding.StructEncoder;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
+
+public class CommonConfigCodecTest {
+
+  private static final CommonConfigCodec CODEC = new CommonConfigCodec();
+
+  @Test
+  public void testEncodeDecodeServerSideConfiguration() throws Exception {
+    ServerSideConfiguration serverSideConfiguration =
+      new ServerSideConfiguration("foo", Collections.singletonMap("bar", new ServerSideConfiguration.Pool(1)));
+    Struct serverSideConfigurationStruct = CODEC.injectServerSideConfiguration(newStructBuilder(), 10).getUpdatedBuilder().build();
+    StructEncoder<Void> encoder = serverSideConfigurationStruct.encoder();
+    CODEC.encodeServerSideConfiguration(encoder, serverSideConfiguration);
+    ByteBuffer byteBuffer = encoder.encode();
+    byteBuffer.rewind();
+    ServerSideConfiguration decodedServerSideConfiguration =
+      CODEC.decodeServerSideConfiguration(serverSideConfigurationStruct.decoder(byteBuffer));
+    assertThat(decodedServerSideConfiguration.getDefaultServerResource(), is("foo"));
+    assertThat(decodedServerSideConfiguration.getResourcePools(), hasKey("bar"));
+  }
+}

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodecTest.java
@@ -41,7 +41,7 @@ public class LifeCycleMessageCodecTest {
   private static final UUID CLIENT_ID = UUID.randomUUID();
 
   private final LifeCycleMessageFactory factory = new LifeCycleMessageFactory();
-  private final LifeCycleMessageCodec codec = new LifeCycleMessageCodec();
+  private final LifeCycleMessageCodec codec = new LifeCycleMessageCodec(new CommonConfigCodec());
 
   @Before
   public void setUp() {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheServerCodec.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheServerCodec.java
@@ -38,12 +38,6 @@ public class EhcacheServerCodec implements MessageCodec<EhcacheEntityMessage, Eh
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheServerCodec.class);
 
-  private static final EhcacheServerCodec SERVER_INSTANCE = new EhcacheServerCodec((EhcacheCodec) EhcacheCodec.messageCodec(), new PassiveReplicationMessageCodec());
-
-  public static EhcacheServerCodec getInstance() {
-    return SERVER_INSTANCE;
-  }
-
   private final EhcacheCodec clientCodec;
   private final PassiveReplicationMessageCodec replicationCodec;
 

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessageCodecTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessageCodecTest.java
@@ -19,6 +19,7 @@ import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.PoolAllocation;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.ehcache.clustered.common.internal.messages.CommonConfigCodec;
 import org.ehcache.clustered.common.internal.store.Chain;
 import org.junit.Test;
 
@@ -59,7 +60,7 @@ public class EhcacheSyncMessageCodecTest {
     storeConfigs.put("cache2", serverStoreConfiguration2);
 
     EhcacheStateSyncMessage message = new EhcacheStateSyncMessage(serverSideConfig, storeConfigs);
-    EhcacheSyncMessageCodec codec = new EhcacheSyncMessageCodec();
+    EhcacheSyncMessageCodec codec = new EhcacheSyncMessageCodec(new CommonConfigCodec());
     EhcacheStateSyncMessage decodedMessage = (EhcacheStateSyncMessage) codec.decode(0, codec.encode(0, message));
 
     assertThat(decodedMessage.getConfiguration().getDefaultServerResource(), is("default-pool"));
@@ -90,7 +91,7 @@ public class EhcacheSyncMessageCodecTest {
 
   @Test
   public void testDataSyncMessageEncodeDecode() throws Exception {
-    EhcacheSyncMessageCodec codec = new EhcacheSyncMessageCodec();
+    EhcacheSyncMessageCodec codec = new EhcacheSyncMessageCodec(new CommonConfigCodec());
     Map<Long, Chain> chainMap = new HashMap<>();
     Chain chain = getChain(true, createPayload(10L), createPayload(100L), createPayload(1000L));
     chainMap.put(1L, chain);

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/internal/messages/PassiveReplicationMessageCodecTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/internal/messages/PassiveReplicationMessageCodecTest.java
@@ -19,6 +19,7 @@ package org.ehcache.clustered.server.internal.messages;
 import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.PoolAllocation;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
+import org.ehcache.clustered.common.internal.messages.CommonConfigCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheMessageType;
 import org.ehcache.clustered.common.internal.store.Chain;
 import org.ehcache.clustered.server.internal.messages.PassiveReplicationMessage.ChainReplicationMessage;
@@ -43,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 public class PassiveReplicationMessageCodecTest {
 
   private static final long MESSAGE_ID = 42L;
-  private PassiveReplicationMessageCodec codec = new PassiveReplicationMessageCodec();
+  private PassiveReplicationMessageCodec codec = new PassiveReplicationMessageCodec(new CommonConfigCodec());
 
   @Test
   public void testClientIDTrackerMessageCodec() {


### PR DESCRIPTION
Encoding and decoding of `ServerSideConfiguration` and `ServerStoreConfiguration` has been refactored out to a common `ConfigCodec` class. This eliminates the encoding/decoding code that was duplicated in lifecycle, replication and sync message codecs. This refactoring will enable extensibility of the codecs as as well.