### PR TITLE
Adding Nexus Staging Plugin - take 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,28 @@
 import scripts.*
 import org.gradle.internal.jvm.Jvm
 
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"  
+  }
+}
+
+// This adds tasks to auto close or release nexus staging repos
+// see https://github.com/Codearte/gradle-nexus-staging-plugin/
+project.plugins.apply 'io.codearte.nexus-staging'
+project.nexusStaging {
+  username = project.sonatypeUser
+  password = project.sonatypePwd
+  packageGroup = 'org.ehcache'
+}
+
+// Disable automatic promotion for added safety
+closeAndPromoteRepository.enabled = false
+
+
 ext {
 
   baseVersion = findProperty('overrideVersion') ?: '3.2.1-SNAPSHOT'


### PR DESCRIPTION
Allows jobs to add "closeRepository" or "closeAndPromoteRepository" to the task list.

https://github.com/Codearte/gradle-nexus-staging-plugin/

This is a copy of the closed PR #1345 since it is now possible to do this in the absence of JDK 1.6