### PR TITLE
Compat' with new tc-platform (get rid of statistic wrappers)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
   sizeofVersion = '0.3.0'
 
   // Clustered
-  terracottaPlatformVersion = '5.2.0-pre5'
+  terracottaPlatformVersion = '5.2.0-pre6'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.2.0-pre6'
   terracottaCoreVersion = '5.2.0-pre6'

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteredStatisticsCountTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteredStatisticsCountTest.java
@@ -19,11 +19,8 @@ import org.ehcache.Cache;
 import org.junit.Assert;
 import org.junit.Test;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.Statistic;
-import org.terracotta.management.model.stats.primitive.Counter;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 
@@ -69,10 +66,10 @@ public class ClusteredStatisticsCountTest extends AbstractClusteringManagementTe
             System.out.println(" - " + entry.getKey() + " : " + entry.getValue());
           }*/
 
-          cacheHitCount = stat.getStatistic(Counter.class, "Cache:HitCount").getValue();
-          clusteredHitCount = stat.getStatistic(Counter.class, "Clustered:HitCount").getValue();
-          clusteredMissCount = stat.getStatistic(Counter.class, "Clustered:MissCount").getValue();
-          cacheMissCount = stat.getStatistic(Counter.class, "Cache:MissCount").getValue();
+          cacheHitCount = stat.getStatistic("Cache:HitCount").longValue();
+          clusteredHitCount = stat.getStatistic("Clustered:HitCount").longValue();
+          clusteredMissCount = stat.getStatistic("Clustered:MissCount").longValue();
+          cacheMissCount = stat.getStatistic("Cache:MissCount").longValue();
         }
       }
     } while(!Thread.currentThread().isInterrupted() &&

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
@@ -31,7 +31,6 @@ import org.terracotta.management.model.cluster.Cluster;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.message.Message;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.primitive.Counter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -229,7 +228,7 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
         .collect(Collectors.toList());
 
       for (ContextualStatistics stat : stats) {
-        val = stat.getStatistic(Counter.class, "Cache:HitCount").getValue();
+        val = stat.getStatistic("Cache:HitCount").longValue();
       }
     } while(!Thread.currentThread().isInterrupted() && val != 2);
 
@@ -247,7 +246,7 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
         .collect(Collectors.toList());
 
       for (ContextualStatistics stat : stats) {
-        val = stat.getStatistic(Counter.class, "Cache:HitCount").getValue();
+        val = stat.getStatistic("Cache:HitCount").longValue();
       }
 
     } while(!Thread.currentThread().isInterrupted() && val != 4);

--- a/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatisticsProvider.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/EhcacheStatisticsProvider.java
@@ -23,7 +23,6 @@ import org.ehcache.management.providers.ExposedCacheBinding;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.context.Context;
-import org.terracotta.management.model.stats.Statistic;
 import org.terracotta.management.registry.Named;
 import org.terracotta.management.registry.action.ExposedObject;
 import org.terracotta.management.registry.collect.StatisticProvider;
@@ -72,13 +71,13 @@ public class EhcacheStatisticsProvider extends CacheBindingManagementProvider {
   }
 
   @Override
