### PR TITLE
Fixes #1834 Perform client ID validation at the clustered tier manager level

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/ClientState.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/ClientState.java
@@ -15,6 +15,8 @@
  */
 package org.ehcache.clustered.server;
 
+import java.util.UUID;
+
 /**
  * Represents a client's state against an {@link ClusterTierManagerActiveEntity}.
  */
@@ -23,13 +25,19 @@ public class ClientState {
    * Indicates if the client has either configured or validated with clustered store manager.
    */
   private boolean attached = false;
+  private UUID clientId;
 
   public boolean isAttached() {
     return attached;
   }
 
-  void attach() {
+  public UUID getClientIdentifier() {
+    return clientId;
+  }
+
+  void attach(UUID clientId) {
     this.attached = true;
+    this.clientId = clientId;
   }
 
 }

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierActiveEntity.java
@@ -268,17 +268,12 @@ public class ClusterTierActiveEntity implements ActiveServerEntity<EhcacheEntity
       throw new LifecycleException("Client : " + clientDescriptor + " is already being tracked with Client ID : " + clientState.getClientIdentifier());
     }
 
-    UUID clientId = validateServerStore.getClientId();
-    if (getTrackedClients().collect(toSet()).contains(clientId)) {
-      throw new InvalidClientIdException("Another client with Client ID : " + clientId + " is already being tracked.");
-    }
-
     ServerStoreConfiguration clientConfiguration = validateServerStore.getStoreConfiguration();
     LOGGER.info("Client {} validating clustered tier '{}'", clientDescriptor, storeIdentifier);
     ServerSideServerStore store = stateService.getStore(storeIdentifier);
     if (store != null) {
       storeCompatibility.verify(store.getStoreConfiguration(), clientConfiguration);
-      attachStore(clientDescriptor, clientId);
+      attachStore(clientDescriptor, validateServerStore.getClientId());
       management.clientValidated(clientDescriptor, connectedClients.get(clientDescriptor));
     } else {
       throw new InvalidStoreException("Clustered tier '" + storeIdentifier + "' does not exist");


### PR DESCRIPTION
Client ID validation done at the clustered tier must be moved to the clustered tier manager level since all the duplicate client ID resolution logic is at the clustered tier manager level and it's earlier in the life cycle.