### PR TITLE
Closes #1754 Release write locks on clear

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
@@ -224,10 +224,10 @@ public class OffHeapServerStore implements ServerStore, MapInternals {
     writeLockAll();
     try {
       clear();
-      segments.clear();
     } finally {
       writeUnlockAll();
     }
+    segments.clear();
   }
 
   // stats


### PR DESCRIPTION
OffheapServerStore was not releasing write locks on destroy.