### PR TITLE
Issue #1686 For now, prepare for destroy only on active

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheExecutionStrategy.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheExecutionStrategy.java
@@ -41,7 +41,7 @@ public class EhcacheExecutionStrategy implements ExecutionStrategy<EhcacheEntity
     } else if (message instanceof LifecycleMessage.ValidateServerStore) {
       return Location.ACTIVE;
     } else if (message instanceof LifecycleMessage.PrepareForDestroy) {
-      return Location.BOTH;
+      return Location.ACTIVE;
     } else if (message instanceof StateRepositoryOpMessage.PutIfAbsentMessage) {
       // State repository operation needing replication
       return Location.BOTH;


### PR DESCRIPTION
This is a temporary change, to last until the _prepare for destroy_ call effectively sets some state server side. Until then, since the passive cannot support the message, make it go to the active only. 