### PR TITLE
[release/3.2] Fix #1767 Null check in BaseCacheConfiguration

### DIFF
--- a/core/src/main/java/org/ehcache/core/config/BaseCacheConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/config/BaseCacheConfiguration.java
@@ -55,6 +55,15 @@ public class BaseCacheConfiguration<K, V> implements CacheConfiguration<K,V> {
           EvictionAdvisor<? super K, ? super V> evictionAdvisor,
           ClassLoader classLoader, Expiry<? super K, ? super V> expiry,
           ResourcePools resourcePools, ServiceConfiguration<?>... serviceConfigurations) {
+    if (keyType == null) {
+      throw new NullPointerException("keyType cannot be null");
+    }
+    if (valueType == null) {
+      throw new NullPointerException("valueType cannot be null");
+    }
+    if (resourcePools == null) {
+      throw new NullPointerException("resourcePools cannot be null");
+    }
     this.keyType = keyType;
     this.valueType = valueType;
     this.evictionAdvisor = evictionAdvisor;

--- a/core/src/test/java/org/ehcache/core/config/BaseCacheConfigurationTest.java
+++ b/core/src/test/java/org/ehcache/core/config/BaseCacheConfigurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.core.config;
+
+import org.ehcache.config.ResourcePools;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * BaseCacheConfigurationTest
+ */
+public class BaseCacheConfigurationTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testThrowsWithNullKeyType() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("keyType");
+
+    new BaseCacheConfiguration<Object, String>(null, String.class, null,
+      null, null, mock(ResourcePools.class));
+  }
+
+  @Test
+  public void testThrowsWithNullValueType() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("valueType");
+
+    new BaseCacheConfiguration<Long, Object>(Long.class, null, null,
+      null, null, mock(ResourcePools.class));
+  }
+
+  @Test
+  public void testThrowsWithNullResourcePools() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("resourcePools");
+
+    new BaseCacheConfiguration<Long, String>(Long.class, String.class, null,
+      null, null, null);
+  }
+
+}


### PR DESCRIPTION
Key type, value type and resource pools cannot be null.