-  public Map<String, Statistic<?, ?>> collectStatistics(Context context, Collection<String> statisticNames) {
+  public Map<String, Number> collectStatistics(Context context, Collection<String> statisticNames) {
     StandardEhcacheStatistics ehcacheStatistics = (StandardEhcacheStatistics) findExposedObject(context);
     if (ehcacheStatistics != null) {
       if (statisticNames == null || statisticNames.isEmpty()) {
         return ehcacheStatistics.queryStatistics();
       } else {
-        Map<String, Statistic<?, ?>> statistics = new TreeMap<String, Statistic<?, ?>>();
+        Map<String, Number> statistics = new TreeMap<String, Number>();
         for (String statisticName : statisticNames) {
           try {
             statistics.put(statisticName, ehcacheStatistics.queryStatistic(statisticName));

--- a/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
@@ -22,7 +22,6 @@ import org.ehcache.management.ManagementRegistryServiceConfiguration;
 import org.ehcache.management.providers.CacheBinding;
 import org.ehcache.management.providers.ExposedCacheBinding;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
-import org.terracotta.management.model.stats.Statistic;
 import org.terracotta.management.registry.collect.StatisticRegistry;
 
 import java.util.Collection;
@@ -57,11 +56,11 @@ public class StandardEhcacheStatistics extends ExposedCacheBinding {
     }
   }
 
-  public Statistic<?, ?> queryStatistic(String fullStatisticName) {
+  public Number queryStatistic(String fullStatisticName) {
     return statisticRegistry.queryStatistic(fullStatisticName);
   }
 
-  public Map<String, Statistic<?, ?>> queryStatistics() {
+  public Map<String, Number> queryStatistics() {
     return statisticRegistry.queryStatistics();
   }
 

--- a/management/src/test/java/org/ehcache/docs/ManagementTest.java
+++ b/management/src/test/java/org/ehcache/docs/ManagementTest.java
@@ -38,7 +38,6 @@ import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.primitive.Counter;
 import org.terracotta.management.registry.ResultSet;
 import org.terracotta.management.registry.StatisticQuery;
 
@@ -232,11 +231,11 @@ public class ManagementTest {
 
         ContextualStatistics statisticsContext1 = counters.getResult(context1);
 
-        Counter counterContext1 = statisticsContext1.getStatistic(Counter.class, "Cache:MissCount");
+        Number counterContext1 = statisticsContext1.getStatistic("Cache:MissCount");
 
         // miss count is a sampled stat, for example its values could be [0,1,2].
         // In the present case, only the last value is important to us , the cache was eventually missed 2 times
-        val = counterContext1.getValue();
+        val = counterContext1.longValue();
       } while(val != 2);
     }
     finally {

--- a/management/src/test/java/org/ehcache/management/providers/statistics/EvictionTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/EvictionTest.java
@@ -37,7 +37,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.primitive.Counter;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -143,27 +142,27 @@ public class EvictionTest {
       Thread.sleep(1000);
 
       int lowestTier = stats.size() - 1;
-      Counter evictionCounterHistory = managementRegistry.withCapability("StatisticsCapability")
+      Number evictionCounter = managementRegistry.withCapability("StatisticsCapability")
         .queryStatistics(stats)
         .on(context)
         .build()
         .execute()
         .getSingleResult()
-        .getStatistic(Counter.class, stats.get(lowestTier));
+        .getStatistic(stats.get(lowestTier));
       assertThat(contextualStatistics.size(), Matchers.is(stats.size()));
 
-      assertThat(evictionCounterHistory.getValue(), Matchers.equalTo(expected.get(lowestTier)));
+      assertThat(evictionCounter.longValue(), Matchers.equalTo(expected.get(lowestTier)));
 
       if(stats.size() == 2) {
-        Counter evictionHighestTierCounterHistory = contextualStatistics.getStatistic(Counter.class, stats.get(0));
-        assertThat(evictionHighestTierCounterHistory.getValue(), Matchers.equalTo(expected.get(0)));
+        Number evictionHighestTierCounter = contextualStatistics.getStatistic(stats.get(0));
+        assertThat(evictionHighestTierCounter.longValue(), Matchers.equalTo(expected.get(0)));
 
       } else if(stats.size() == 3) {
-        Counter evictionHighestTierCounterHistory = contextualStatistics.getStatistic(Counter.class, stats.get(0));
-        assertThat(evictionHighestTierCounterHistory.getValue(), Matchers.equalTo(expected.get(0)));
+        Number evictionHighestTierCounterHistory = contextualStatistics.getStatistic(stats.get(0));
+        assertThat(evictionHighestTierCounterHistory.longValue(), Matchers.equalTo(expected.get(0)));
 
-        Counter evictionMiddleTierCounterHistory = contextualStatistics.getStatistic(Counter.class, stats.get(1));
-        assertThat(evictionMiddleTierCounterHistory.getValue(), Matchers.equalTo(expected.get(1)));
+        Number evictionMiddleTierCounterHistory = contextualStatistics.getStatistic(stats.get(1));
+        assertThat(evictionMiddleTierCounterHistory.longValue(), Matchers.equalTo(expected.get(1)));
 
       }
     }

--- a/management/src/test/java/org/ehcache/management/providers/statistics/StandardEhcacheStatisticsTest.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/StandardEhcacheStatisticsTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.primitive.Counter;
 
 import java.util.Arrays;
 
@@ -74,9 +73,9 @@ public class StandardEhcacheStatisticsTest {
         .getSingleResult();
 
       assertThat(counter.size(), Matchers.is(1));
-      Counter count = counter.getStatistic(Counter.class, "Cache:HitCount");
+      Number count = counter.getStatistic("Cache:HitCount");
 
-      assertThat(count.getValue(), Matchers.equalTo(1L));
+      assertThat(count.longValue(), Matchers.equalTo(1L));
     }
     finally {
       if(cacheManager != null) {

--- a/management/src/test/java/org/ehcache/management/providers/statistics/StatsUtil.java
+++ b/management/src/test/java/org/ehcache/management/providers/statistics/StatsUtil.java
@@ -20,7 +20,6 @@ import org.hamcrest.Matchers;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.primitive.Counter;
 import org.terracotta.management.registry.ResultSet;
 import org.terracotta.management.registry.StatisticQuery;
 
@@ -55,8 +54,8 @@ public class StatsUtil {
 
     assertThat(counters.size(), Matchers.is(1));
 
-    Counter counterHistory = statisticsContext.getStatistic(Counter.class, statName);
-    long value = counterHistory.getValue();
+    Number counter = statisticsContext.getStatistic(statName);
+    long value = counter.longValue();
 
     assertThat(value, Matchers.is(expectedResult));
 

--- a/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultSharedManagementServiceTest.java
@@ -34,7 +34,6 @@ import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.model.stats.primitive.Counter;
 import org.terracotta.management.registry.ResultSet;
 import org.terracotta.management.registry.StatisticQuery;
 import org.terracotta.management.registry.StatisticQuery.Builder;
@@ -176,7 +175,7 @@ public class DefaultSharedManagementServiceTest {
     Builder builder = service.withCapability("StatisticsCapability")
         .queryStatistic(statisticName)
         .on(contextList);
-    ResultSet<ContextualStatistics> allCounters = getResultSet(builder, contextList, Counter.class, statisticName);
+    ResultSet<ContextualStatistics> allCounters = getResultSet(builder, contextList, statisticName);
 
     assertThat(allCounters.size(), equalTo(3));
 
@@ -185,22 +184,22 @@ public class DefaultSharedManagementServiceTest {
     assertThat(allCounters.getResult(contextList.get(2)).size(), equalTo(1));
 
 
-    assertThat(allCounters.getResult(contextList.get(0)).getStatistic(Counter.class, statisticName).getValue(), equalTo(1L));
-    assertThat(allCounters.getResult(contextList.get(1)).getStatistic(Counter.class, statisticName).getValue(), equalTo(1L));
-    assertThat(allCounters.getResult(contextList.get(2)).getStatistic(Counter.class, statisticName).getValue(), equalTo(1L));
+    assertThat(allCounters.getResult(contextList.get(0)).getStatistic(statisticName).longValue(), equalTo(1L));
+    assertThat(allCounters.getResult(contextList.get(1)).getStatistic(statisticName).longValue(), equalTo(1L));
+    assertThat(allCounters.getResult(contextList.get(2)).getStatistic(statisticName).longValue(), equalTo(1L));
 
   }
 
-  private static ResultSet<ContextualStatistics> getResultSet(StatisticQuery.Builder builder, List<Context> contextList, Class<Counter> type, String statisticsName) {
+  private static ResultSet<ContextualStatistics> getResultSet(StatisticQuery.Builder builder, List<Context> contextList, String statisticsName) {
     ResultSet<ContextualStatistics> counters = null;
 
     //wait till Counter history is initialized and contains values > 0.
     while(!Thread.currentThread().isInterrupted()) {
       counters = builder.build().execute();
 
-      if(counters.getResult(contextList.get(0)).getStatistic(type, statisticsName).getValue()> 0 &&
-         counters.getResult(contextList.get(1)).getStatistic(type, statisticsName).getValue() > 0 &&
-         counters.getResult(contextList.get(2)).getStatistic(type, statisticsName).getValue() > 0) {
+      if(counters.getResult(contextList.get(0)).getStatistic(statisticsName).longValue()> 0 &&
+         counters.getResult(contextList.get(1)).getStatistic(statisticsName).longValue() > 0 &&
+         counters.getResult(contextList.get(2)).getStatistic(statisticsName).longValue() > 0) {
         break;
       }
     }


### PR DESCRIPTION
See: https://github.com/Terracotta-OSS/terracotta-platform/issues/261

Depends on new tc-platform release __5.2.0-pre6__ (https://github.com/Terracotta-OSS/terracotta-platform/pull/264)

Note: All Ehcache tests passed locally with the tc-platform snapshot.