### PR TITLE
Fix #1710 Entity gets configured when created

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
@@ -210,10 +210,6 @@ public class EhcacheClientEntity implements Entity {
     }
   }
 
-  public UUID identity() {
-    return ClusteredEhcacheIdentity.deserialize(endpoint.getEntityConfiguration());
-  }
-
   @Override
   public void close() {
     endpoint.close();

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntity.java
@@ -18,12 +18,10 @@ package org.ehcache.clustered.client.internal;
 
 import org.ehcache.clustered.client.config.TimeoutDuration;
 import org.ehcache.clustered.client.internal.service.ClusteredTierDestructionException;
-import org.ehcache.clustered.client.internal.service.ClusteredTierManagerConfigurationException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierCreationException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierManagerValidationException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierReleaseException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierValidationException;
-import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.exceptions.ClusterException;
@@ -232,16 +230,6 @@ public class EhcacheClientEntity implements Entity {
       }
     } catch (ClusterException e) {
       throw new ClusteredTierManagerValidationException("Error validating server clustered tier manager", e);
-    }
-  }
-
-  public void configure(ServerSideConfiguration config) throws ClusteredTierManagerConfigurationException, TimeoutException {
-    try {
-      clientId = UUID.randomUUID();
-      this.messageFactory.setClientId(clientId);
-      invokeInternal(timeouts.getLifecycleOperationTimeout(), messageFactory.configureStoreManager(config), true);
-    } catch (ClusterException e) {
-      throw new ClusteredTierManagerConfigurationException("Error configuring clustered tier manager", e);
     }
   }
 

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityFactory.java
@@ -22,6 +22,7 @@ import org.ehcache.clustered.client.service.EntityBusyException;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLock;
 import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLock.Hold;
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.connection.Connection;
@@ -107,10 +108,10 @@ public class EhcacheClientEntityFactory {
     boolean finished = false;
 
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = getEntityRef(identifier);
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = getEntityRef(identifier);
       try {
         while (true) {
-          ref.create(UUID.randomUUID());
+          ref.create(new ClusteredTierManagerConfiguration(identifier, config));
           try {
             EhcacheClientEntity entity = ref.fetchEntity();
             try {
@@ -224,7 +225,7 @@ public class EhcacheClientEntityFactory {
     boolean finished = false;
 
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = getEntityRef(identifier);
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = getEntityRef(identifier);
       try {
         if (!ref.destroy()) {
           throw new EntityBusyException("Destroy operation failed; " + identifier + " clustered tier in use by other clients");
@@ -270,7 +271,7 @@ public class EhcacheClientEntityFactory {
     return new VoltronReadWriteLock(connection, "EhcacheClientEntityFactory-AccessLock-" + entityIdentifier);
   }
 
-  private EntityRef<EhcacheClientEntity, UUID> getEntityRef(String identifier) {
+  private EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> getEntityRef(String identifier) {
     try {
       return connection.getEntityRef(EhcacheClientEntity.class, ENTITY_VERSION, identifier);
     } catch (EntityNotProvidedException e) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/EhcacheClientEntityService.java
@@ -16,14 +16,13 @@
 
 package org.ehcache.clustered.client.internal;
 
-import java.util.UUID;
-
-import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.ehcache.clustered.common.internal.messages.CommonConfigCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 
+import org.ehcache.clustered.common.internal.messages.EntityConfigurationCodec;
 import org.ehcache.clustered.common.internal.messages.LifeCycleMessageCodec;
 import org.ehcache.clustered.common.internal.messages.ResponseCodec;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpCodec;
@@ -32,7 +31,9 @@ import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.EntityClientService;
 import org.terracotta.entity.MessageCodec;
 
-public class EhcacheClientEntityService implements EntityClientService<EhcacheClientEntity, UUID, EhcacheEntityMessage, EhcacheEntityResponse> {
+public class EhcacheClientEntityService implements EntityClientService<EhcacheClientEntity, ClusteredTierManagerConfiguration, EhcacheEntityMessage, EhcacheEntityResponse> {
+
+  private final EntityConfigurationCodec configCodec = new EntityConfigurationCodec(new CommonConfigCodec());
 
   @Override
   public boolean handlesEntityType(Class<EhcacheClientEntity> cls) {
@@ -40,13 +41,13 @@ public class EhcacheClientEntityService implements EntityClientService<EhcacheCl
   }
 
   @Override
-  public byte[] serializeConfiguration(UUID configuration) {
-    return ClusteredEhcacheIdentity.serialize(configuration);
+  public byte[] serializeConfiguration(ClusteredTierManagerConfiguration configuration) {
+    return configCodec.encode(configuration);
   }
 
   @Override
-  public UUID deserializeConfiguration(byte[] configuration) {
-    return ClusteredEhcacheIdentity.deserialize(configuration);
+  public ClusteredTierManagerConfiguration deserializeConfiguration(byte[] configuration) {
+    return configCodec.decodeClusteredTierManagerConfiguration(configuration);
   }
 
   @Override

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/replication/LifeCycleMessageActivePassvieReplicationTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/replication/LifeCycleMessageActivePassvieReplicationTest.java
@@ -24,11 +24,9 @@ import org.ehcache.clustered.client.internal.UnitTestConnectionService;
 import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLockEntityClientService;
 import org.ehcache.clustered.client.internal.service.ClusteredTierCreationException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierDestructionException;
-import org.ehcache.clustered.client.internal.service.ClusteredTierManagerConfigurationException;
 import org.ehcache.clustered.client.internal.service.ClusteringServiceFactory;
 import org.ehcache.clustered.client.service.ClusteringService;
 import org.ehcache.clustered.common.internal.exceptions.InvalidStoreException;
-import org.ehcache.clustered.common.internal.exceptions.InvalidStoreManagerException;
 import org.ehcache.clustered.lock.server.VoltronReadWriteLockServerEntityService;
 import org.ehcache.clustered.server.EhcacheServerEntityService;
 import org.junit.After;
@@ -77,33 +75,6 @@ public class LifeCycleMessageActivePassvieReplicationTest {
   public void tearDown() throws Exception {
     UnitTestConnectionService.removeStripe(STRIPENAME);
     clusterControl.tearDown();
-  }
-
-  @Test
-  public void testConfigureReplication() throws Exception {
-    ClusteringServiceConfiguration configuration =
-        ClusteringServiceConfigurationBuilder.cluster(URI.create(STRIPE_URI))
-            .autoCreate()
-            .build();
-
-    ClusteringService service = new ClusteringServiceFactory().create(configuration);
-
-    service.start(null);
-
-    EhcacheClientEntity clientEntity = getEntity(service);
-
-    clusterControl.terminateActive();
-    clusterControl.waitForActive();
-
-    try {
-      clientEntity.configure(configuration.getServerConfiguration());
-      fail("ClusteredTierManagerConfigurationException Expected.");
-    } catch (ClusteredTierManagerConfigurationException e) {
-      assertThat(e.getCause(), instanceOf(InvalidStoreManagerException.class));
-      assertThat(e.getCause().getMessage(), is("Clustered Tier Manager already configured"));
-    }
-
-    service.stop();
   }
 
   @Test

--- a/clustered/client/src/test/java/org/ehcache/clustered/server/ObservableEhcacheServerEntityService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/server/ObservableEhcacheServerEntityService.java
@@ -21,6 +21,7 @@ import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.ConcurrencyStrategy;
+import org.terracotta.entity.ConfigurationException;
 import org.terracotta.entity.EntityServerService;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.PassiveServerEntity;
@@ -78,14 +79,14 @@ public class ObservableEhcacheServerEntityService
   }
 
   @Override
-  public EhcacheActiveEntity createActiveEntity(ServiceRegistry registry, byte[] configuration) {
+  public EhcacheActiveEntity createActiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     EhcacheActiveEntity activeEntity = delegate.createActiveEntity(registry, configuration);
     servedActiveEntities.add(activeEntity);
     return activeEntity;
   }
 
   @Override
-  public EhcachePassiveEntity createPassiveEntity(ServiceRegistry registry, byte[] configuration) {
+  public EhcachePassiveEntity createPassiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     EhcachePassiveEntity passiveEntity = delegate.createPassiveEntity(registry, configuration);
     servedPassiveEntities.add(passiveEntity);
     return passiveEntity;

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/ClusteredTierManagerConfiguration.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/ClusteredTierManagerConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal;
+
+import org.ehcache.clustered.common.ServerSideConfiguration;
+
+/**
+ * ClusteredTierManagerConfiguration
+ */
+public class ClusteredTierManagerConfiguration {
+
+  private final String identifier;
+  private final ServerSideConfiguration configuration;
+
+  public ClusteredTierManagerConfiguration(String identifier, ServerSideConfiguration configuration) {
+    this.identifier = identifier;
+    this.configuration = configuration;
+  }
+
+  public ServerSideConfiguration getConfiguration() {
+    return configuration;
+  }
+
+  public String getIdentifier() {
+    return identifier;
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheMessageType.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EhcacheMessageType.java
@@ -30,7 +30,6 @@ import static org.terracotta.runnel.EnumMappingBuilder.newEnumMappingBuilder;
  */
 public enum EhcacheMessageType {
   // Lifecycle messages
-  CONFIGURE,
   VALIDATE,
   CREATE_SERVER_STORE,
   VALIDATE_SERVER_STORE,
@@ -61,12 +60,11 @@ public enum EhcacheMessageType {
   public static final String MESSAGE_TYPE_FIELD_NAME = "opCode";
   public static final int MESSAGE_TYPE_FIELD_INDEX = 10;
   public static final EnumMapping<EhcacheMessageType> EHCACHE_MESSAGE_TYPES_ENUM_MAPPING = newEnumMappingBuilder(EhcacheMessageType.class)
-    .mapping(CONFIGURE, 1)
-    .mapping(VALIDATE, 2)
-    .mapping(CREATE_SERVER_STORE, 3)
-    .mapping(VALIDATE_SERVER_STORE, 4)
-    .mapping(RELEASE_SERVER_STORE, 5)
-    .mapping(DESTROY_SERVER_STORE, 6)
+    .mapping(VALIDATE, 1)
+    .mapping(CREATE_SERVER_STORE, 2)
+    .mapping(VALIDATE_SERVER_STORE, 3)
+    .mapping(RELEASE_SERVER_STORE, 4)
+    .mapping(DESTROY_SERVER_STORE, 5)
 
     .mapping(GET_AND_APPEND, 21)
     .mapping(APPEND, 22)
@@ -87,7 +85,7 @@ public enum EhcacheMessageType {
     .mapping(DESTROY_SERVER_STORE_REPLICATION, 66)
     .build();
 
-  public static final EnumSet<EhcacheMessageType> LIFECYCLE_MESSAGES = of(CONFIGURE, VALIDATE, CREATE_SERVER_STORE, VALIDATE_SERVER_STORE, RELEASE_SERVER_STORE, DESTROY_SERVER_STORE);
+  public static final EnumSet<EhcacheMessageType> LIFECYCLE_MESSAGES = of(VALIDATE, CREATE_SERVER_STORE, VALIDATE_SERVER_STORE, RELEASE_SERVER_STORE, DESTROY_SERVER_STORE);
   public static boolean isLifecycleMessage(EhcacheMessageType value) {
     return LIFECYCLE_MESSAGES.contains(value);
   }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EntityConfigurationCodec.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/EntityConfigurationCodec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.common.internal.messages;
+
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.StructBuilder;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructEncoder;
+
+import static java.nio.ByteBuffer.wrap;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
+
+/**
+ * EntityConfigurationCodec
+ */
+public class EntityConfigurationCodec {
+
+  private static final String IDENTIFIER = "identifier";
+
+  private final StructBuilder tierManagerConfigurationBaseStruct = newStructBuilder()
+    .string(IDENTIFIER, 10);
+
+  private final ConfigCodec configCodec;
+  private final Struct tierManagerConfigurationStruct;
+
+  public EntityConfigurationCodec(ConfigCodec configCodec) {
+    this.configCodec = configCodec;
+    tierManagerConfigurationStruct = configCodec.injectServerSideConfiguration(tierManagerConfigurationBaseStruct, 10)
+      .getUpdatedBuilder()
+      .build();
+  }
+
+  public byte[] encode(ClusteredTierManagerConfiguration configuration) {
+    StructEncoder encoder = tierManagerConfigurationStruct.encoder();
+    encoder.string(IDENTIFIER, configuration.getIdentifier());
+    configCodec.encodeServerSideConfiguration(encoder, configuration.getConfiguration());
+    return encoder.encode().array();
+  }
+
+  public ClusteredTierManagerConfiguration decodeClusteredTierManagerConfiguration(byte[] payload) {
+    StructDecoder decoder = tierManagerConfigurationStruct.decoder(wrap(payload));
+    String identifier = decoder.string(IDENTIFIER);
+    if (identifier == null) {
+      throw new IllegalArgumentException("Payload is an invalid content");
+    }
+    ServerSideConfiguration configuration = configCodec.decodeServerSideConfiguration(decoder);
+    if (configuration == null) {
+      throw new AssertionError("Creation configuration cannot be null");
+    }
+    return new ClusteredTierManagerConfiguration(identifier, configuration);
+  }
+}

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageFactory.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageFactory.java
@@ -29,10 +29,6 @@ public class LifeCycleMessageFactory {
     return new LifecycleMessage.ValidateStoreManager(configuration, clientId);
   }
 
-  public LifecycleMessage configureStoreManager(ServerSideConfiguration configuration) {
-    return new LifecycleMessage.ConfigureStoreManager(configuration, clientId);
-  }
-
   public LifecycleMessage createServerStore(String name, ServerStoreConfiguration serverStoreConfiguration) {
     return new LifecycleMessage.CreateServerStore(name, serverStoreConfiguration, clientId);
   }

--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifecycleMessage.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/messages/LifecycleMessage.java
@@ -65,26 +65,6 @@ public abstract class LifecycleMessage extends EhcacheOperationMessage implement
     }
   }
 
-  public static class ConfigureStoreManager extends LifecycleMessage {
-    private static final long serialVersionUID = 730771302294202898L;
-
-    private final ServerSideConfiguration configuration;
-
-    ConfigureStoreManager(ServerSideConfiguration config, UUID clientId) {
-      this.configuration = config;
-      this.clientId = clientId;
-    }
-
-    @Override
-    public EhcacheMessageType getMessageType() {
-      return EhcacheMessageType.CONFIGURE;
-    }
-
-    public ServerSideConfiguration getConfiguration() {
-      return configuration;
-    }
-  }
-
   public abstract static class BaseServerStore extends LifecycleMessage {
     private static final long serialVersionUID = 4879477027919589726L;
 

--- a/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodecTest.java
+++ b/clustered/common/src/test/java/org/ehcache/clustered/common/internal/messages/LifeCycleMessageCodecTest.java
@@ -49,20 +49,6 @@ public class LifeCycleMessageCodecTest {
   }
 
   @Test
-  public void testConfigureStoreManager() throws Exception {
-    ServerSideConfiguration configuration = getServerSideConfiguration();
-    LifecycleMessage message = factory.configureStoreManager(configuration);
-
-    byte[] encoded = codec.encode(message);
-    LifecycleMessage.ConfigureStoreManager decodedMessage = (LifecycleMessage.ConfigureStoreManager) codec.decode(message.getMessageType(), wrap(encoded));
-
-    assertThat(decodedMessage.getClientId(), is(CLIENT_ID));
-    assertThat(decodedMessage.getMessageType(), is(EhcacheMessageType.CONFIGURE));
-    assertThat(decodedMessage.getConfiguration().getDefaultServerResource(), is(configuration.getDefaultServerResource()));
-    assertThat(decodedMessage.getConfiguration().getResourcePools(), is(configuration.getResourcePools()));
-  }
-
-  @Test
   public void testValidateStoreManager() throws Exception {
     ServerSideConfiguration configuration = getServerSideConfiguration();
     LifecycleMessage message = factory.validateStoreManager(configuration);

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicEntityInteractionTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/BasicEntityInteractionTest.java
@@ -17,8 +17,10 @@ package org.ehcache.clustered;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.UUID;
 import org.ehcache.clustered.client.internal.EhcacheClientEntity;
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
+import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -30,7 +32,9 @@ import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.testing.rules.BasicExternalCluster;
 import org.terracotta.testing.rules.Cluster;
 
-import static org.hamcrest.core.Is.is;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -45,6 +49,7 @@ public class BasicEntityInteractionTest {
 
   @ClassRule
   public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, Collections.<File>emptyList(), "", RESOURCE_CONFIG, "");
+  private ClusteredTierManagerConfiguration blankConfiguration = new ClusteredTierManagerConfiguration("identifier", new ServerSideConfiguration(emptyMap()));
 
   @BeforeClass
   public static void waitForActive() throws Exception {
@@ -55,7 +60,7 @@ public class BasicEntityInteractionTest {
   public void testAbsentEntityRetrievalFails() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testAbsentEntityRetrievalFails");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testAbsentEntityRetrievalFails");
 
       try {
         ref.fetchEntity();
@@ -72,20 +77,10 @@ public class BasicEntityInteractionTest {
   public void testAbsentEntityCreationSucceeds() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testAbsentEntityCreationSucceeds");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testAbsentEntityCreationSucceeds");
 
-      UUID uuid = UUID.randomUUID();
-      ref.create(uuid);
-      try {
-        EhcacheClientEntity entity = ref.fetchEntity();
-        try {
-          assertThat(entity.identity(), is(uuid));
-        } finally {
-          entity.close();
-        }
-      } finally {
-        ref.destroy();
-      }
+      ref.create(blankConfiguration);
+      assertThat(ref.fetchEntity(), not(Matchers.nullValue()));
     } finally {
       client.close();
     }
@@ -95,20 +90,20 @@ public class BasicEntityInteractionTest {
   public void testPresentEntityCreationFails() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityCreationFails");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityCreationFails");
 
-      UUID uuid = UUID.randomUUID();
-      ref.create(uuid);
+      ref.create(blankConfiguration);
       try {
         try {
-          ref.create(uuid);
+          ref.create(blankConfiguration);
           fail("Expected EntityAlreadyExistsException");
         } catch (EntityAlreadyExistsException e) {
           //expected
         }
 
+        ClusteredTierManagerConfiguration otherConfiguration = new ClusteredTierManagerConfiguration("different", new ServerSideConfiguration(emptyMap()));
         try {
-          ref.create(UUID.randomUUID());
+          ref.create(otherConfiguration);
           fail("Expected EntityAlreadyExistsException");
         } catch (EntityAlreadyExistsException e) {
           //expected
@@ -125,7 +120,7 @@ public class BasicEntityInteractionTest {
   public void testAbsentEntityDestroyFails() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testAbsentEntityDestroyFails");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testAbsentEntityDestroyFails");
 
       try {
         ref.destroy();
@@ -142,10 +137,9 @@ public class BasicEntityInteractionTest {
   public void testPresentEntityDestroySucceeds() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityDestroySucceeds");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityDestroySucceeds");
 
-      UUID uuid = UUID.randomUUID();
-      ref.create(uuid);
+      ref.create(blankConfiguration);
       ref.destroy();
 
       try {
@@ -164,10 +158,9 @@ public class BasicEntityInteractionTest {
   public void testPresentEntityDestroyBlockedByHeldReferenceSucceeds() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityDestroyBlockedByHeldReferenceSucceeds");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityDestroyBlockedByHeldReferenceSucceeds");
 
-      UUID uuid = UUID.randomUUID();
-      ref.create(uuid);
+      ref.create(blankConfiguration);
 
       EhcacheClientEntity entity = ref.fetchEntity();
       try {
@@ -184,10 +177,9 @@ public class BasicEntityInteractionTest {
   public void testPresentEntityDestroyNotBlockedByReleasedReferenceSucceeds() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityDestroyNotBlockedByReleasedReferenceSucceeds");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testPresentEntityDestroyNotBlockedByReleasedReferenceSucceeds");
 
-      UUID uuid = UUID.randomUUID();
-      ref.create(uuid);
+      ref.create(blankConfiguration);
       ref.fetchEntity().close();
       ref.destroy();
     } finally {
@@ -199,23 +191,13 @@ public class BasicEntityInteractionTest {
   public void testDestroyedEntityAllowsRecreation() throws Throwable {
     Connection client = CLUSTER.newConnection();
     try {
-      EntityRef<EhcacheClientEntity, UUID> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testDestroyedEntityAllowsRecreation");
+      EntityRef<EhcacheClientEntity, ClusteredTierManagerConfiguration> ref = client.getEntityRef(EhcacheClientEntity.class, 1, "testDestroyedEntityAllowsRecreation");
 
-      ref.create(UUID.randomUUID());
+      ref.create(blankConfiguration);
       ref.destroy();
 
-      UUID uuid = UUID.randomUUID();
-      ref.create(uuid);
-      try {
-        EhcacheClientEntity entity = ref.fetchEntity();
-        try {
-          assertThat(entity.identity(), is(uuid));
-        } finally {
-          entity.close();
-        }
-      } finally {
-        ref.destroy();
-      }
+      ref.create(blankConfiguration);
+      assertThat(ref.fetchEntity(), not(nullValue()));
     } finally {
       client.close();
     }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicLifeCyclePassiveReplicationTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicLifeCyclePassiveReplicationTest.java
@@ -26,23 +26,19 @@ import org.ehcache.clustered.client.internal.EhcacheClientEntity;
 import org.ehcache.clustered.client.internal.lock.VoltronReadWriteLock;
 import org.ehcache.clustered.client.internal.service.ClusteredTierCreationException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierDestructionException;
-import org.ehcache.clustered.client.internal.service.ClusteredTierManagerConfigurationException;
 import org.ehcache.clustered.client.internal.service.ClusteredTierManagerValidationException;
 import org.ehcache.clustered.client.internal.service.ClusteringServiceFactory;
 import org.ehcache.clustered.client.service.ClusteringService;
 import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.exceptions.InvalidStoreException;
-import org.ehcache.clustered.common.internal.exceptions.InvalidStoreManagerException;
 import org.ehcache.clustered.common.internal.exceptions.LifecycleException;
-import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.impl.serialization.CompactJavaSerializer;
 import org.ehcache.spi.service.MaintainableService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.testing.rules.BasicExternalCluster;
 import org.terracotta.testing.rules.Cluster;
@@ -146,33 +142,6 @@ public class BasicLifeCyclePassiveReplicationTest {
     } catch (ClusteredTierDestructionException e) {
       assertThat(e.getCause(), instanceOf(InvalidStoreException.class));
       assertThat(e.getCause().getMessage(), is("Clustered tier 'testCache' does not exist"));
-    }
-
-    service.stop();
-    cleanUpCluster(service);
-  }
-
-  @Test
-  public void testConfigureReplication() throws Exception {
-    ClusteringServiceConfiguration configuration =
-        ClusteringServiceConfigurationBuilder.cluster(CLUSTER.getConnectionURI())
-            .autoCreate()
-            .build();
-
-    ClusteringService service = new ClusteringServiceFactory().create(configuration);
-
-    service.start(null);
-
-    EhcacheClientEntity clientEntity = getEntity(service);
-
-    CLUSTER.getClusterControl().terminateActive();
-
-    try {
-      clientEntity.configure(configuration.getServerConfiguration());
-      fail("ClusteredTierManagerConfigurationException Expected.");
-    } catch (ClusteredTierManagerConfigurationException e) {
-      assertThat(e.getCause(), instanceOf(InvalidStoreManagerException.class));
-      assertThat(e.getCause().getMessage(), is("Clustered Tier Manager already configured"));
     }
 
     service.stop();

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -466,9 +466,6 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
 
   private EhcacheEntityResponse invokeLifeCycleOperation(ClientDescriptor clientDescriptor, LifecycleMessage message) throws ClusterException {
     switch (message.getMessageType()) {
-      case CONFIGURE:
-        // TODO remove message altogether
-        break;
       case VALIDATE:
         validate(clientDescriptor, (ValidateStoreManager) message);
         break;

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -102,7 +102,7 @@ import static org.ehcache.clustered.common.internal.messages.LifecycleMessage.Va
 import static org.ehcache.clustered.server.ConcurrencyStrategies.DefaultConcurrencyStrategy.DATA_CONCURRENCY_KEY_OFFSET;
 import static org.ehcache.clustered.server.ConcurrencyStrategies.DefaultConcurrencyStrategy.DEFAULT_KEY;
 
-class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> {
+public class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheActiveEntity.class);
   static final String SYNC_DATA_SIZE_PROP = "ehcache.sync.data.size.threshold";
@@ -161,7 +161,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
     }
   }
 
-  EhcacheActiveEntity(ServiceRegistry services, ClusteredTierManagerConfiguration config, final KeySegmentMapper mapper) throws ConfigurationException {
+  public EhcacheActiveEntity(ServiceRegistry services, ClusteredTierManagerConfiguration config, final KeySegmentMapper mapper) throws ConfigurationException {
     if (config == null) {
       throw new ConfigurationException("ClusteredTierManagerConfiguration cannot be null");
     }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -37,7 +37,6 @@ import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
-import org.ehcache.clustered.common.internal.ClusteredEhcacheIdentity;
 import org.ehcache.clustered.common.PoolAllocation;
 import org.ehcache.clustered.common.internal.exceptions.ClusterException;
 import org.ehcache.clustered.common.internal.exceptions.InvalidClientIdException;
@@ -84,7 +83,6 @@ import org.terracotta.entity.MessageCodecException;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceRegistry;
-import org.terracotta.offheapresource.OffHeapResources;
 
 import static org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse.allInvalidationDone;
 import static org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse.clientInvalidateAll;
@@ -96,7 +94,6 @@ import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.
 import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isPassiveReplicationMessage;
 import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isStateRepoOperationMessage;
 import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isStoreOperationMessage;
-import static org.ehcache.clustered.common.internal.messages.LifecycleMessage.ConfigureStoreManager;
 import static org.ehcache.clustered.common.internal.messages.LifecycleMessage.CreateServerStore;
 import static org.ehcache.clustered.common.internal.messages.LifecycleMessage.DestroyServerStore;
 import static org.ehcache.clustered.common.internal.messages.LifecycleMessage.ReleaseServerStore;
@@ -110,9 +107,6 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
   private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheActiveEntity.class);
   static final String SYNC_DATA_SIZE_PROP = "ehcache.sync.data.size.threshold";
   private static final long DEFAULT_SYNC_DATA_SIZE_THRESHOLD = 4 * 1024 * 1024;
-
-  private final String identifier;
-  private final ServerSideConfiguration configuration;
 
   /**
    * Tracks the state of a connected client.  An entry is added to this map when the
@@ -137,6 +131,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
   private volatile ConcurrentHashMap<String, List<InvalidationTuple>> inflightInvalidations;
   private final Management management;
   private final AtomicBoolean reconnectComplete = new AtomicBoolean(true);
+  private final ServerSideConfiguration configuration;
 
   static class InvalidationHolder {
     final ClientDescriptor clientDescriptorWaitingForInvalidation;
@@ -166,35 +161,28 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
     }
   }
 
-  private static class OffHeapResourcesServiceConfiguration implements ServiceConfiguration<OffHeapResources> {
-
-    @Override
-    public Class<OffHeapResources> getServiceType() {
-      return OffHeapResources.class;
-    }
-
-  }
-
   EhcacheActiveEntity(ServiceRegistry services, ClusteredTierManagerConfiguration config, final KeySegmentMapper mapper) throws ConfigurationException {
     if (config == null) {
       throw new ConfigurationException("ClusteredTierManagerConfiguration cannot be null");
     }
-    this.identifier = config.getIdentifier();
     this.configuration = config.getConfiguration();
     this.responseFactory = new EhcacheEntityResponseFactory();
     this.clientCommunicator = services.getService(new CommunicatorServiceConfiguration());
-    ehcacheStateService = services.getService(new EhcacheStateServiceConfig(services, mapper));
+    ehcacheStateService = services.getService(new EhcacheStateServiceConfig(config, services, mapper));
     if (ehcacheStateService == null) {
       throw new AssertionError("Server failed to retrieve EhcacheStateService.");
-    }
-    if (!ehcacheStateService.hasValidOffheapResources()) {
-      throw new ConfigurationException("Server does not have offheap-resource configured - Unable to create Ehcache clustering components");
     }
     entityMessenger = services.getService(new BasicServiceConfiguration<>(IEntityMessenger.class));
     if (entityMessenger == null) {
       throw new AssertionError("Server failed to retrieve IEntityMessenger service.");
     }
-    this.management = new Management(services, ehcacheStateService, true);
+    try {
+      ehcacheStateService.configure();
+      this.management = new Management(services, ehcacheStateService, true);
+    } catch (ConfigurationException e) {
+      ehcacheStateService.destroy();
+      throw e;
+    }
   }
 
   /**
@@ -420,11 +408,12 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
   @Override
   public void createNew() {
     management.init();
+    management.sharedPoolsConfigured();
   }
 
   @Override
   public void loadExisting() {
-    ehcacheStateService.loadExisting();
+    ehcacheStateService.loadExisting(configuration);
     LOGGER.debug("Preparing for handling Inflight Invalidations and independent Passive Evictions in loadExisting");
     inflightInvalidations = new ConcurrentHashMap<>();
     addInflightInvalidationsForEventualCaches();
@@ -478,7 +467,7 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
   private EhcacheEntityResponse invokeLifeCycleOperation(ClientDescriptor clientDescriptor, LifecycleMessage message) throws ClusterException {
     switch (message.getMessageType()) {
       case CONFIGURE:
-        configure(clientDescriptor, (ConfigureStoreManager) message);
+        // TODO remove message altogether
         break;
       case VALIDATE:
         validate(clientDescriptor, (ValidateStoreManager) message);
@@ -752,22 +741,6 @@ class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMessage, Eh
 
     ehcacheStateService.destroy();
 
-  }
-
-  /**
-   * Handles the {@link LifecycleMessage.ConfigureStoreManager ConfigureStoreManager} message.  This method creates the shared
-   * resource pools to be available to clients of this {@code EhcacheActiveEntity}.
-   *
-   * @param clientDescriptor the client identifier requesting store manager configuration
-   * @param message the {@code ConfigureStoreManager} message carrying the desired shared resource pool configuration
-   */
-  private void configure(ClientDescriptor clientDescriptor, ConfigureStoreManager message) throws ClusterException {
-    validateClientConnected(clientDescriptor);
-    if (ehcacheStateService.getClientMessageTracker().isConfigureApplicable(message.getClientId(), message.getId())) {
-      ehcacheStateService.configure(message.getConfiguration());
-    }
-    this.clientStateMap.get(clientDescriptor).attach();
-    management.sharedPoolsConfigured();
   }
 
   /**

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheExecutionStrategy.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheExecutionStrategy.java
@@ -36,8 +36,6 @@ class EhcacheExecutionStrategy implements ExecutionStrategy<EhcacheEntityMessage
     } else if (message instanceof ServerStoreOpMessage) {
       // Server store operation not needing replication
       return Location.ACTIVE;
-    } else if (message instanceof LifecycleMessage.ConfigureStoreManager) {
-      return Location.BOTH;
     } else if (message instanceof LifecycleMessage.ValidateStoreManager) {
       return Location.ACTIVE;
     } else if (message instanceof LifecycleMessage.CreateServerStore) {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
@@ -18,7 +18,6 @@ package org.ehcache.clustered.server;
 
 import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.PoolAllocation;
-import org.ehcache.clustered.common.ServerSideConfiguration;
 import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.exceptions.ClusterException;
@@ -28,7 +27,6 @@ import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
 import org.ehcache.clustered.common.internal.messages.EhcacheMessageType;
 import org.ehcache.clustered.common.internal.messages.EhcacheOperationMessage;
 import org.ehcache.clustered.common.internal.messages.LifecycleMessage;
-import org.ehcache.clustered.common.internal.messages.LifecycleMessage.ConfigureStoreManager;
 import org.ehcache.clustered.server.internal.messages.PassiveReplicationMessage;
 import org.ehcache.clustered.server.internal.messages.PassiveReplicationMessage.ChainReplicationMessage;
 import org.ehcache.clustered.server.internal.messages.PassiveReplicationMessage.ClearInvalidationCompleteMessage;
@@ -243,9 +241,6 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
 
   private void invokeLifeCycleOperation(LifecycleMessage message) throws ClusterException {
     switch (message.getMessageType()) {
-      case CONFIGURE:
-        // TODO remove message altogether
-        break;
       case VALIDATE:
         applyMessage(message);
         break;

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcachePassiveEntity.java
@@ -55,7 +55,7 @@ import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.
 import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isStateRepoOperationMessage;
 import static org.ehcache.clustered.common.internal.messages.EhcacheMessageType.isStoreOperationMessage;
 
-class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> {
+public class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, EhcacheEntityResponse> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EhcachePassiveEntity.class);
 
@@ -105,7 +105,7 @@ class EhcachePassiveEntity implements PassiveServerEntity<EhcacheEntityMessage, 
     }
   }
 
-  EhcachePassiveEntity(ServiceRegistry services, ClusteredTierManagerConfiguration config, final KeySegmentMapper mapper) throws ConfigurationException {
+  public EhcachePassiveEntity(ServiceRegistry services, ClusteredTierManagerConfiguration config, final KeySegmentMapper mapper) throws ConfigurationException {
     if (config == null) {
       throw new ConfigurationException("ClusteredTierManagerConfiguration cannot be null");
     }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheServerEntityService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheServerEntityService.java
@@ -15,11 +15,13 @@
  */
 package org.ehcache.clustered.server;
 
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.ehcache.clustered.common.internal.messages.CommonConfigCodec;
 import org.ehcache.clustered.common.internal.messages.ConfigCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheCodec;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
+import org.ehcache.clustered.common.internal.messages.EntityConfigurationCodec;
 import org.ehcache.clustered.common.internal.messages.LifeCycleMessageCodec;
 import org.ehcache.clustered.common.internal.messages.ResponseCodec;
 import org.ehcache.clustered.common.internal.messages.ServerStoreOpCodec;
@@ -29,6 +31,7 @@ import org.ehcache.clustered.server.internal.messages.EhcacheSyncMessageCodec;
 import org.ehcache.clustered.server.internal.messages.PassiveReplicationMessageCodec;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.entity.ConcurrencyStrategy;
+import org.terracotta.entity.ConfigurationException;
 import org.terracotta.entity.EntityServerService;
 import org.terracotta.entity.ExecutionStrategy;
 import org.terracotta.entity.MessageCodec;
@@ -44,6 +47,8 @@ public class EhcacheServerEntityService implements EntityServerService<EhcacheEn
   private static final KeySegmentMapper DEFAULT_MAPPER = new KeySegmentMapper(DEFAULT_CONCURRENCY);
   private static final ConfigCodec CONFIG_CODEC = new CommonConfigCodec();
 
+  private final EntityConfigurationCodec configCodec = new EntityConfigurationCodec(new CommonConfigCodec());
+
   @Override
   public long getVersion() {
     return ENTITY_VERSION;
@@ -55,13 +60,15 @@ public class EhcacheServerEntityService implements EntityServerService<EhcacheEn
   }
 
   @Override
-  public EhcacheActiveEntity createActiveEntity(ServiceRegistry registry, byte[] configuration) {
-    return new EhcacheActiveEntity(registry, configuration, DEFAULT_MAPPER);
+  public EhcacheActiveEntity createActiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
+    ClusteredTierManagerConfiguration clusteredTierManagerConfiguration = configCodec.decodeClusteredTierManagerConfiguration(configuration);
+    return new EhcacheActiveEntity(registry, clusteredTierManagerConfiguration, DEFAULT_MAPPER);
   }
 
   @Override
-  public EhcachePassiveEntity createPassiveEntity(ServiceRegistry registry, byte[] configuration) {
-    return new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
+  public EhcachePassiveEntity createPassiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
+    ClusteredTierManagerConfiguration clusteredTierManagerConfiguration = configCodec.decodeClusteredTierManagerConfiguration(configuration);
+    return new EhcachePassiveEntity(registry, clusteredTierManagerConfiguration, DEFAULT_MAPPER);
   }
 
   @Override

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
@@ -118,6 +118,11 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
     this.stateRepositoryManager = new StateRepositoryManager();
   }
 
+  @Override
+  public boolean hasValidOffheapResources() {
+    return offHeapResources != null && !offHeapResources.getAllIdentifiers().isEmpty();
+  }
+
   public ServerStoreImpl getStore(String name) {
     return stores.get(name);
   }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/ClientMessageTracker.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/ClientMessageTracker.java
@@ -32,11 +32,9 @@ public class ClientMessageTracker {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientMessageTracker.class);
 
   private final ConcurrentMap<UUID, MessageTracker> messageTrackers = new ConcurrentHashMap<>();
-  private volatile UUID entityConfiguredStamp = null;
-  private volatile long configuredTimestamp;
 
   //TODO : This method will be removed once we move to model where
-  //caches are entites. Then passive just needs to keep track of
+  //caches are entities. Then passive just needs to keep track of
   //applied messages. Thus only 'applied' method will be keeping
   // track of watermarking for de-duplication. This method is only
   // allowed to be used by cache lifecycle message for now.
@@ -74,21 +72,6 @@ public class ClientMessageTracker {
   public void remove(UUID clientId) {
     messageTrackers.remove(clientId);
     LOGGER.info("Stop tracking client {}.", clientId);
-  }
-
-  public void setEntityConfiguredStamp(UUID clientId, long timestamp) {
-    this.entityConfiguredStamp = clientId;
-    this.configuredTimestamp = timestamp;
-  }
-
-  public boolean isConfigureApplicable(UUID clientId, long timestamp) {
-    if (entityConfiguredStamp == null) {
-      return true;
-    }
-    if (clientId.equals(entityConfiguredStamp) && configuredTimestamp == timestamp) {
-      return false;
-    }
-    return true;
   }
 
   public void reconcileTrackedClients(Set<UUID> trackedClients) {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
@@ -21,6 +21,7 @@ import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.exceptions.ClusterException;
 import org.ehcache.clustered.server.ServerSideServerStore;
 import org.ehcache.clustered.server.repo.StateRepositoryManager;
+import org.terracotta.entity.ConfigurationException;
 
 import com.tc.classloader.CommonComponent;
 
@@ -29,8 +30,6 @@ import java.util.Set;
 
 @CommonComponent
 public interface EhcacheStateService {
-
-  boolean hasValidOffheapResources();
 
   String getDefaultServerResource();
 
@@ -50,7 +49,7 @@ public interface EhcacheStateService {
 
   void validate(ServerSideConfiguration configuration) throws ClusterException;
 
-  void configure(ServerSideConfiguration configuration) throws ClusterException;
+  void configure() throws ConfigurationException;
 
   ServerSideServerStore createStore(String name, ServerStoreConfiguration serverStoreConfiguration) throws ClusterException;
 
@@ -68,6 +67,6 @@ public interface EhcacheStateService {
 
   InvalidationTracker removeInvalidationtracker(String cacheId);
 
-  void loadExisting();
+  void loadExisting(ServerSideConfiguration configuration);
 
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
@@ -30,6 +30,8 @@ import java.util.Set;
 @CommonComponent
 public interface EhcacheStateService {
 
+  boolean hasValidOffheapResources();
+
   String getDefaultServerResource();
 
   Map<String, ServerSideConfiguration.Pool> getSharedResourcePools();

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateServiceProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateServiceProvider.java
@@ -69,10 +69,6 @@ public class EhcacheStateServiceProvider implements ServiceProvider {
   @Override
   public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
     if (configuration != null && configuration.getServiceType().equals(EhcacheStateService.class)) {
-      if (offHeapResourcesProvider == null) {
-        LOGGER.warn("EhcacheStateService requested but no offheap-resource was defined - returning null");
-        return null;
-      }
       EhcacheStateServiceConfig stateServiceConfig = (EhcacheStateServiceConfig) configuration;
       EhcacheStateService storeManagerService = new EhcacheStateServiceImpl(
         offHeapResourcesProvider, stateServiceConfig.getMapper());

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateServiceProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateServiceProvider.java
@@ -44,7 +44,7 @@ public class EhcacheStateServiceProvider implements ServiceProvider {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EhcacheStateServiceProvider.class);
 
-  private ConcurrentMap<Long, EhcacheStateService> serviceMap = new ConcurrentHashMap<>();
+  private ConcurrentMap<String, EhcacheStateService> serviceMap = new ConcurrentHashMap<>();
   private OffHeapResources offHeapResourcesProvider;
 
   @Override
@@ -70,9 +70,10 @@ public class EhcacheStateServiceProvider implements ServiceProvider {
   public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
     if (configuration != null && configuration.getServiceType().equals(EhcacheStateService.class)) {
       EhcacheStateServiceConfig stateServiceConfig = (EhcacheStateServiceConfig) configuration;
-      EhcacheStateService storeManagerService = new EhcacheStateServiceImpl(
-        offHeapResourcesProvider, stateServiceConfig.getMapper());
-      EhcacheStateService result = serviceMap.putIfAbsent(consumerID, storeManagerService);
+      EhcacheStateServiceImpl storeManagerService = new EhcacheStateServiceImpl(
+        offHeapResourcesProvider, stateServiceConfig.getConfig().getConfiguration(), stateServiceConfig.getMapper(),
+        service -> serviceMap.remove(stateServiceConfig.getConfig().getIdentifier(), service));
+      EhcacheStateService result = serviceMap.putIfAbsent(stateServiceConfig.getConfig().getIdentifier(), storeManagerService);
       if (result == null) {
         result = storeManagerService;
       }
@@ -93,5 +94,9 @@ public class EhcacheStateServiceProvider implements ServiceProvider {
   @Override
   public void prepareForSynchronization() throws ServiceProviderCleanupException {
     serviceMap.clear();
+  }
+
+  public interface DestroyCallback {
+    void destroy(EhcacheStateService service);
   }
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/config/EhcacheStateServiceConfig.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/config/EhcacheStateServiceConfig.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.clustered.server.state.config;
 
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.ehcache.clustered.server.KeySegmentMapper;
 import org.ehcache.clustered.server.state.EhcacheStateService;
 import org.terracotta.entity.ServiceConfiguration;
@@ -23,16 +24,16 @@ import org.terracotta.entity.ServiceRegistry;
 
 import com.tc.classloader.CommonComponent;
 
-import java.util.Set;
-
 @CommonComponent
 public class EhcacheStateServiceConfig implements ServiceConfiguration<EhcacheStateService> {
 
+  private final ClusteredTierManagerConfiguration config;
   private final ServiceRegistry serviceRegistry;
   private final KeySegmentMapper mapper;
 
 
-  public EhcacheStateServiceConfig(ServiceRegistry serviceRegistry, final KeySegmentMapper mapper) {
+  public EhcacheStateServiceConfig(ClusteredTierManagerConfiguration config, ServiceRegistry serviceRegistry, final KeySegmentMapper mapper) {
+    this.config = config;
     this.serviceRegistry = serviceRegistry;
     this.mapper = mapper;
   }
@@ -40,6 +41,10 @@ public class EhcacheStateServiceConfig implements ServiceConfiguration<EhcacheSt
   @Override
   public Class<EhcacheStateService> getServiceType() {
     return EhcacheStateService.class;
+  }
+
+  public ClusteredTierManagerConfiguration getConfig() {
+    return config;
   }
 
   public ServiceRegistry getServiceRegistry() {

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcacheActiveEntityTest.java
@@ -246,9 +246,6 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
 
-    assertSuccess(activeEntity.invoke(client,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration)));
-
     assertThat(registry.getStoreManagerService().getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
 
     assertThat(registry.getResource("serverResource1").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(4L)));
@@ -1042,12 +1039,14 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
 
-    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.configureStoreManager(serverSideConfig)));
+    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
 
+    UUID client2Id = UUID.randomUUID();
     ClientDescriptor client2 = new TestClientDescriptor();
     activeEntity.connected(client2);
     assertThat(activeEntity.getConnectedClients().keySet(), containsInAnyOrder(client, client2));
 
+    MESSAGE_FACTORY.setClientId(client2Id);
     assertSuccess(activeEntity.invoke(client2, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
 
     assertThat(activeEntity.getConnectedClients().get(client), is(Matchers.<String>empty()));
@@ -1073,8 +1072,6 @@ public class EhcacheActiveEntityTest {
     ClientDescriptor client = new TestClientDescriptor();
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
-
-    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.configureStoreManager(serverSideConfig)));
 
     activeEntity.disconnected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), is(Matchers.<ClientDescriptor>empty()));
@@ -1106,8 +1103,6 @@ public class EhcacheActiveEntityTest {
     ClientDescriptor client = new TestClientDescriptor();
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
-    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.configureStoreManager(serverSideConfig)));
-
     assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
 
     assertThat(activeEntity.getConnectedClients().get(client), is(Matchers.<String>empty()));
@@ -1132,9 +1127,6 @@ public class EhcacheActiveEntityTest {
     ClientDescriptor client = new TestClientDescriptor();
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
-
-    assertSuccess(activeEntity.invoke(client,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration)));
 
     assertFailure(activeEntity.invoke(client,
         MESSAGE_FACTORY.validateStoreManager(new ServerSideConfigBuilder()
@@ -1161,9 +1153,6 @@ public class EhcacheActiveEntityTest {
     ClientDescriptor client = new TestClientDescriptor();
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
-
-    assertSuccess(activeEntity.invoke(client,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration)));
 
     assertFailure(activeEntity.invoke(client,
         MESSAGE_FACTORY.validateStoreManager(new ServerSideConfigBuilder()
@@ -1208,17 +1197,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
 
-    assertSuccess(activeEntity.invoke(client,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration)));
-
-    activeEntity.disconnected(client);
-    assertThat(activeEntity.getConnectedClients().keySet(), is(Matchers.<ClientDescriptor>empty()));
-
-    ClientDescriptor client2 = new TestClientDescriptor();
-    activeEntity.connected(client2);
-    assertThat(activeEntity.getConnectedClients().keySet(), contains(client2));
-
-    assertFailure(activeEntity.invoke(client2,
+    assertFailure(activeEntity.invoke(client,
         MESSAGE_FACTORY.createServerStore("cacheAlias",
             new ServerStoreConfigBuilder()
                 .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
@@ -1290,18 +1269,9 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
 
-    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.configureStoreManager(serverSideConfig)));
+    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
 
-    activeEntity.disconnected(client);
-    assertThat(activeEntity.getConnectedClients().keySet(), is(Matchers.<ClientDescriptor>empty()));
-
-    ClientDescriptor client2 = new TestClientDescriptor();
-    activeEntity.connected(client2);
-    assertThat(activeEntity.getConnectedClients().keySet(), contains(client2));
-
-    assertSuccess(activeEntity.invoke(client2, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
-
-    assertSuccess(activeEntity.invoke(client2,
+    assertSuccess(activeEntity.invoke(client,
         MESSAGE_FACTORY.createServerStore("cacheAlias",
             new ServerStoreConfigBuilder()
                 .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
@@ -1313,8 +1283,8 @@ public class EhcacheActiveEntityTest {
     assertThat(registry.getResource("serverResource1").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(4L + 4L)));
     assertThat(registry.getResource("serverResource2").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(8L)));
 
-    assertThat(activeEntity.getConnectedClients().get(client2), contains("cacheAlias"));
-    assertThat(activeEntity.getInUseStores().get("cacheAlias"), contains(client2));
+    assertThat(activeEntity.getConnectedClients().get(client), contains("cacheAlias"));
+    assertThat(activeEntity.getInUseStores().get("cacheAlias"), contains(client));
     assertThat(registry.getStoreManagerService().getStores(), containsInAnyOrder("cacheAlias"));
   }
 
@@ -1541,15 +1511,9 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
     assertThat(activeEntity.getConnectedClients().keySet(), contains(client));
 
-    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.configureStoreManager(serverSideConfig)));
+    assertSuccess(activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
 
-    ClientDescriptor client2 = new TestClientDescriptor();
-    activeEntity.connected(client2);
-    assertThat(activeEntity.getConnectedClients().keySet(), containsInAnyOrder(client, client2));
-
-    assertSuccess(activeEntity.invoke(client2, MESSAGE_FACTORY.validateStoreManager(serverSideConfig)));
-
-    assertFailure(activeEntity.invoke(client2,
+    assertFailure(activeEntity.invoke(client,
         MESSAGE_FACTORY.validateServerStore("cacheAlias",
             new ServerStoreConfigBuilder()
                 .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
@@ -1563,7 +1527,6 @@ public class EhcacheActiveEntityTest {
     assertThat(registry.getResource("serverResource2").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(8L)));
 
     assertThat(activeEntity.getConnectedClients().get(client), is(Matchers.<String>empty()));
-    assertThat(activeEntity.getConnectedClients().get(client2), is(Matchers.<String>empty()));
     assertThat(activeEntity.getInUseStores().get("cacheAlias"), is(nullValue()));
     assertThat(registry.getStoreManagerService().getStores(), is(Matchers.<String>empty()));
   }
@@ -2369,9 +2332,6 @@ public class EhcacheActiveEntityTest {
     registry.addResource("secondary-server-resource", 16, MemoryUnit.MEGABYTES);
 
     final EhcacheActiveEntity activeEntity = new EhcacheActiveEntity(registry, configuration, DEFAULT_MAPPER);
-    ClientDescriptor configurer = new TestClientDescriptor();
-    activeEntity.connected(configurer);
-    activeEntity.invoke(configurer, MESSAGE_FACTORY.configureStoreManager(configureConfig));
 
     ClientDescriptor validator = new TestClientDescriptor();
     activeEntity.connected(validator);
@@ -2393,10 +2353,6 @@ public class EhcacheActiveEntityTest {
         .build();
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", configure);
     EhcacheActiveEntity activeEntity = new EhcacheActiveEntity(registry, configuration, DEFAULT_MAPPER);
-
-    ClientDescriptor configurer = new TestClientDescriptor();
-    activeEntity.connected(configurer);
-    activeEntity.invoke(configurer, MESSAGE_FACTORY.configureStoreManager(configure));
 
     ClientDescriptor validator = new TestClientDescriptor();
     activeEntity.connected(validator);
@@ -2423,10 +2379,6 @@ public class EhcacheActiveEntityTest {
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", configure);
     EhcacheActiveEntity activeEntity = new EhcacheActiveEntity(registry, configuration, DEFAULT_MAPPER);
 
-    ClientDescriptor configurer = new TestClientDescriptor();
-    activeEntity.connected(configurer);
-    assertSuccess(activeEntity.invoke(configurer,MESSAGE_FACTORY.configureStoreManager(configure)));
-
     ClientDescriptor validator = new TestClientDescriptor();
     activeEntity.connected(validator);
     ServerSideConfiguration validate = new ServerSideConfigBuilder()
@@ -2452,10 +2404,6 @@ public class EhcacheActiveEntityTest {
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", configure);
     EhcacheActiveEntity activeEntity = new EhcacheActiveEntity(registry, configuration, DEFAULT_MAPPER);
 
-    ClientDescriptor configurer = new TestClientDescriptor();
-    activeEntity.connected(configurer);
-    activeEntity.invoke(configurer,MESSAGE_FACTORY.configureStoreManager(configure));
-
     ClientDescriptor validator = new TestClientDescriptor();
     activeEntity.connected(validator);
     ServerSideConfiguration validate = new ServerSideConfigBuilder()
@@ -2480,10 +2428,6 @@ public class EhcacheActiveEntityTest {
         .build();
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", initialConfiguration);
     EhcacheActiveEntity activeEntity = new EhcacheActiveEntity(registry, configuration, DEFAULT_MAPPER);
-
-    ClientDescriptor configurer = new TestClientDescriptor();
-    activeEntity.connected(configurer);
-    activeEntity.invoke(configurer, MESSAGE_FACTORY.configureStoreManager(initialConfiguration));
 
     ClientDescriptor validator = new TestClientDescriptor();
     activeEntity.connected(validator);
@@ -2560,11 +2504,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
 
 
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
+    activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     activeEntity.invoke(client,
       MESSAGE_FACTORY.createServerStore("myCache",
@@ -2607,11 +2547,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
 
 
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
+    activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     activeEntity.invoke(client,
       MESSAGE_FACTORY.createServerStore("myCache",
@@ -2651,11 +2587,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
 
 
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
+    activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     activeEntity.invoke(client,
       MESSAGE_FACTORY.createServerStore("myCache",
@@ -2696,9 +2628,6 @@ public class EhcacheActiveEntityTest {
 
     ServerSideConfiguration serverSideConfiguration = new ServerSideConfigBuilder().build();
 
-    activeEntity.invoke(client,
-      MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
     @SuppressWarnings("unchecked")
     PassiveSynchronizationChannel<EhcacheEntityMessage> syncChannel = mock(PassiveSynchronizationChannel.class);
     activeEntity.synchronizeKeyToPassive(syncChannel, 1);
@@ -2720,11 +2649,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
 
 
-    activeEntity.invoke(client,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    activeEntity.invoke(client,
-        MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
+    activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     activeEntity.invoke(client,
         MESSAGE_FACTORY.createServerStore("test",
@@ -2765,11 +2690,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client);
 
 
-    activeEntity.invoke(client,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    activeEntity.invoke(client,
-        MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
+    activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     try {
       activeEntity.invoke(client,
@@ -2817,11 +2738,7 @@ public class EhcacheActiveEntityTest {
     activeEntity.connected(client2);
 
 
-    activeEntity.invoke(client1,
-        MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    activeEntity.invoke(client1,
-        MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
+    activeEntity.invoke(client1, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     activeEntity.invoke(client1,
         MESSAGE_FACTORY.createServerStore("test",
@@ -2950,7 +2867,6 @@ public class EhcacheActiveEntityTest {
     ClientDescriptor client = new TestClientDescriptor();
     activeEntity.connected(client);
 
-    activeEntity.invoke(client, MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
     activeEntity.invoke(client, MESSAGE_FACTORY.validateStoreManager(serverSideConfiguration));
 
     ServerStoreConfiguration serverStoreConfiguration = new ServerStoreConfigBuilder()

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/EhcachePassiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/EhcachePassiveEntityTest.java
@@ -53,7 +53,6 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -94,51 +93,8 @@ public class EhcachePassiveEntityTest {
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
     final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
 
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
     assertThat(registry.getStoreManagerService()
         .getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
-
-    assertThat(registry.getResource("serverResource1").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(4L)));
-    assertThat(registry.getResource("serverResource2").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(8L)));
-    assertThat(registry.getResource("defaultServerResource").getUsed(), is(0L));
-
-    assertThat(registry.getStoreManagerService().getStores(), is(Matchers.<String>empty()));
-  }
-
-  @Test
-  public void testConfigureAfterConfigure() throws Exception {
-    OffHeapIdentifierRegistry registry = new OffHeapIdentifierRegistry(32, MemoryUnit.MEGABYTES);
-    registry.addResource("defaultServerResource", 8, MemoryUnit.MEGABYTES);
-    registry.addResource("serverResource1", 8, MemoryUnit.MEGABYTES);
-    registry.addResource("serverResource2", 8, MemoryUnit.MEGABYTES);
-
-    ServerSideConfiguration serverSideConfiguration = new ServerSideConfigBuilder()
-      .defaultResource("defaultServerResource")
-      .sharedPool("primary", "serverResource1", 4, MemoryUnit.MEGABYTES)
-      .sharedPool("secondary", "serverResource2", 8, MemoryUnit.MEGABYTES)
-      .build();
-    ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
-    final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
-
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
-    try {
-      passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(new ServerSideConfigBuilder()
-          .defaultResource("defaultServerResource")
-          .sharedPool("primary-new", "serverResource1", 4, MemoryUnit.MEGABYTES)
-          .sharedPool("secondary-new", "serverResource2", 8, MemoryUnit.MEGABYTES)
-          .build()));
-      fail("invocation should have triggered an exception");
-    } catch (IllegalStateException e) {
-      assertThat(e.getMessage(), containsString("operation failed"));
-    }
-
-    assertThat(registry.getStoreManagerService()
-        .getSharedResourcePoolIds(), containsInAnyOrder("primary", "secondary"));
-
-    assertThat(registry.getStoreManagerService()
-        .getSharedResourcePoolIds(), hasSize(2));
 
     assertThat(registry.getResource("serverResource1").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(4L)));
     assertThat(registry.getResource("serverResource2").getUsed(), is(MemoryUnit.MEGABYTES.toBytes(8L)));
@@ -253,7 +209,6 @@ public class EhcachePassiveEntityTest {
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
     final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
 
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
     EhcacheEntityMessage createServerStore = MESSAGE_FACTORY.createServerStore("cacheAlias",
         new ServerStoreConfigBuilder()
             .dedicated("serverResource1", 4, MemoryUnit.MEGABYTES)
@@ -292,8 +247,6 @@ public class EhcachePassiveEntityTest {
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
     final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
 
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
-
     EhcacheEntityMessage createServerStore = MESSAGE_FACTORY.createServerStore("cacheAlias",
         new ServerStoreConfigBuilder()
             .shared("primary")
@@ -327,8 +280,6 @@ public class EhcachePassiveEntityTest {
       .build();
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
     final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
-
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
 
     EhcacheEntityMessage createServerStore = MESSAGE_FACTORY.createServerStore("dedicatedCache",
         new ServerStoreConfigBuilder()
@@ -395,7 +346,6 @@ public class EhcachePassiveEntityTest {
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
     final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
 
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
     assertThat(registry.getStoreManagerService().getStores(), is(Matchers.<String>empty()));
 
     EhcacheEntityMessage createServerStore = MESSAGE_FACTORY.createServerStore("dedicatedCache",
@@ -467,8 +417,6 @@ public class EhcachePassiveEntityTest {
       .build();
     ClusteredTierManagerConfiguration configuration = new ClusteredTierManagerConfiguration("identifier", serverSideConfiguration);
     final EhcachePassiveEntity passiveEntity = new EhcachePassiveEntity(registry, configuration, DEFAULT_MAPPER);
-
-    passiveEntity.invoke(MESSAGE_FACTORY.configureStoreManager(serverSideConfiguration));
 
     EhcacheEntityMessage createServerStore = MESSAGE_FACTORY.createServerStore("dedicatedCache",
         new ServerStoreConfigBuilder()

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/state/EhcacheStateServiceProviderTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/state/EhcacheStateServiceProviderTest.java
@@ -16,6 +16,8 @@
 
 package org.ehcache.clustered.server.state;
 
+import org.ehcache.clustered.common.ServerSideConfiguration;
+import org.ehcache.clustered.common.internal.ClusteredTierManagerConfiguration;
 import org.ehcache.clustered.server.KeySegmentMapper;
 import org.ehcache.clustered.server.state.config.EhcacheStateServiceConfig;
 import org.junit.Before;
@@ -33,10 +35,14 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
 
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 
 public class EhcacheStateServiceProviderTest {
@@ -45,6 +51,7 @@ public class EhcacheStateServiceProviderTest {
 
   private PlatformConfiguration platformConfiguration;
   private ServiceProviderConfiguration serviceProviderConfiguration;
+  private ClusteredTierManagerConfiguration tierManagerConfiguration;
 
   @Before
   public void setUp() {
@@ -72,6 +79,8 @@ public class EhcacheStateServiceProviderTest {
     };
 
     serviceProviderConfiguration = mock(ServiceProviderConfiguration.class);
+
+    tierManagerConfiguration = new ClusteredTierManagerConfiguration("identifier", new ServerSideConfiguration(emptyMap()));
   }
 
   @Test
@@ -85,15 +94,16 @@ public class EhcacheStateServiceProviderTest {
     EhcacheStateServiceProvider serviceProvider = new EhcacheStateServiceProvider();
     serviceProvider.initialize(serviceProviderConfiguration, platformConfiguration);
 
-    EhcacheStateService ehcacheStateService = serviceProvider.getService(1L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
+    EhcacheStateService ehcacheStateService = serviceProvider.getService(1L, new EhcacheStateServiceConfig(tierManagerConfiguration, null, DEFAULT_MAPPER));
 
     assertNotNull(ehcacheStateService);
 
-    EhcacheStateService sameStateService = serviceProvider.getService(1L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
+    EhcacheStateService sameStateService = serviceProvider.getService(1L, new EhcacheStateServiceConfig(tierManagerConfiguration, null, DEFAULT_MAPPER));
 
     assertSame(ehcacheStateService, sameStateService);
 
-    EhcacheStateService anotherStateService = serviceProvider.getService(2L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
+    ClusteredTierManagerConfiguration otherConfiguration = new ClusteredTierManagerConfiguration("otherIdentifier", new ServerSideConfiguration(emptyMap()));
+    EhcacheStateService anotherStateService = serviceProvider.getService(2L, new EhcacheStateServiceConfig(otherConfiguration, null, DEFAULT_MAPPER));
 
     assertNotNull(anotherStateService);
     assertNotSame(ehcacheStateService, anotherStateService);
@@ -101,17 +111,32 @@ public class EhcacheStateServiceProviderTest {
   }
 
   @Test
-  public void testClear() throws ServiceProviderCleanupException {
+  public void testDestroyService() throws Exception {
     EhcacheStateServiceProvider serviceProvider = new EhcacheStateServiceProvider();
     serviceProvider.initialize(serviceProviderConfiguration, platformConfiguration);
 
-    EhcacheStateService ehcacheStateService = serviceProvider.getService(1L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
-    EhcacheStateService anotherStateService = serviceProvider.getService(2L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
+    EhcacheStateServiceConfig configuration = new EhcacheStateServiceConfig(tierManagerConfiguration, null, DEFAULT_MAPPER);
+    EhcacheStateService ehcacheStateService = serviceProvider.getService(1L, configuration);
+
+    ehcacheStateService.destroy();
+
+    assertThat(serviceProvider.getService(1L, configuration), not(same(ehcacheStateService)));
+  }
+
+  @Test
+  public void testPrepareForSynchronization() throws ServiceProviderCleanupException {
+    EhcacheStateServiceProvider serviceProvider = new EhcacheStateServiceProvider();
+    serviceProvider.initialize(serviceProviderConfiguration, platformConfiguration);
+
+    ClusteredTierManagerConfiguration otherConfiguration = new ClusteredTierManagerConfiguration("otherIdentifier", new ServerSideConfiguration(emptyMap()));
+
+    EhcacheStateService ehcacheStateService = serviceProvider.getService(1L, new EhcacheStateServiceConfig(tierManagerConfiguration, null, DEFAULT_MAPPER));
+    EhcacheStateService anotherStateService = serviceProvider.getService(2L, new EhcacheStateServiceConfig(otherConfiguration, null, DEFAULT_MAPPER));
 
     serviceProvider.prepareForSynchronization();
 
-    EhcacheStateService ehcacheStateServiceAfterClear = serviceProvider.getService(1L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
-    EhcacheStateService anotherStateServiceAfterClear = serviceProvider.getService(2L, new EhcacheStateServiceConfig(null, DEFAULT_MAPPER));
+    EhcacheStateService ehcacheStateServiceAfterClear = serviceProvider.getService(1L, new EhcacheStateServiceConfig(tierManagerConfiguration, null, DEFAULT_MAPPER));
+    EhcacheStateService anotherStateServiceAfterClear = serviceProvider.getService(2L, new EhcacheStateServiceConfig(otherConfiguration, null, DEFAULT_MAPPER));
 
     assertNotSame(ehcacheStateService, ehcacheStateServiceAfterClear);
     assertNotSame(anotherStateService, anotherStateServiceAfterClear);

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/state/EhcacheStateServiceProviderTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/state/EhcacheStateServiceProviderTest.java
@@ -37,12 +37,12 @@ import java.util.Collections;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 
 public class EhcacheStateServiceProviderTest {
@@ -120,7 +120,7 @@ public class EhcacheStateServiceProviderTest {
 
     ehcacheStateService.destroy();
 
-    assertThat(serviceProvider.getService(1L, configuration), not(same(ehcacheStateService)));
+    assertThat(serviceProvider.getService(1L, configuration), not(sameInstance(ehcacheStateService)));
   }
 
   @Test


### PR DESCRIPTION
* Entity receives configuration during create - much more than the previous `UUID`
  * An identifier - currently a `String` by default sourced from the entity URL in the connection
  * The `ServerSideConfiguration` that used to be passed during `configure` step
* Entity uses the `CreationException` in case of mismatch between server resources and specified ones, same for shared pools.
* State service destroy effectively removes the instance from the provider
* Clean up related to the above changes

Flagged as no merge for now since this means breaking compatibility of client -> server communication and thus requires bumping version to 3.3.0-SNAPSHOT on master.
(description copied in the issue for better reference)