### PR TITLE
[release/3.1] Issue #1814 Remove findbugs warning

### DIFF
--- a/clustered/common/src/main/java/org/ehcache/clustered/common/internal/store/ValueWrapper.java
+++ b/clustered/common/src/main/java/org/ehcache/clustered/common/internal/store/ValueWrapper.java
@@ -16,12 +16,15 @@
 
 package org.ehcache.clustered.common.internal.store;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.Serializable;
 import java.util.Arrays;
 
 /**
  * ValueWrapper
  */
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public class ValueWrapper implements Serializable {
 
   private static final long serialVersionUID = -4794738044295644587L;


### PR DESCRIPTION
Suppressing the warning as the type is used in a specific context
where exposing that byte[] is not an issue.