### PR TITLE
Make hash handling in clustered store explicit

### DIFF
--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
@@ -36,6 +36,7 @@ import org.ehcache.core.spi.store.StoreAccessTimeoutException;
 import org.ehcache.core.spi.time.TimeSource;
 import org.ehcache.core.statistics.StoreOperationOutcomes;
 import org.ehcache.expiry.Expirations;
+import org.ehcache.impl.internal.util.HashUtils;
 import org.ehcache.impl.serialization.LongSerializer;
 import org.ehcache.impl.serialization.StringSerializer;
 import org.junit.After;
@@ -157,7 +158,8 @@ public class ClusteredStoreTest {
   @SuppressWarnings("unchecked")
   public void testGetTimeout() throws Exception {
     ServerStoreProxy proxy = mock(ServerStoreProxy.class);
-    when(proxy.get(1L)).thenThrow(TimeoutException.class);
+    long longKey = HashUtils.intHashToLong(new Long(1L).hashCode());
+    when(proxy.get(longKey)).thenThrow(TimeoutException.class);
     ClusteredStore<Long, String> store = new ClusteredStore<Long, String>(null, null, proxy, null);
     assertThat(store.get(1L), nullValue());
     validateStats(store, EnumSet.of(StoreOperationOutcomes.GetOutcome.TIMEOUT));
@@ -179,12 +181,13 @@ public class ClusteredStoreTest {
     ServerStoreProxy serverStoreProxy = mock(ServerStoreProxy.class);
     Chain chain = mock(Chain.class);
     when(chain.isEmpty()).thenReturn(false);
-    when(serverStoreProxy.get(42L)).thenReturn(chain);
+    long longKey = HashUtils.intHashToLong(new Long(42L).hashCode());
+    when(serverStoreProxy.get(longKey)).thenReturn(chain);
 
     ClusteredStore<Long, String> clusteredStore = new ClusteredStore<Long, String>(operationsCodec, chainResolver,
                                                                                     serverStoreProxy, timeSource);
     clusteredStore.get(42L);
-    verify(serverStoreProxy).replaceAtHead(eq(42L), eq(chain), any(Chain.class));
+    verify(serverStoreProxy).replaceAtHead(eq(longKey), eq(chain), any(Chain.class));
   }
 
   @Test
@@ -202,12 +205,13 @@ public class ClusteredStoreTest {
     ServerStoreProxy serverStoreProxy = mock(ServerStoreProxy.class);
     Chain chain = mock(Chain.class);
     when(chain.isEmpty()).thenReturn(false);
-    when(serverStoreProxy.get(42L)).thenReturn(chain);
+    long longKey = HashUtils.intHashToLong(new Long(42L).hashCode());
+    when(serverStoreProxy.get(longKey)).thenReturn(chain);
 
     ClusteredStore<Long, String> clusteredStore = new ClusteredStore<Long, String>(operationsCodec, chainResolver,
                                                                                     serverStoreProxy, timeSource);
     clusteredStore.get(42L);
-    verify(serverStoreProxy, never()).replaceAtHead(eq(42L), eq(chain), any(Chain.class));
+    verify(serverStoreProxy, never()).replaceAtHead(eq(longKey), eq(chain), any(Chain.class));
   }
 
   @Test

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -45,6 +45,7 @@ import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
 import org.ehcache.impl.internal.store.heap.holders.SerializedOnHeapValueHolder;
 import org.ehcache.core.spi.time.TimeSource;
 import org.ehcache.core.spi.time.TimeSourceService;
+import org.ehcache.impl.internal.util.HashUtils;
 import org.ehcache.impl.serialization.TransientStateRepository;
 import org.ehcache.sizeof.annotations.IgnoreSizeOf;
 import org.ehcache.spi.serialization.Serializer;
@@ -938,7 +939,8 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
   @Override
   public void silentInvalidateAllWithHash(long hash, BiFunction<K, ValueHolder<V>, Void> biFunction) throws StoreAccessException {
     silentInvalidateAllWithHashObserver.begin();
-    Map<K, OnHeapValueHolder<V>> removed = map.removeAllWithHash((int) hash);
+    int intHash = HashUtils.longHashToInt(hash);
+    Map<K, OnHeapValueHolder<V>> removed = map.removeAllWithHash(intHash);
     for (Entry<K, OnHeapValueHolder<V>> entry : removed.entrySet()) {
       biFunction.apply(entry.getKey(), entry.getValue());
     }
@@ -967,11 +969,12 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
   @Override
   public void invalidateAllWithHash(long hash) throws StoreAccessException {
     invalidateAllWithHashObserver.begin();
-    Map<K, OnHeapValueHolder<V>> removed = map.removeAllWithHash((int) hash);
+    int intHash = HashUtils.longHashToInt(hash);
+    Map<K, OnHeapValueHolder<V>> removed = map.removeAllWithHash(intHash);
     for (Entry<K, OnHeapValueHolder<V>> entry : removed.entrySet()) {
       notifyInvalidation(entry.getKey(), entry.getValue());
     }
-    LOG.debug("CLIENT: onheap store removed all with hash {}", hash);
+    LOG.debug("CLIENT: onheap store removed all with hash {}", intHash);
     invalidateAllWithHashObserver.end(CachingTierOperationOutcomes.InvalidateAllWithHashOutcome.SUCCESS);
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -48,6 +48,7 @@ import org.ehcache.core.statistics.AuthoritativeTierOperationOutcomes;
 import org.ehcache.core.statistics.LowerCachingTierOperationsOutcome;
 import org.ehcache.core.statistics.StoreOperationOutcomes;
 import org.ehcache.impl.internal.store.BinaryValueHolder;
+import org.ehcache.impl.internal.util.HashUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.offheapstore.exceptions.OversizeMappingException;
@@ -995,7 +996,8 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
   @Override
   public void invalidateAllWithHash(long hash) {
     invalidateAllWithHashObserver.begin();
-    Map<K, OffHeapValueHolder<V>> removed = backingMap().removeAllWithHash((int) hash);
+    int intHash = HashUtils.longHashToInt(hash);
+    Map<K, OffHeapValueHolder<V>> removed = backingMap().removeAllWithHash(intHash);
     for (Map.Entry<K, OffHeapValueHolder<V>> entry : removed.entrySet()) {
       notifyInvalidation(entry.getKey(), entry.getValue());
     }

--- a/impl/src/main/java/org/ehcache/impl/internal/util/HashUtils.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/util/HashUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.util;
+
+/**
+ * HashUtils
+ */
+public class HashUtils {
+
+  public static long intHashToLong(int hash) {
+    long l = ((long) hash) & 0xffffffffL;
+    return (l << 32 ) | l;
+  }
+
+  public static int longHashToInt(long hash) {
+    return (int) hash;
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/util/HashUtilsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/util/HashUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.util;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * HashUtilsTest
+ */
+public class HashUtilsTest {
+
+  @Test
+  public void testHashTransform() {
+    Random random = new Random();
+    for (int i = 0; i < 10; i++) {
+      int hash = random.nextInt();
+      long longHash = HashUtils.intHashToLong(hash);
+      int inthash = HashUtils.longHashToInt(longHash);
+
+      assertThat(inthash, is(hash));
+    }
+  }
+
+}


### PR DESCRIPTION
We transform the key hash code into a long for the server but need
the transformation to be reversible as it is the basis for
invalidation in caching tiers. This commit extracts the cast based
conversion into a utility class and enriches it.