### PR TITLE
[master] Remove java6Home definition from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,3 @@ deployUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
 
 # Enable the daemon by adding org.gradle.daemon in USER_HOME/.gradle/gradle.properties
 org.gradle.parallel=true
-
-java6Home=/Library/Java/JavaVirtualMachines/1.6.0_65-b14-462.jdk/Contents/Home


### PR DESCRIPTION
Defining these props is part of the local project setup, not
something that makes sense to share.