### PR TITLE
Move JMX statistics to an ehcache service

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107Cache.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107Cache.java
@@ -75,7 +75,7 @@ class Eh107Cache<K, V> implements Cache<K, V> {
     this.name = name;
     this.cacheResources = cacheResources;
     this.managementBean = new Eh107CacheMXBean(name, cacheManager, config);
-    this.statisticsBean = new Eh107CacheStatisticsMXBean(name, cacheManager, ehCache);
+    this.statisticsBean = new Eh107CacheStatisticsMXBean(name, cacheManager);
 
     for (Map.Entry<CacheEntryListenerConfiguration<K, V>, ListenerResources<K, V>> entry : cacheResources
         .getListenerResources().entrySet()) {

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
@@ -17,12 +17,9 @@ package org.ehcache.jsr107;
 
 import org.ehcache.Status;
 import org.ehcache.config.CacheConfiguration;
-import org.ehcache.core.EhcacheManager;
 import org.ehcache.core.InternalCache;
-import org.ehcache.core.internal.service.ServiceLocator;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 import org.ehcache.impl.copy.IdentityCopier;
-import org.ehcache.jsr107.config.Jsr107CacheConfiguration;
 import org.ehcache.jsr107.internal.Jsr107CacheLoaderWriter;
 import org.ehcache.jsr107.internal.WrappedCacheLoaderWriter;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
@@ -42,7 +39,6 @@ import java.util.concurrent.ConcurrentMap;
 import javax.cache.Cache;
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
-import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.Configuration;
 import javax.cache.spi.CachingProvider;
 import javax.management.InstanceAlreadyExistsException;
@@ -60,14 +56,14 @@ class Eh107CacheManager implements CacheManager {
 
   private final Object cachesLock = new Object();
   private final ConcurrentMap<String, Eh107Cache<?, ?>> caches = new ConcurrentHashMap<String, Eh107Cache<?, ?>>();
-  private final EhcacheManager ehCacheManager;
+  private final Eh107InternalCacheManager ehCacheManager;
   private final EhcacheCachingProvider cachingProvider;
   private final ClassLoader classLoader;
   private final URI uri;
   private final Properties props;
   private final ConfigurationMerger configurationMerger;
 
-  Eh107CacheManager(EhcacheCachingProvider cachingProvider, EhcacheManager ehCacheManager, Properties props,
+  Eh107CacheManager(EhcacheCachingProvider cachingProvider, Eh107InternalCacheManager ehCacheManager, Properties props,
                     ClassLoader classLoader, URI uri, ConfigurationMerger configurationMerger) {
     this.cachingProvider = cachingProvider;
     this.ehCacheManager = ehCacheManager;
@@ -79,7 +75,7 @@ class Eh107CacheManager implements CacheManager {
     refreshAllCaches();
   }
 
-  EhcacheManager getEhCacheManager() {
+  Eh107InternalCacheManager getEhCacheManager() {
     return ehCacheManager;
   }
 

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheStatisticsMXBean.java
@@ -15,303 +15,80 @@
  */
 package org.ehcache.jsr107;
 
-import org.ehcache.Cache;
-import org.ehcache.core.InternalCache;
-import org.ehcache.core.statistics.CacheOperationOutcomes;
-import org.ehcache.core.statistics.StoreOperationOutcomes;
-import org.ehcache.core.statistics.BulkOps;
-import org.terracotta.context.ContextManager;
-import org.terracotta.context.TreeNode;
-import org.terracotta.context.query.Matchers;
-import org.terracotta.context.query.Query;
-import org.terracotta.statistics.OperationStatistic;
-import org.terracotta.statistics.derived.LatencySampling;
-import org.terracotta.statistics.derived.MinMaxAverage;
-import org.terracotta.statistics.jsr166e.LongAdder;
-import org.terracotta.statistics.observer.ChainedOperationObserver;
-
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.EnumSet.allOf;
-import static org.terracotta.context.query.Matchers.attributes;
-import static org.terracotta.context.query.Matchers.context;
-import static org.terracotta.context.query.Matchers.hasAttribute;
-import static org.terracotta.context.query.QueryBuilder.queryBuilder;
+import org.ehcache.core.spi.service.StatisticsService;
 
 /**
  * @author Ludovic Orban
  */
 class Eh107CacheStatisticsMXBean extends Eh107MXBean implements javax.cache.management.CacheStatisticsMXBean {
 
-  private final CompensatingCounters compensatingCounters = new CompensatingCounters();
-  private final OperationStatistic<CacheOperationOutcomes.GetOutcome> get;
-  private final OperationStatistic<CacheOperationOutcomes.PutOutcome> put;
-  private final OperationStatistic<CacheOperationOutcomes.RemoveOutcome> remove;
-  private final OperationStatistic<CacheOperationOutcomes.PutIfAbsentOutcome> putIfAbsent;
-  private final OperationStatistic<CacheOperationOutcomes.ReplaceOutcome> replace;
-  private final OperationStatistic<CacheOperationOutcomes.ConditionalRemoveOutcome> conditionalRemove;
-  private final OperationStatistic<StoreOperationOutcomes.EvictionOutcome> lowestTierEviction;
-  private final Map<BulkOps, LongAdder> bulkMethodEntries;
-  private final LatencyMonitor<CacheOperationOutcomes.GetOutcome> averageGetTime;
-  private final LatencyMonitor<CacheOperationOutcomes.PutOutcome> averagePutTime;
-  private final LatencyMonitor<CacheOperationOutcomes.RemoveOutcome> averageRemoveTime;
+  private final String cacheName;
+  private final StatisticsService statisticsService;
 
-  Eh107CacheStatisticsMXBean(String cacheName, Eh107CacheManager cacheManager, InternalCache<?, ?> cache) {
+  Eh107CacheStatisticsMXBean(String cacheName, Eh107CacheManager cacheManager) {
     super(cacheName, cacheManager, "CacheStatistics");
-    this.bulkMethodEntries = cache.getBulkMethodEntries();
-
-    get = findCacheStatistic(cache, CacheOperationOutcomes.GetOutcome.class, "get");
-    put = findCacheStatistic(cache, CacheOperationOutcomes.PutOutcome.class, "put");
-    remove = findCacheStatistic(cache, CacheOperationOutcomes.RemoveOutcome.class, "remove");
-    putIfAbsent = findCacheStatistic(cache, CacheOperationOutcomes.PutIfAbsentOutcome.class, "putIfAbsent");
-    replace = findCacheStatistic(cache, CacheOperationOutcomes.ReplaceOutcome.class, "replace");
-    conditionalRemove = findCacheStatistic(cache, CacheOperationOutcomes.ConditionalRemoveOutcome.class, "conditionalRemove");
-    lowestTierEviction = findLowestTierStatistic(cache, StoreOperationOutcomes.EvictionOutcome.class, "eviction");
-
-    averageGetTime = new LatencyMonitor<CacheOperationOutcomes.GetOutcome>(allOf(CacheOperationOutcomes.GetOutcome.class));
-    get.addDerivedStatistic(averageGetTime);
-    averagePutTime = new LatencyMonitor<CacheOperationOutcomes.PutOutcome>(allOf(CacheOperationOutcomes.PutOutcome.class));
-    put.addDerivedStatistic(averagePutTime);
-    averageRemoveTime= new LatencyMonitor<CacheOperationOutcomes.RemoveOutcome>(allOf(CacheOperationOutcomes.RemoveOutcome.class));
-    remove.addDerivedStatistic(averageRemoveTime);
+    this.cacheName = cacheName;
+    this.statisticsService = cacheManager.getEhCacheManager().getServiceLocator().getService(StatisticsService.class);
   }
 
   @Override
   public void clear() {
-    compensatingCounters.snapshot();
-    averageGetTime.clear();
-    averagePutTime.clear();
-    averageRemoveTime.clear();
+    statisticsService.clear(cacheName);
   }
 
   @Override
   public long getCacheHits() {
-    return normalize(getHits() - compensatingCounters.cacheHits - compensatingCounters.bulkGetHits);
+    return statisticsService.getCacheHits(cacheName);
   }
 
   @Override
   public float getCacheHitPercentage() {
-    long cacheHits = getCacheHits();
-    return normalize((float) cacheHits / (cacheHits + getCacheMisses())) * 100.0f;
+    return statisticsService.getCacheHitPercentage(cacheName);
   }
 
   @Override
   public long getCacheMisses() {
-    return normalize(getMisses() - compensatingCounters.cacheMisses - compensatingCounters.bulkGetMiss);
+    return statisticsService.getCacheMisses(cacheName);
   }
 
   @Override
   public float getCacheMissPercentage() {
-    long cacheMisses = getCacheMisses();
-    return normalize((float) cacheMisses / (getCacheHits() + cacheMisses)) * 100.0f;
+    return statisticsService.getCacheMissPercentage(cacheName);
   }
 
   @Override
   public long getCacheGets() {
-    return normalize(getHits() + getMisses()
-                     - compensatingCounters.cacheGets
-                     - compensatingCounters.bulkGetHits
-                     - compensatingCounters.bulkGetMiss);
+    return statisticsService.getCacheGets(cacheName);
   }
 
   @Override
   public long getCachePuts() {
-    return normalize(getBulkCount(BulkOps.PUT_ALL) - compensatingCounters.bulkPuts +
-        put.sum(EnumSet.of(CacheOperationOutcomes.PutOutcome.PUT)) +
-        put.sum(EnumSet.of(CacheOperationOutcomes.PutOutcome.UPDATED)) +
-        putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
-        replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT)) -
-        compensatingCounters.cachePuts);
+    return statisticsService.getCachePuts(cacheName);
   }
 
   @Override
   public long getCacheRemovals() {
-    return normalize(getBulkCount(BulkOps.REMOVE_ALL) - compensatingCounters.bulkRemovals +
-        remove.sum(EnumSet.of(CacheOperationOutcomes.RemoveOutcome.SUCCESS)) +
-        conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS)) -
-        compensatingCounters.cacheRemovals);
+    return statisticsService.getCacheRemovals(cacheName);
   }
 
   @Override
   public long getCacheEvictions() {
-    return normalize(lowestTierEviction.sum(EnumSet.of(StoreOperationOutcomes.EvictionOutcome.SUCCESS)) - compensatingCounters.cacheEvictions);
+    return statisticsService.getCacheEvictions(cacheName);
   }
 
   @Override
   public float getAverageGetTime() {
-    return (float) averageGetTime.value();
+    return statisticsService.getAverageGetTime(cacheName);
   }
 
   @Override
   public float getAveragePutTime() {
-    return (float) averagePutTime.value();
+    return statisticsService.getAveragePutTime(cacheName);
   }
 
   @Override
   public float getAverageRemoveTime() {
-    return (float) averageRemoveTime.value();
+    return statisticsService.getAverageRemoveTime(cacheName);
   }
 
-  private long getMisses() {
-    return getBulkCount(BulkOps.GET_ALL_MISS) +
-        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS)) +
-        putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
-        replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.MISS_NOT_PRESENT)) +
-        conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
-  }
-
-  private long getHits() {
-    return getBulkCount(BulkOps.GET_ALL_HITS) +
-        get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT)) +
-        putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.HIT)) +
-        replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT, CacheOperationOutcomes.ReplaceOutcome.MISS_PRESENT)) +
-        conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS, CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));
-  }
-
-  private long getBulkCount(BulkOps bulkOps) {
-    return bulkMethodEntries.get(bulkOps).longValue();
-  }
-
-  private static long normalize(long value) {
-    return Math.max(0, value);
-  }
-
-  private static float normalize(float value) {
-    if (Float.isNaN(value)) {
-      return 0.0f;
-    }
-    return Math.min(1.0f, Math.max(0.0f, value));
-  }
-
-  static <T extends Enum<T>> OperationStatistic<T> findCacheStatistic(Cache<?, ?> cache, Class<T> type, String statName) {
-    @SuppressWarnings("unchecked")
-    Query query = queryBuilder()
-        .children()
-        .filter(context(attributes(Matchers.<Map<String, Object>>allOf(hasAttribute("name", statName), hasAttribute("type", type)))))
-        .build();
-
-    Set<TreeNode> result = query.execute(Collections.singleton(ContextManager.nodeFor(cache)));
-    if (result.size() > 1) {
-      throw new RuntimeException("result must be unique");
-    }
-    if (result.isEmpty()) {
-      throw new RuntimeException("result must not be null");
-    }
-    @SuppressWarnings("unchecked")
-    OperationStatistic<T> statistic = (OperationStatistic<T>) result.iterator().next().getContext().attributes().get("this");
-    return statistic;
-  }
-
-  <T extends Enum<T>> OperationStatistic<T> findLowestTierStatistic(Cache<?, ?> cache, Class<T> type, String statName) {
-
-    @SuppressWarnings("unchecked")
-    Query statQuery = queryBuilder()
-        .descendants()
-        .filter(context(attributes(Matchers.<Map<String, Object>>allOf(hasAttribute("name", statName), hasAttribute("type", type)))))
-        .build();
-
-    Set<TreeNode> statResult = statQuery.execute(Collections.singleton(ContextManager.nodeFor(cache)));
-
-    if(statResult.size() < 1) {
-      throw new RuntimeException("Failed to find lowest tier statistic: " + statName + " , valid result Set sizes must 1 or more.  Found result Set size of: " + statResult.size());
-    }
-
-    //if only 1 store then you don't need to find the lowest tier
-    if(statResult.size() == 1) {
-      @SuppressWarnings("unchecked")
-      OperationStatistic<T> statistic = (OperationStatistic<T>) statResult.iterator().next().getContext().attributes().get("this");
-      return statistic;
-    }
-
-    String lowestStoreType = "onheap";
-    TreeNode lowestTierNode = null;
-    for(TreeNode treeNode : statResult) {
-      if(((Set)treeNode.getContext().attributes().get("tags")).size() != 1) {
-        throw new RuntimeException("Failed to find lowest tier statistic. \"tags\" set must be size 1");
-      }
-
-      String storeType = treeNode.getContext().attributes().get("tags").toString();
-      if(storeType.compareToIgnoreCase(lowestStoreType) < 0) {
-        lowestStoreType = treeNode.getContext().attributes().get("tags").toString();
-        lowestTierNode = treeNode;
-      }
-    }
-
-    @SuppressWarnings("unchecked")
-    OperationStatistic<T> statistic = (OperationStatistic<T>) lowestTierNode.getContext().attributes().get("this");
-    return statistic;
-  }
-
-  class CompensatingCounters {
-    volatile long cacheHits;
-    volatile long cacheMisses;
-    volatile long cacheGets;
-    volatile long bulkGetHits;
-    volatile long bulkGetMiss;
-    volatile long cachePuts;
-    volatile long bulkPuts;
-    volatile long cacheRemovals;
-    volatile long bulkRemovals;
-    volatile long cacheEvictions;
-
-    void snapshot() {
-      cacheHits += Eh107CacheStatisticsMXBean.this.getCacheHits();
-      cacheMisses += Eh107CacheStatisticsMXBean.this.getCacheMisses();
-      cacheGets += Eh107CacheStatisticsMXBean.this.getCacheGets();
-      bulkGetHits += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.GET_ALL_HITS);
-      bulkGetMiss += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.GET_ALL_MISS);
-      cachePuts += Eh107CacheStatisticsMXBean.this.getCachePuts();
-      bulkPuts += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.PUT_ALL);
-      cacheRemovals += Eh107CacheStatisticsMXBean.this.getCacheRemovals();
-      bulkRemovals += Eh107CacheStatisticsMXBean.this.getBulkCount(BulkOps.REMOVE_ALL);
-      cacheEvictions += Eh107CacheStatisticsMXBean.this.getCacheEvictions();
-    }
-  }
-
-  private static class LatencyMonitor<T extends Enum<T>> implements ChainedOperationObserver<T> {
-
-    private final LatencySampling<T> sampling;
-    private volatile MinMaxAverage average;
-
-    public LatencyMonitor(Set<T> targets) {
-      this.sampling = new LatencySampling<T>(targets, 1.0);
-      this.average = new MinMaxAverage();
-      sampling.addDerivedStatistic(average);
-    }
-
-    @Override
-    public void begin(long time) {
-      sampling.begin(time);
-    }
-
-    @Override
-    public void end(long time, T result) {
-      sampling.end(time, result);
-    }
-
-    @Override
-    public void end(long time, T result, long... parameters) {
-      sampling.end(time, result, parameters);
-    }
-
-    public double value() {
-      Double value = average.mean();
-      if (value == null) {
-        //Someone involved with 107 can't do math
-        return 0;
-      } else {
-        //We use nanoseconds, 107 uses microseconds
-        return value / 1000f;
-      }
-    }
-
-    public synchronized void clear() {
-      sampling.removeDerivedStatistic(average);
-      average = new MinMaxAverage();
-      sampling.addDerivedStatistic(average);
-    }
-  }
 }

