### PR TITLE
Closes #1834 Client message tracking at cluster tier level

### DIFF
--- a/clustered/client/src/test/java/org/ehcache/clustered/client/replication/ActivePassiveClientIdTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/replication/ActivePassiveClientIdTest.java
@@ -109,18 +109,18 @@ public class ActivePassiveClientIdTest {
 
     ObservableClusterTierServerEntityService.ObservableClusterTierPassiveEntity ehcachePassiveEntity = observableClusterTierServerEntityService.getServedPassiveEntities().get(0);
 
-    assertThat(ehcachePassiveEntity.getMessageTrackerMap().size(), is(0));
+    assertThat(ehcachePassiveEntity.getMessageTrackerMap("test").size(), is(0));
 
     storeProxy.getAndAppend(42L, createPayload(42L));
 
-    assertThat(ehcachePassiveEntity.getMessageTrackerMap().size(), is(1));
+    assertThat(ehcachePassiveEntity.getMessageTrackerMap("test").size(), is(1));
 
     service.stop();
 
     CompletableFuture<Boolean> completableFuture = CompletableFuture.supplyAsync(() -> {
       while (true) {
         try {
-          if (ehcachePassiveEntity.getMessageTrackerMap().size() == 0) {
+          if (ehcachePassiveEntity.getMessageTrackerMap("test").size() == 0) {
             return true;
           }
         } catch (Exception e) {

--- a/clustered/client/src/test/java/org/ehcache/clustered/server/ObservableEhcacheServerEntityService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/server/ObservableEhcacheServerEntityService.java
@@ -60,14 +60,6 @@ public class ObservableEhcacheServerEntityService
     return Collections.unmodifiableList(observables);
   }
 
-  public List<ObservableEhcachePassiveEntity> getServedPassiveEntities() throws Exception {
-    List<ObservableEhcachePassiveEntity> observables = new ArrayList<>(servedPassiveEntities.size());
-    for (ClusterTierManagerPassiveEntity servedPassiveEntity : servedPassiveEntities) {
-      observables.add(new ObservableEhcachePassiveEntity(servedPassiveEntity));
-    }
-    return Collections.unmodifiableList(observables);
-  }
-
   @Override
   public long getVersion() {
     return delegate.getVersion();
@@ -150,29 +142,6 @@ public class ObservableEhcacheServerEntityService
       return ehcacheStateService.getDedicatedResourcePoolIds();
     }
 
-    public Map getClientsWaitingForInvalidation() throws Exception {
-      Field field = activeEntity.getClass().getDeclaredField("clientsWaitingForInvalidation");
-      field.setAccessible(true);
-      return (Map)field.get(activeEntity);
-    }
   }
 
-  public static final class ObservableEhcachePassiveEntity {
-    private final ClusterTierManagerPassiveEntity passiveEntity;
-    private final EhcacheStateServiceImpl ehcacheStateService;
-
-    private ObservableEhcachePassiveEntity(ClusterTierManagerPassiveEntity passiveEntity) throws Exception {
-      this.passiveEntity = passiveEntity;
-      Field field = passiveEntity.getClass().getDeclaredField("ehcacheStateService");
-      field.setAccessible(true);
-      this.ehcacheStateService = (EhcacheStateServiceImpl)field.get(passiveEntity);
-    }
-
-    public Map getMessageTrackerMap() throws Exception {
-      Field field = this.ehcacheStateService.getClientMessageTracker().getClass().getDeclaredField("messageTrackers");
-      field.setAccessible(true);
-      return (Map)field.get(this.ehcacheStateService.getClientMessageTracker());
-    }
-
-  }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/server/store/ObservableClusterTierServerEntityService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/server/store/ObservableClusterTierServerEntityService.java
@@ -144,10 +144,10 @@ public class ObservableClusterTierServerEntityService
       this.ehcacheStateService = (EhcacheStateServiceImpl)field.get(passiveEntity);
     }
 
-    public Map getMessageTrackerMap() throws Exception {
-      Field field = this.ehcacheStateService.getClientMessageTracker().getClass().getDeclaredField("clientUUIDMessageTrackerMap");
+    public Map getMessageTrackerMap(String storeAlias) throws Exception {
+      Field field = this.ehcacheStateService.getClientMessageTracker(storeAlias).getClass().getDeclaredField("clientUUIDMessageTrackerMap");
       field.setAccessible(true);
-      return (Map)field.get(this.ehcacheStateService.getClientMessageTracker());
+      return (Map)field.get(this.ehcacheStateService.getClientMessageTracker(storeAlias));
     }
 
   }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/EhcacheStateServiceImpl.java
@@ -110,7 +110,7 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
    */
   private final Map<String, ServerStoreImpl> stores = new ConcurrentHashMap<>();
 
-  private final ClientMessageTracker messageTracker = new DefaultClientMessageTracker();
+  private final Map<String, ClientMessageTracker> messageTrackers = new ConcurrentHashMap<>();
   private volatile InvalidationTrackerManager invalidationTrackerManager;
   private final StateRepositoryManager stateRepositoryManager;
   private final ServerSideConfiguration configuration;
@@ -405,6 +405,7 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
     }
 
     stores.put(name, serverStore);
+    messageTrackers.put(name, new DefaultClientMessageTracker());
 
     registerStoreStatistics(serverStore, name);
 
@@ -421,6 +422,7 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
       store.close();
     }
     stateRepositoryManager.destroyStateRepository(name);
+    messageTrackers.remove(name);
   }
 
   private PageSource getPageSource(String name, PoolAllocation allocation) throws ConfigurationException {
@@ -485,8 +487,8 @@ public class EhcacheStateServiceImpl implements EhcacheStateService {
   }
 
   @Override
-  public ClientMessageTracker getClientMessageTracker() {
-    return this.messageTracker;
+  public ClientMessageTracker getClientMessageTracker(String name) {
+    return this.messageTrackers.get(name);
   }
 
   private static boolean nullSafeEquals(Object s1, Object s2) {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClusterTierClientState.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClusterTierClientState.java
@@ -16,6 +16,8 @@
 
 package org.ehcache.clustered.server.management;
 
+import java.util.UUID;
+
 /**
  * ClusterTierClientState
  */
@@ -23,11 +25,17 @@ public class ClusterTierClientState {
 
   private final boolean attached;
   private final String storeIdentifier;
+  private final UUID clientId;
 
 
   public ClusterTierClientState(String storeIdentifier, boolean attached) {
+    this(storeIdentifier, attached, null);
+  }
+
+  public ClusterTierClientState(String storeIdentifier, boolean attached, UUID clientId) {
     this.attached = attached;
     this.storeIdentifier = storeIdentifier;
+    this.clientId = clientId;
   }
 
   public boolean isAttached() {
@@ -36,5 +44,9 @@ public class ClusterTierClientState {
 
   public String getStoreIdentifier() {
     return storeIdentifier;
+  }
+
+  public UUID getClientIdentifier() {
+    return clientId;
   }
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClusterTierManagement.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/ClusterTierManagement.java
@@ -103,34 +103,34 @@ public class ClusterTierManagement {
     }
   }
 
-  public void clientConnected(ClientDescriptor clientDescriptor) {
+  public void clientConnected(ClientDescriptor clientDescriptor, ClusterTierClientState clientState) {
     if (managementRegistry != null) {
       LOGGER.trace("clientConnected({})", clientDescriptor);
-      managementRegistry.registerAndRefresh(new ClusterTierClientStateBinding(clientDescriptor, new ClusterTierClientState(storeIdentifier, false)));
+      managementRegistry.registerAndRefresh(new ClusterTierClientStateBinding(clientDescriptor, clientState));
     }
   }
 
 
-  public void clientDisconnected(ClientDescriptor clientDescriptor) {
+  public void clientDisconnected(ClientDescriptor clientDescriptor, ClusterTierClientState clientState) {
     if (managementRegistry != null) {
       LOGGER.trace("clientDisconnected({})", clientDescriptor);
-      ClusterTierClientState clientState = new ClusterTierClientState(storeIdentifier, false);
-      managementRegistry.pushServerEntityNotification(new ClusterTierClientStateBinding(clientDescriptor, clientState), EHCACHE_SERVER_STORE_RELEASED.name());
-      managementRegistry.unregisterAndRefresh(new ClusterTierClientStateBinding(clientDescriptor, clientState));
+      ClusterTierClientStateBinding clientStateBinding = new ClusterTierClientStateBinding(clientDescriptor, clientState);
+      managementRegistry.pushServerEntityNotification(clientStateBinding, EHCACHE_SERVER_STORE_RELEASED.name());
+      managementRegistry.unregisterAndRefresh(clientStateBinding);
     }
   }
 
-  public void clientReconnected(ClientDescriptor clientDescriptor) {
+  public void clientReconnected(ClientDescriptor clientDescriptor, ClusterTierClientState clientState) {
     if (managementRegistry != null) {
       LOGGER.trace("clientReconnected({})", clientDescriptor);
-      managementRegistry.pushServerEntityNotification(new ClusterTierClientStateBinding(clientDescriptor, new ClusterTierClientState(storeIdentifier, true)), EHCACHE_SERVER_STORE_CLIENT_RECONNECTED.name());
+      managementRegistry.pushServerEntityNotification(new ClusterTierClientStateBinding(clientDescriptor, clientState), EHCACHE_SERVER_STORE_CLIENT_RECONNECTED.name());
     }
   }
 
-  public void clientValidated(ClientDescriptor clientDescriptor) {
+  public void clientValidated(ClientDescriptor clientDescriptor, ClusterTierClientState clientState) {
     if (managementRegistry != null) {
       LOGGER.trace("clientValidated({})", clientDescriptor);
-      ClusterTierClientStateBinding clientStateBinding = new ClusterTierClientStateBinding(clientDescriptor, new ClusterTierClientState(storeIdentifier, true));
+      ClusterTierClientStateBinding clientStateBinding = new ClusterTierClientStateBinding(clientDescriptor, clientState);
       managementRegistry.unregister(clientStateBinding);
       managementRegistry.registerAndRefresh(clientStateBinding).thenRun(() ->
         managementRegistry.pushServerEntityNotification(clientStateBinding, EHCACHE_SERVER_STORE_ATTACHED.name()));

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/state/EhcacheStateService.java
@@ -62,7 +62,7 @@ public interface EhcacheStateService {
 
   StateRepositoryManager getStateRepositoryManager() throws ClusterException;
 
-  ClientMessageTracker getClientMessageTracker();
+  ClientMessageTracker getClientMessageTracker(String name);
 
   void loadExisting(ServerSideConfiguration configuration);
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierPassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierPassiveEntity.java
@@ -176,7 +176,7 @@ public class ClusterTierPassiveEntity implements PassiveServerEntity<EhcacheEnti
         }
         break;
       case CLIENT_ID_TRACK_OP:
-        stateService.getClientMessageTracker().remove(message.getClientId());
+        stateService.getClientMessageTracker(storeIdentifier).remove(message.getClientId());
         break;
       default:
         throw new AssertionError("Unsupported Retirement Message : " + message);
@@ -214,7 +214,7 @@ public class ClusterTierPassiveEntity implements PassiveServerEntity<EhcacheEnti
   }
 
   private void applyMessage(EhcacheOperationMessage message) {
-    ClientMessageTracker clientMessageTracker = stateService.getClientMessageTracker();
+    ClientMessageTracker clientMessageTracker = stateService.getClientMessageTracker(storeIdentifier);
     clientMessageTracker.applied(message.getId(), message.getClientId());
   }
 

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/ClusterTierManagerPassiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/ClusterTierManagerPassiveEntityTest.java
@@ -253,7 +253,7 @@ public class ClusterTierManagerPassiveEntityTest {
       passiveEntity.invoke(new InvalidMessage());
       fail("Invalid message should result in AssertionError");
     } catch (AssertionError e) {
-      assertThat(e.getMessage(), containsString("Unsupported"));
+      assertThat(e.getMessage(), containsString("No invokes supported by this entity"));
     }
   }
 

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/store/ClusterTierActiveEntityTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/store/ClusterTierActiveEntityTest.java
@@ -1024,7 +1024,7 @@ public class ClusterTierActiveEntityTest {
 
     EhcacheStateService ehcacheStateService = defaultRegistry.getStoreManagerService();
 
-    ClientMessageTracker clientMessageTracker = ehcacheStateService.getClientMessageTracker();
+    ClientMessageTracker clientMessageTracker = ehcacheStateService.getClientMessageTracker(defaultStoreName);
 
     Random random = new Random();
     Set<Long> msgIds = new HashSet<>();


### PR DESCRIPTION
Client tracking need not happen at the cluster tier manager level as it adds an unnecessary contention point for different caches. So moving that to the cluster tier level.