### PR TITLE
Clean up CacheOperationOutcomes.GetOutcome

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
@@ -157,7 +157,7 @@ class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cache.mana
 
   private long getMisses() {
     return getBulkCount(BulkOps.GET_ALL_MISS) +
-        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER, CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER)) +
+        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS)) +
         putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
         replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.MISS_NOT_PRESENT)) +
         conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
@@ -165,7 +165,7 @@ class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cache.mana
 
   private long getHits() {
     return getBulkCount(BulkOps.GET_ALL_HITS) +
-        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER, CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER)) +
+        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT)) +
         putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.HIT)) +
         replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT, CacheOperationOutcomes.ReplaceOutcome.MISS_PRESENT)) +
         conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS, CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));

--- a/core/src/main/java/org/ehcache/core/Ehcache.java
+++ b/core/src/main/java/org/ehcache/core/Ehcache.java
@@ -171,10 +171,10 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
 
       // Check for expiry first
       if (valueHolder == null) {
-        getObserver.end(GetOutcome.MISS_NO_LOADER);
+        getObserver.end(GetOutcome.MISS);
         return null;
       } else {
-        getObserver.end(GetOutcome.HIT_NO_LOADER);
+        getObserver.end(GetOutcome.HIT);
         return valueHolder.value();
       }
     } catch (StoreAccessException e) {
@@ -741,9 +741,9 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
           @Override
           public V apply(K mappedKey, V mappedValue) {
             if (mappedValue == null) {
-              getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER);
+              getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.MISS);
             } else {
-              getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER);
+              getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT);
             }
 
             V newValue = computeFunction.apply(mappedKey, mappedValue);
@@ -799,10 +799,10 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
 
       V returnValue = existingValue.get();
       if (returnValue != null) {
-        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER);
+        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT);
         removeObserver.end(RemoveOutcome.SUCCESS);
       } else {
-        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER);
+        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.MISS);
       }
       return returnValue;
     }
@@ -834,10 +834,10 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
 
       V returnValue = existingValue.get();
       if (returnValue != null) {
-        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER);
+        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT);
         putObserver.end(PutOutcome.UPDATED);
       } else {
-        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER);
+        getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.MISS);
         putObserver.end(PutOutcome.PUT);
       }
       return returnValue;