--- a/107/src/main/java/org/ehcache/jsr107/Eh107InternalCacheManager.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107InternalCacheManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.jsr107;
+
+import org.ehcache.config.Configuration;
+import org.ehcache.core.EhcacheManager;
+import org.ehcache.core.internal.service.ServiceLocator;
+import org.ehcache.spi.service.Service;
+
+import java.util.Collection;
+
+/**
+ * Class which has for only purpose to allow to retrieve the {@code ServiceLocator}.
+ *
+ * @author Henri Tremblay
+ */
+class Eh107InternalCacheManager extends EhcacheManager {
+
+  public Eh107InternalCacheManager(Configuration config, Collection<Service> services, boolean useLoaderInAtomics) {
+    super(config, services, useLoaderInAtomics);
+  }
+
+  public ServiceLocator getServiceLocator() {
+    return serviceLocator;
+  }
+}

--- a/107/src/main/java/org/ehcache/jsr107/EhcacheCachingProvider.java
+++ b/107/src/main/java/org/ehcache/jsr107/EhcacheCachingProvider.java
@@ -16,11 +16,12 @@
 package org.ehcache.jsr107;
 
 import org.ehcache.config.Configuration;
-import org.ehcache.core.EhcacheManager;
 import org.ehcache.core.config.DefaultConfiguration;
 import org.ehcache.core.internal.service.ServiceLocator;
 import org.ehcache.core.internal.util.ClassLoading;
