### PR TITLE
Close #1762: Reactivate M&M after a failover.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,13 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.2.0-pre1'
+  terracottaPlatformVersion = '5.2.0-pre3'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.2.0-pre1'
-  terracottaCoreVersion = '5.2.0-pre3'
+  terracottaCoreVersion = '5.2.0-pre5'
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
-  terracottaPassthroughTestingVersion = '1.2.0-pre2'
+  terracottaPassthroughTestingVersion = '1.2.0-pre4'
   entityTestLibVersion = terracottaPassthroughTestingVersion
 
   // Tools

--- a/clustered/integration-test/build.gradle
+++ b/clustered/integration-test/build.gradle
@@ -51,6 +51,12 @@ task unzipKit(type: Copy) {
   into 'build/ehcache-kit'
 }
 
+task copyServerLibs(type: Copy) {
+  dependsOn unzipKit
+  from project.configurations.serverLibs
+  into "$unzipKit.destinationDir/${project(':clustered:clustered-dist').archivesBaseName}-$project.version-kit/server/plugins/lib"
+}
+
 compileTestJava {
   options.forkOptions.executable = Jvm.current().javacExecutable
 }
@@ -59,13 +65,12 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 test {
-  dependsOn unzipKit
+  dependsOn copyServerLibs
   executable = Jvm.current().javaExecutable
   // If you want to see all mutations of the voltron monitoring tree, add to JAVA_OPTS: -Dorg.terracotta.management.service.monitoring.VoltronMonitoringService.DEBUG=true
   environment 'JAVA_OPTS', '-Dcom.tc.l2.lockmanager.greedy.locks.enabled=false'
   //If this directory does not exist, tests will fail with a cryptic assert failure
   systemProperty 'kitInstallationPath', "$unzipKit.destinationDir/${project(':clustered:clustered-dist').archivesBaseName}-$project.version-kit"
-  systemProperty 'managementPlugins', project.configurations.serverLibs.join(File.pathSeparator)
   // Uncomment to include client logging in console output
   // testLogging.showStandardStreams = true
 }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -85,14 +84,8 @@ public abstract class AbstractClusteringManagementTest {
   protected static TmsAgentService tmsAgentService;
   protected static ServerEntityIdentifier tmsServerEntityIdentifier;
 
-  private static final List<File> MANAGEMENT_PLUGINS = System.getProperty("managementPlugins") == null ?
-    Collections.emptyList() :
-    Stream.of(System.getProperty("managementPlugins").split(File.pathSeparator))
-      .map(File::new)
-      .collect(Collectors.toList());
-
   @ClassRule
-  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, MANAGEMENT_PLUGINS, "", RESOURCE_CONFIG, "");
+  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, Collections.emptyList(), "", RESOURCE_CONFIG, "");
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheConfigWithManagementTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheConfigWithManagementTest.java
@@ -50,12 +50,8 @@ public class EhcacheConfigWithManagementTest {
       + "</ohr:offheap-resources>" +
       "</config>\n";
 
-  private static final List<File> MANAGEMENT_PLUGINS = Stream.of(System.getProperty("managementPlugins", "").split(File.pathSeparator))
-    .map(File::new)
-    .collect(Collectors.toList());
-
   @ClassRule
-  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, MANAGEMENT_PLUGINS, "", RESOURCE_CONFIG, "");
+  public static Cluster CLUSTER = new BasicExternalCluster(new File("build/cluster"), 1, Collections.emptyList(), "", RESOURCE_CONFIG, "");
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheActiveEntity.java
@@ -407,8 +407,6 @@ public class EhcacheActiveEntity implements ActiveServerEntity<EhcacheEntityMess
 
   @Override
   public void createNew() {
-    management.init();
-    management.sharedPoolsConfigured();
   }
 
   @Override


### PR DESCRIPTION
- [x] Applied workaround for Terracotta-OSS/terracotta-core#426 (to restart m&m after a failover)
- [x] Needs new tc-platform release __5.2.0-pre3__
- [x] Activated management server libs by default in integration tests
- [ ] @anthonydahanne : after this, you'll be able to add more ehcache failover tests with M&M :-)