@@ -908,7 +908,7 @@ public class Ehcache<K, V> implements InternalCache<K, V> {
 
       if (!quiet) getObserver.begin();
       if (nextException == null) {
-        if (!quiet) getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER);
+        if (!quiet) getObserver.end(org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome.HIT);
         current = next;
         advance();
         return new ValueHolderBasedEntry<K, V>(current);

--- a/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
@@ -190,10 +190,10 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
 
       // Check for expiry first
       if (valueHolder == null) {
-        getObserver.end(GetOutcome.MISS_NO_LOADER);
+        getObserver.end(GetOutcome.MISS);
         return null;
       } else {
-        getObserver.end(GetOutcome.HIT_NO_LOADER);
+        getObserver.end(GetOutcome.HIT);
         return valueHolder.value();
       }
     } catch (StoreAccessException e) {
@@ -235,10 +235,10 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
 
       // Check for expiry first
       if (valueHolder == null) {
-        getObserver.end(GetOutcome.MISS_WITH_LOADER);
+        getObserver.end(GetOutcome.MISS);
         return null;
       } else {
-        getObserver.end(GetOutcome.HIT_WITH_LOADER);
+        getObserver.end(GetOutcome.HIT);
         return valueHolder.value();
       }
     } catch (StoreAccessException e) {
@@ -1234,9 +1234,9 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
           @Override
           public V apply(K mappedKey, V mappedValue) {
             if (mappedValue == null) {
-              getObserver.end(GetOutcome.MISS_NO_LOADER);
+              getObserver.end(GetOutcome.MISS);
             } else {
-              getObserver.end(GetOutcome.HIT_NO_LOADER);
+              getObserver.end(GetOutcome.HIT);
             }
 
             V newValue = computeFunction.apply(mappedKey, mappedValue);
@@ -1309,10 +1309,10 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
 
       V returnValue = existingValue.get();
       if (returnValue != null) {
-        getObserver.end(GetOutcome.HIT_NO_LOADER);
+        getObserver.end(GetOutcome.HIT);
         removeObserver.end(RemoveOutcome.SUCCESS);
       } else {
-        getObserver.end(GetOutcome.MISS_NO_LOADER);
+        getObserver.end(GetOutcome.MISS);
       }
       return returnValue;
     }
@@ -1350,10 +1350,10 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
 
       V returnValue = existingValue.get();
       if (returnValue != null) {
-        getObserver.end(GetOutcome.HIT_NO_LOADER);
+        getObserver.end(GetOutcome.HIT);
         putObserver.end(PutOutcome.UPDATED);
       } else {
-        getObserver.end(GetOutcome.MISS_NO_LOADER);
+        getObserver.end(GetOutcome.MISS);
         putObserver.end(PutOutcome.PUT);
       }
       return returnValue;
@@ -1424,7 +1424,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
 
       if (!quiet) getObserver.begin();
       if (nextException == null) {
-        if (!quiet) getObserver.end(GetOutcome.HIT_NO_LOADER);
+        if (!quiet) getObserver.end(GetOutcome.HIT);
         current = next;
         advance();
         return new ValueHolderBasedEntry<K, V>(current);

--- a/core/src/main/java/org/ehcache/core/statistics/CacheOperationOutcomes.java
+++ b/core/src/main/java/org/ehcache/core/statistics/CacheOperationOutcomes.java
@@ -39,14 +39,10 @@ public interface CacheOperationOutcomes {
    * Outcomes for cache Get operations.
    */
   enum GetOutcome implements CacheOperationOutcomes {
-    /** hit, no loader */
-    HIT_NO_LOADER,
-    /** miss, no loader */
-    MISS_NO_LOADER,
-    /** hit */
-    HIT_WITH_LOADER,
-    /** miss */
-    MISS_WITH_LOADER,
+    /** hit, loader or not is Cache impl specific */
+    HIT,
+    /** miss, loader or not is Cache impl specific*/
+    MISS,
     /** failure */
     FAILURE
   };

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicGetTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicGetTest.java
@@ -68,7 +68,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     assertThat(ehcache.get("key"), is(nullValue()));
     verify(this.store).get(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS));
   }
 
   /**
@@ -110,7 +110,7 @@ public class EhcacheBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.store).get(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT));
   }
 
   /**

--- a/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicGetTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheWithLoaderWriterBasicGetTest.java
@@ -81,7 +81,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     assertThat(ehcache.get("key"), is(nullValue()));
     verify(this.store).computeIfAbsent(eq("key"), getAnyFunction());
     verifyZeroInteractions(this.spiedResilienceStrategy);
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoadingOutcome.class));
   }
 
@@ -104,7 +104,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoaderWriter).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().containsKey("key"), is(false));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS));
     validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.CacheLoadingOutcome.SUCCESS));
   }
 
@@ -128,7 +128,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoaderWriter).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT));
     validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.CacheLoadingOutcome.SUCCESS));
   }
 
@@ -257,7 +257,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.store).computeIfAbsent(eq("key"), getAnyFunction());
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoadingOutcome.class));
   }
 
@@ -281,7 +281,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoaderWriter, never()).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoadingOutcome.class));
   }
 
@@ -306,7 +306,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoaderWriter, never()).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoadingOutcome.class));
   }
 
@@ -331,7 +331,7 @@ public class EhcacheWithLoaderWriterBasicGetTest extends EhcacheBasicCrudBase {
     verify(this.cacheLoaderWriter, never()).load(eq("key"));
     verifyZeroInteractions(this.spiedResilienceStrategy);
     assertThat(fakeStore.getEntryMap().get("key"), equalTo("value"));
-    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER));
+    validateStats(ehcache, EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT));
     validateStats(ehcache, EnumSet.noneOf(CacheOperationOutcomes.CacheLoadingOutcome.class));
   }
 

--- a/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
@@ -23,7 +23,6 @@ import org.ehcache.management.providers.CacheBinding;
 import org.ehcache.management.providers.ExposedCacheBinding;
 import org.terracotta.context.extended.OperationStatisticDescriptor;
 import org.terracotta.context.extended.StatisticsRegistry;
-import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.stats.Statistic;
 import org.terracotta.management.registry.collect.StatisticsRegistryMetadata;
@@ -50,8 +49,8 @@ class StandardEhcacheStatistics extends ExposedCacheBinding {
 
     this.statisticsRegistryMetadata = new StatisticsRegistryMetadata(statisticsRegistry);
 
-    EnumSet<CacheOperationOutcomes.GetOutcome> hit = of(CacheOperationOutcomes.GetOutcome.HIT_NO_LOADER, CacheOperationOutcomes.GetOutcome.HIT_WITH_LOADER);
-    EnumSet<CacheOperationOutcomes.GetOutcome> miss = of(CacheOperationOutcomes.GetOutcome.MISS_NO_LOADER, CacheOperationOutcomes.GetOutcome.MISS_WITH_LOADER);
+    EnumSet<CacheOperationOutcomes.GetOutcome> hit = of(CacheOperationOutcomes.GetOutcome.HIT);
+    EnumSet<CacheOperationOutcomes.GetOutcome> miss = of(CacheOperationOutcomes.GetOutcome.MISS);
     OperationStatisticDescriptor<CacheOperationOutcomes.GetOutcome> getCacheStatisticDescriptor = OperationStatisticDescriptor.descriptor("get", singleton("cache"), CacheOperationOutcomes.GetOutcome.class);
 
     statisticsRegistry.registerCompoundOperations("Cache:Hit", getCacheStatisticDescriptor, hit);


### PR DESCRIPTION
Dropped _NO_LOADER / _WITH_LOADER variants since the implementation
classes are now different, there is no possible confusion.