+import org.ehcache.core.spi.service.StatisticsService;
 import org.ehcache.impl.config.serializer.DefaultSerializationProviderConfiguration;
+import org.ehcache.impl.internal.statistics.DefaultStatisticsService;
 import org.ehcache.jsr107.config.Jsr107Configuration;
 import org.ehcache.jsr107.config.Jsr107Service;
 import org.ehcache.jsr107.internal.DefaultJsr107Service;
@@ -137,14 +138,18 @@ public class EhcacheCachingProvider implements CachingProvider {
     Eh107CacheLoaderWriterProvider cacheLoaderWriterFactory = new Eh107CacheLoaderWriterProvider();
     Jsr107Service jsr107Service = new DefaultJsr107Service(ServiceLocator.findSingletonAmongst(Jsr107Configuration.class, config.getServiceCreationConfigurations().toArray()));
 
-    Collection<Service> services = new ArrayList<Service>();
+    StatisticsService statisticsService = new DefaultStatisticsService();
+
+    Collection<Service> services = new ArrayList<Service>(4);
     services.add(cacheLoaderWriterFactory);
     services.add(jsr107Service);
+    services.add(statisticsService);
+
     if (ServiceLocator.findSingletonAmongst(DefaultSerializationProviderConfiguration.class, config.getServiceCreationConfigurations().toArray()) == null) {
       services.add(new DefaultJsr107SerializationProvider());
     }
 
-    EhcacheManager ehcacheManager = new EhcacheManager(config, services, !jsr107Service.jsr107CompliantAtomics());
+    Eh107InternalCacheManager ehcacheManager = new Eh107InternalCacheManager(config, services, !jsr107Service.jsr107CompliantAtomics());
     ehcacheManager.init();
 
     return new Eh107CacheManager(this, ehcacheManager, properties, config.getClassLoader(), uri,

--- a/core/src/main/java/org/ehcache/core/spi/service/StatisticsService.java
+++ b/core/src/main/java/org/ehcache/core/spi/service/StatisticsService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.core.spi.service;
+
+import org.ehcache.spi.service.Service;
+
+/**
+ * Service providing raw statistics for cache and tier usage.
+ *
+ * @author Henri Tremblay
+ */
+public interface StatisticsService extends Service {
+
+  void clear(String cacheName);
+
+  long getCacheHits(String cacheName);
+
+  float getCacheHitPercentage(String cacheName);
+
+  long getCacheMisses(String cacheName);
+
+  float getCacheMissPercentage(String cacheName);
+
+  long getCacheGets(String cacheName);
+
+  long getCachePuts(String cacheName);
+
+  long getCacheRemovals(String cacheName);
+
+  long getCacheEvictions(String cacheName);
+
+  float getAverageGetTime(String cacheName);
+
+  float getAveragePutTime(String cacheName);
+
+  float getAverageRemoveTime(String cacheName);
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/CacheStatistics.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/CacheStatistics.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.Cache;
+import org.ehcache.core.InternalCache;
+import org.ehcache.core.statistics.BulkOps;
+import org.ehcache.core.statistics.CacheOperationOutcomes;
+import org.ehcache.core.statistics.StoreOperationOutcomes;
+import org.terracotta.context.ContextManager;
+import org.terracotta.context.TreeNode;
+import org.terracotta.context.query.Matchers;
+import org.terracotta.context.query.Query;
+import org.terracotta.statistics.OperationStatistic;
+import org.terracotta.statistics.derived.LatencySampling;
+import org.terracotta.statistics.derived.MinMaxAverage;
+import org.terracotta.statistics.jsr166e.LongAdder;
+import org.terracotta.statistics.observer.ChainedOperationObserver;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.EnumSet.allOf;
+import static org.terracotta.context.query.Matchers.attributes;
+import static org.terracotta.context.query.Matchers.context;
+import static org.terracotta.context.query.Matchers.hasAttribute;
+import static org.terracotta.context.query.QueryBuilder.queryBuilder;
+
+/**
+ * Contains usage statistics relative to a given cache.
+ *
+ * @author Henri Tremblay
+ */
+class CacheStatistics {
+
+  private final CompensatingCounters compensatingCounters = new CompensatingCounters();
+
+  private final OperationStatistic<CacheOperationOutcomes.GetOutcome> get;
+  private final OperationStatistic<CacheOperationOutcomes.PutOutcome> put;
+  private final OperationStatistic<CacheOperationOutcomes.RemoveOutcome> remove;
+  private final OperationStatistic<CacheOperationOutcomes.PutIfAbsentOutcome> putIfAbsent;
+  private final OperationStatistic<CacheOperationOutcomes.ReplaceOutcome> replace;
+  private final OperationStatistic<CacheOperationOutcomes.ConditionalRemoveOutcome> conditionalRemove;
+  private final OperationStatistic<StoreOperationOutcomes.EvictionOutcome> lowestTierEviction;
+
+  private final Map<BulkOps, LongAdder> bulkMethodEntries;
+
+  private final LatencyMonitor<CacheOperationOutcomes.GetOutcome> averageGetTime;
+  private final LatencyMonitor<CacheOperationOutcomes.PutOutcome> averagePutTime;
+  private final LatencyMonitor<CacheOperationOutcomes.RemoveOutcome> averageRemoveTime;
+
+  public CacheStatistics(InternalCache<?, ?> cache) {
+    this.bulkMethodEntries = cache.getBulkMethodEntries();
+
+    get = findCacheStatistic(cache, CacheOperationOutcomes.GetOutcome.class, "get");
+    put = findCacheStatistic(cache, CacheOperationOutcomes.PutOutcome.class, "put");
+    remove = findCacheStatistic(cache, CacheOperationOutcomes.RemoveOutcome.class, "remove");
+    putIfAbsent = findCacheStatistic(cache, CacheOperationOutcomes.PutIfAbsentOutcome.class, "putIfAbsent");
+    replace = findCacheStatistic(cache, CacheOperationOutcomes.ReplaceOutcome.class, "replace");
+    conditionalRemove = findCacheStatistic(cache, CacheOperationOutcomes.ConditionalRemoveOutcome.class, "conditionalRemove");
+    lowestTierEviction = findLowestTierStatistic(cache, StoreOperationOutcomes.EvictionOutcome.class, "eviction");
+
+    averageGetTime = new LatencyMonitor<CacheOperationOutcomes.GetOutcome>(allOf(CacheOperationOutcomes.GetOutcome.class));
+    get.addDerivedStatistic(averageGetTime);
+    averagePutTime = new LatencyMonitor<CacheOperationOutcomes.PutOutcome>(allOf(CacheOperationOutcomes.PutOutcome.class));
+    put.addDerivedStatistic(averagePutTime);
+    averageRemoveTime= new LatencyMonitor<CacheOperationOutcomes.RemoveOutcome>(allOf(CacheOperationOutcomes.RemoveOutcome.class));
+    remove.addDerivedStatistic(averageRemoveTime);
+  }
+
+  static <T extends Enum<T>> OperationStatistic<T> findCacheStatistic(Cache<?, ?> cache, Class<T> type, String statName) {
+    @SuppressWarnings("unchecked")
+    Query query = queryBuilder()
+      .children()
+      .filter(context(attributes(Matchers.<Map<String, Object>>allOf(hasAttribute("name", statName), hasAttribute("type", type)))))
+      .build();
+
+    Set<TreeNode> result = query.execute(Collections.singleton(ContextManager.nodeFor(cache)));
+    if (result.size() > 1) {
+      throw new RuntimeException("result must be unique");
+    }
+    if (result.isEmpty()) {
+      throw new RuntimeException("result must not be null");
+    }
+    @SuppressWarnings("unchecked")
+    OperationStatistic<T> statistic = (OperationStatistic<T>) result.iterator().next().getContext().attributes().get("this");
+    return statistic;
+  }
+
+  <T extends Enum<T>> OperationStatistic<T> findLowestTierStatistic(Cache<?, ?> cache, Class<T> type, String statName) {
+
+    @SuppressWarnings("unchecked")
+    Query statQuery = queryBuilder()
+      .descendants()
+      .filter(context(attributes(Matchers.<Map<String, Object>>allOf(hasAttribute("name", statName), hasAttribute("type", type)))))
+      .build();
+
+    Set<TreeNode> statResult = statQuery.execute(Collections.singleton(ContextManager.nodeFor(cache)));
+
+    if (statResult.size() < 1) {
+      throw new RuntimeException("Failed to find lowest tier statistic: " + statName + " , valid result Set sizes must 1 or more.  Found result Set size of: " + statResult.size());
+    }
+
+    //if only 1 store then you don't need to find the lowest tier
+    if (statResult.size() == 1) {
+      @SuppressWarnings("unchecked")
+      OperationStatistic<T> statistic = (OperationStatistic<T>) statResult.iterator().next().getContext().attributes().get("this");
+      return statistic;
+    }
+
+    String lowestStoreType = "onheap";
+    TreeNode lowestTierNode = null;
+    for (TreeNode treeNode : statResult) {
+      if (((Set)treeNode.getContext().attributes().get("tags")).size() != 1) {
+        throw new RuntimeException("Failed to find lowest tier statistic. \"tags\" set must be size 1");
+      }
+
+      String storeType = treeNode.getContext().attributes().get("tags").toString();
+      if (storeType.compareToIgnoreCase(lowestStoreType) < 0) {
+        lowestStoreType = treeNode.getContext().attributes().get("tags").toString();
+        lowestTierNode = treeNode;
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    OperationStatistic<T> statistic = (OperationStatistic<T>) lowestTierNode.getContext().attributes().get("this");
+    return statistic;
+  }
+
+  public void clear() {
+    compensatingCounters.snapshot();
+    averageGetTime.clear();
+    averagePutTime.clear();
+    averageRemoveTime.clear();
+  }
+
+  public long getCacheHits() {
+    return normalize(getHits() - compensatingCounters.cacheHits - compensatingCounters.bulkGetHits);
+  }
+
+  public float getCacheHitPercentage() {
+    long cacheHits = getCacheHits();
+    return normalize((float) cacheHits / (cacheHits + getCacheMisses())) * 100.0f;
+  }
+
+  public long getCacheMisses() {
+    return normalize(getMisses() - compensatingCounters.cacheMisses - compensatingCounters.bulkGetMiss);
+  }
+
+  public float getCacheMissPercentage() {
+    long cacheMisses = getCacheMisses();
+    return normalize((float) cacheMisses / (getCacheHits() + cacheMisses)) * 100.0f;
+  }
+
+  public long getCacheGets() {
+    return normalize(getHits() + getMisses()
+                     - compensatingCounters.cacheGets
+                     - compensatingCounters.bulkGetHits
+                     - compensatingCounters.bulkGetMiss);
+  }
+
+  public long getCachePuts() {
+    return normalize(getBulkCount(BulkOps.PUT_ALL) - compensatingCounters.bulkPuts +
+                     put.sum(EnumSet.of(CacheOperationOutcomes.PutOutcome.PUT)) +
+                     put.sum(EnumSet.of(CacheOperationOutcomes.PutOutcome.UPDATED)) +
+                     putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
+                     replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT)) -
+                     compensatingCounters.cachePuts);
+  }
+
+  public long getCacheRemovals() {
+    return normalize(getBulkCount(BulkOps.REMOVE_ALL) - compensatingCounters.bulkRemovals +
+                     remove.sum(EnumSet.of(CacheOperationOutcomes.RemoveOutcome.SUCCESS)) +
+                     conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS)) -
+                     compensatingCounters.cacheRemovals);
+  }
+
+  public long getCacheEvictions() {
+    return normalize(lowestTierEviction.sum(EnumSet.of(StoreOperationOutcomes.EvictionOutcome.SUCCESS)) - compensatingCounters.cacheEvictions);
+  }
+
+  public float getAverageGetTime() {
+    return (float) averageGetTime.value();
+  }
+
+  public float getAveragePutTime() {
+    return (float) averagePutTime.value();
+  }
+
+  public float getAverageRemoveTime() {
+    return (float) averageRemoveTime.value();
+  }
+
+  private long getMisses() {
+    return getBulkCount(BulkOps.GET_ALL_MISS) +
+           get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS)) +
+           putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
+           replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.MISS_NOT_PRESENT)) +
+           conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
+  }
+
+  private long getHits() {
+    return getBulkCount(BulkOps.GET_ALL_HITS) +
+           get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT)) +
+           putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.HIT)) +
+           replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT, CacheOperationOutcomes.ReplaceOutcome.MISS_PRESENT)) +
+           conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS, CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));
+  }
+
+  private long getBulkCount(BulkOps bulkOps) {
+    return bulkMethodEntries.get(bulkOps).longValue();
+  }
+
+  private static long normalize(long value) {
+    return Math.max(0, value);
+  }
+
+  private static float normalize(float value) {
+    if (Float.isNaN(value)) {
+      return 0.0f;
+    }
+    return Math.min(1.0f, Math.max(0.0f, value));
+  }
+
+  private class CompensatingCounters {
+    volatile long cacheHits;
+    volatile long cacheMisses;
+    volatile long cacheGets;
+    volatile long bulkGetHits;
+    volatile long bulkGetMiss;
+    volatile long cachePuts;
+    volatile long bulkPuts;
+    volatile long cacheRemovals;
+    volatile long bulkRemovals;
+    volatile long cacheEvictions;
+
+    void snapshot() {
+      cacheHits += getCacheHits();
+      cacheMisses += getCacheMisses();
+      cacheGets += getCacheGets();
+      bulkGetHits += getBulkCount(BulkOps.GET_ALL_HITS);
+      bulkGetMiss += getBulkCount(BulkOps.GET_ALL_MISS);
+      cachePuts += getCachePuts();
+      bulkPuts += getBulkCount(BulkOps.PUT_ALL);
+      cacheRemovals += getCacheRemovals();
+      bulkRemovals += getBulkCount(BulkOps.REMOVE_ALL);
+      cacheEvictions += getCacheEvictions();
+    }
+  }
+
+  private static class LatencyMonitor<T extends Enum<T>> implements ChainedOperationObserver<T> {
+
+    private final LatencySampling<T> sampling;
+    private volatile MinMaxAverage average;
+
+    public LatencyMonitor(Set<T> targets) {
+      this.sampling = new LatencySampling<T>(targets, 1.0);
+      this.average = new MinMaxAverage();
+      sampling.addDerivedStatistic(average);
+    }
+
+    @Override
+    public void begin(long time) {
+      sampling.begin(time);
+    }
+
+    @Override
+    public void end(long time, T result) {
+      sampling.end(time, result);
+    }
+
+    @Override
+    public void end(long time, T result, long... parameters) {
+      sampling.end(time, result, parameters);
+    }
+
+    public double value() {
+      Double value = average.mean();
+      if (value == null) {
+        //Someone involved with 107 can't do math
+        return 0;
+      } else {
+        //We use nanoseconds, 107 uses microseconds
+        return value / 1000f;
+      }
+    }
+
+    public synchronized void clear() {
+      sampling.removeDerivedStatistic(average);
+      average = new MinMaxAverage();
+      sampling.addDerivedStatistic(average);
+    }
+  }
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsService.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsService.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.Cache;
+import org.ehcache.Status;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.core.InternalCache;
+import org.ehcache.core.events.CacheManagerListener;
+import org.ehcache.core.spi.service.CacheManagerProviderService;
+import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.core.spi.store.InternalCacheManager;
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceDependencies;
+import org.ehcache.spi.service.ServiceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default implementation using the statistics calculated by the observers set on the caches.
+ *
+ * @author Henri Tremblay
+ */
+@ServiceDependencies(CacheManagerProviderService.class)
+public class DefaultStatisticsService implements StatisticsService, CacheManagerListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultStatisticsService.class);
+
+  private final ConcurrentMap<String, CacheStatistics> cacheStatistics = new ConcurrentHashMap<String, CacheStatistics>();
+  private volatile InternalCacheManager cacheManager;
+  private volatile boolean started = false;
+
+  private CacheStatistics getStatistics(String cacheName) {
+    CacheStatistics stats = cacheStatistics.get(cacheName);
+    if (stats == null) {
+      throw new IllegalArgumentException("Unknown cache: " + cacheName);
+    }
+    return stats;
+  }
+
+  public boolean isStarted() {
+    return started;
+  }
+
+  @Override
+  public void start(ServiceProvider<Service> serviceProvider) {
+    LOGGER.debug("Starting service");
+    CacheManagerProviderService cacheManagerProviderService = serviceProvider.getService(CacheManagerProviderService.class);
+    cacheManager = cacheManagerProviderService.getCacheManager();
+    cacheManager.registerListener(this);
+    started = true;
+  }
+
+  @Override
+  public void stop() {
+    LOGGER.debug("Stopping service");
+    cacheManager.deregisterListener(this);
+    cacheStatistics.clear();
+    started = false;
+  }
+
+  @Override
+  public void stateTransition(Status from, Status to) {
+    LOGGER.debug("Moving from " + from + " to " + to);
+    switch(to) {
+      case AVAILABLE:
+        registerAllCaches();
+        break;
+      case UNINITIALIZED:
+        cacheManager.deregisterListener(this);
+        cacheStatistics.clear();
+        break;
+      case MAINTENANCE:
+        throw new IllegalStateException("Should not be started in maintenance mode");
+      default:
+        throw new AssertionError("Unsupported state: " + to);
+    }
+  }
+
+  private void registerAllCaches() {
+    for (Map.Entry<String, CacheConfiguration<?, ?>> entry : cacheManager.getRuntimeConfiguration().getCacheConfigurations().entrySet()) {
+      String alias = entry.getKey();
+      CacheConfiguration<?, ?> configuration = entry.getValue();
+      Cache<?, ?> cache = cacheManager.getCache(alias, configuration.getKeyType(), configuration.getValueType());
+      cacheAdded(alias, cache);
+    }
+  }
+
+  @Override
+  public void cacheAdded(String alias, Cache<?, ?> cache) {
+    LOGGER.debug("Cache added " + alias);
+    cacheStatistics.put(alias, new CacheStatistics((InternalCache<?, ?>) cache));
+  }
+
+  @Override
+  public void cacheRemoved(String alias, Cache<?, ?> cache) {
+    LOGGER.debug("Cache removed " + alias);
+    cacheStatistics.remove(alias);
+  }
+
+  @Override
+  public void clear(String cacheName) {
+    getStatistics(cacheName).clear();
+  }
+
+  @Override
+  public long getCacheHits(String cacheName) {
+    return getStatistics(cacheName).getCacheHits();
+  }
+
+  @Override
+  public float getCacheHitPercentage(String cacheName) {
+    return getStatistics(cacheName).getCacheHitPercentage();
+  }
+
+  @Override
+  public long getCacheMisses(String cacheName) {
+    return getStatistics(cacheName).getCacheMisses();
+  }
+
+  @Override
+  public float getCacheMissPercentage(String cacheName) {
+    return getStatistics(cacheName).getCacheMissPercentage();
+  }
+
+  @Override
+  public long getCacheGets(String cacheName) {
+    return getStatistics(cacheName).getCacheGets();
+  }
+
+  @Override
+  public long getCachePuts(String cacheName) {
+    return getStatistics(cacheName).getCachePuts();
+  }
+
+  @Override
+  public long getCacheRemovals(String cacheName) {
+    return getStatistics(cacheName).getCacheRemovals();
+  }
+
+  @Override
+  public long getCacheEvictions(String cacheName) {
+    return getStatistics(cacheName).getCacheEvictions();
+  }
+
+  @Override
+  public float getAverageGetTime(String cacheName) {
+    return getStatistics(cacheName).getAverageGetTime ();
+  }
+
+  @Override
+  public float getAveragePutTime(String cacheName) {
+    return getStatistics(cacheName).getAveragePutTime();
+  }
+
+  @Override
+  public float getAverageRemoveTime(String cacheName) {
+    return getStatistics(cacheName).getAverageRemoveTime();
+  }
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceFactory.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+/**
+ * @author Henri Tremblay
+ */
+public class DefaultStatisticsServiceFactory implements ServiceFactory<StatisticsService> {
+
+  @Override
+  public StatisticsService create(ServiceCreationConfiguration<StatisticsService> serviceConfiguration) {
+    return new DefaultStatisticsService();
+  }
+
+  @Override
+  public Class<StatisticsService> getServiceType() {
+    return StatisticsService.class;
+  }
+}

--- a/impl/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
+++ b/impl/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
@@ -15,3 +15,4 @@ org.ehcache.impl.internal.loaderwriter.writebehind.WriteBehindProviderFactory
 org.ehcache.impl.internal.events.CacheEventNotificationListenerServiceProviderFactory
 org.ehcache.impl.internal.spi.copy.DefaultCopyProviderFactory
 org.ehcache.impl.internal.sizeof.DefaultSizeOfEngineProviderFactory
+org.ehcache.impl.internal.statistics.DefaultStatisticsServiceFactory

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.Status;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ehcache.config.units.MemoryUnit.MB;
+
+/**
+ * @author Henri Tremblay
+ */
+public class DefaultStatisticsServiceTest {
+
+  private static final String CACHE = "myCache";
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private final DefaultStatisticsService service = new DefaultStatisticsService();
+  private CacheManager cacheManager;
+
+  @Before
+  public void before() {
+    CacheConfigurationBuilder<Long, String> cacheConfiguration =
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
+        ResourcePoolsBuilder.newResourcePoolsBuilder()
+          .heap(1, MB));
+
+    cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+      .using(service)
+      .withCache(CACHE, cacheConfiguration)
+      .build();
+  }
+
+  @Test
+  public void startStopStart() throws Exception {
+    cacheManager.init();
+
+    assertThat(service.isStarted()).isTrue();
+
+    Cache<Long, String> cache = cacheManager.getCache(CACHE, Long.class, String.class);
+    cache.get(2L);
+    assertThat(service.getCacheMisses(CACHE)).isEqualTo(1);
+
+    cacheManager.close();
+
+    assertThat(service.isStarted()).isFalse();
+
+    cacheManager.init();
+
+    assertThat(service.isStarted()).isTrue();
+
+    // We expect the stats to be reinitialized after a stop start
+    assertThat(service.getCacheMisses(CACHE)).isEqualTo(0);
+    cache = cacheManager.getCache(CACHE, Long.class, String.class);
+    cache.get(2L);
+    assertThat(service.getCacheMisses(CACHE)).isEqualTo(1);
+  }
+
+  @Test
+  public void startInMaintenance() throws Exception {
+    expectedException.expect(IllegalStateException.class);
+    service.stateTransition(Status.UNINITIALIZED, Status.MAINTENANCE);
+  }
+
+  @Test
+  public void clear() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheHits() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheHitPercentage() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheMisses() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheMissPercentage() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheGets() throws Exception {
+
+  }
+
+  @Test
+  public void getCachePuts() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheRemovals() throws Exception {
+
+  }
+
+  @Test
+  public void getCacheEvictions() throws Exception {
+
+  }
+
+  @Test
+  public void getAverageGetTime() throws Exception {
+
+  }
+
+  @Test
+  public void getAveragePutTime() throws Exception {
+
+  }
+
+  @Test
+  public void getAverageRemoveTime() throws Exception {
+
+  }
+
+}


### PR DESCRIPTION
This is the first step of a series of refactoring. It moves the statistics into ehcache.