### PR TITLE
[3.4] Allow to specify the number of segments created by a disk store (close #1932)

### DIFF
--- a/docs/src/docs/asciidoc/user/tiering.adoc
+++ b/docs/src/docs/asciidoc/user/tiering.adoc
@@ -141,6 +141,18 @@ NOTE: Ehcache 3 only offers persistence in the case of clean shutdowns (`close()
 is no data integrity guarantee. At restart, Ehcache will detect that the `CacheManager` wasn't cleanly closed and will wipe the disk
 storage before using it.
 
+==== Segments
+
+A disk storage is separated in segments which are providing concurrency access but are also holding open file pointers.
+The default is 16. In some cases, you might want to reduce the concurrency and save resources by reducing the number of segments.
+
+[source,java,indent=0]
+----
+include::{sourcedir33}/impl/src/test/java/org/ehcache/docs/Tiering.java[tag=diskSegments]
+----
+
+<1> Give an `OffHeapDiskStoreConfiguration` instance specifying the wanted number of segments.
+
 === Clustered
 
 A clustered tier means the client is connecting to a remote Terracotta server where the cached data is put. It is also

--- a/impl/src/main/java/org/ehcache/impl/config/store/disk/OffHeapDiskStoreConfiguration.java
+++ b/impl/src/main/java/org/ehcache/impl/config/store/disk/OffHeapDiskStoreConfiguration.java
@@ -24,11 +24,26 @@ import org.ehcache.spi.service.ServiceConfiguration;
  */
 public class OffHeapDiskStoreConfiguration implements ServiceConfiguration<OffHeapDiskStore.Provider> {
 
+  public static final int DEFAULT_WRITER_CONCURRENCY = 1;
+  public static final int DEFAULT_DISK_SEGMENTS = 16;
+
   private final String threadPoolAlias;
   private final int writerConcurrency;
+  private final int diskSegments;
 
   /**
-   * Creates a new configuration instance using the provided parameters.
+   * Creates a new configuration instance using the provided {@code diskSegments}. Other attributes are set to their default
+   * ({@code null} for {@code threadPoolAlias} and {@link #DEFAULT_DISK_SEGMENTS} for {@code threadPoolAlias})
+   *
+   * @param diskSegments number of disk segments allocated. The more disk segments there is, the more concurrency you get but
+   *               the more resources you are using (mainly file pointers)
+   */
+  public OffHeapDiskStoreConfiguration(int diskSegments) {
+    this(null, DEFAULT_WRITER_CONCURRENCY, diskSegments);
+  }
+
+  /**
+   * Creates a new configuration instance using the provided parameters. {@code diskSegments} is set to {@link #DEFAULT_DISK_SEGMENTS}.
    *
    * @param threadPoolAlias the thread pool alias
    * @param writerConcurrency the writer concurrency
@@ -36,8 +51,23 @@ public class OffHeapDiskStoreConfiguration implements ServiceConfiguration<OffHe
    * @see org.ehcache.impl.config.executor.PooledExecutionServiceConfiguration
    */
   public OffHeapDiskStoreConfiguration(String threadPoolAlias, int writerConcurrency) {
+    this(threadPoolAlias, writerConcurrency, DEFAULT_DISK_SEGMENTS);
+  }
+
+  /**
+   * Creates a new configuration instance using the provided parameters.
+   *
+   * @param threadPoolAlias the thread pool alias
+   * @param writerConcurrency the writer concurrency
+   * @param diskSegments number of disk segments allocated. The more disk segments there is, the more concurrency you get but
+   *               the more resources you are using (mainly file pointers)
+   *
+   * @see org.ehcache.impl.config.executor.PooledExecutionServiceConfiguration
+   */
+  public OffHeapDiskStoreConfiguration(String threadPoolAlias, int writerConcurrency, int diskSegments) {
     this.threadPoolAlias = threadPoolAlias;
     this.writerConcurrency = writerConcurrency;
+    this.diskSegments = diskSegments;
   }
 
   /**
@@ -58,6 +88,15 @@ public class OffHeapDiskStoreConfiguration implements ServiceConfiguration<OffHe
    */
   public int getWriterConcurrency() {
     return writerConcurrency;
+  }
+
+  /**
+   * Returns the number of disk segments created
+   *
+   * @return the number of segments
+   */
+  public int getDiskSegments() {
+    return diskSegments;
   }
 
   /**

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -100,7 +100,6 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
 
   private static final String KEY_TYPE_PROPERTY_NAME = "keyType";
   private static final String VALUE_TYPE_PROPERTY_NAME = "valueType";
-  private static final int DEFAULT_CONCURRENCY = 16;
 
   protected final AtomicReference<Status> status = new AtomicReference<Status>(Status.UNINITIALIZED);
 
@@ -115,17 +114,19 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
   private final ExecutionService executionService;
   private final String threadPoolAlias;
   private final int writerConcurrency;
+  private final int diskSegments;
 
   private volatile EhcachePersistentConcurrentOffHeapClockCache<K, OffHeapValueHolder<V>> map;
 
   public OffHeapDiskStore(FileBasedPersistenceContext fileBasedPersistenceContext,
-                          ExecutionService executionService, String threadPoolAlias, int writerConcurrency,
+                          ExecutionService executionService, String threadPoolAlias, int writerConcurrency, int diskSegments,
                           final Configuration<K, V> config, TimeSource timeSource, StoreEventDispatcher<K, V> eventDispatcher, long sizeInBytes) {
     super(STATISTICS_TAG, config, timeSource, eventDispatcher);
     this.fileBasedPersistenceContext = fileBasedPersistenceContext;
     this.executionService = executionService;
     this.threadPoolAlias = threadPoolAlias;
     this.writerConcurrency = writerConcurrency;
+    this.diskSegments = diskSegments;
 
     EvictionAdvisor<? super K, ? super V> evictionAdvisor = config.getEvictionAdvisor();
     if (evictionAdvisor != null) {
@@ -224,7 +225,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
         DiskWriteThreadPool writeWorkers = new DiskWriteThreadPool(executionService, threadPoolAlias, writerConcurrency);
 
         Factory<FileBackedStorageEngine<K, OffHeapValueHolder<V>>> storageEngineFactory = FileBackedStorageEngine.createFactory(source,
-                max((size / DEFAULT_CONCURRENCY) / 10, 1024), BYTES, keyPortability, elementPortability, writeWorkers, false);
+                max((size / diskSegments) / 10, 1024), BYTES, keyPortability, elementPortability, writeWorkers, false);
 
         EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>> factory = new EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>>(
             source,
@@ -267,7 +268,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
     DiskWriteThreadPool writeWorkers = new DiskWriteThreadPool(executionService, threadPoolAlias, writerConcurrency);
 
     Factory<FileBackedStorageEngine<K, OffHeapValueHolder<V>>> storageEngineFactory = FileBackedStorageEngine.createFactory(source,
-        max((size / DEFAULT_CONCURRENCY) / 10, 1024), BYTES, keyPortability, elementPortability, writeWorkers, true);
+        max((size / diskSegments) / 10, 1024), BYTES, keyPortability, elementPortability, writeWorkers, true);
 
     EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>> factory = new EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>>(
         source,
@@ -275,7 +276,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
         64,
         evictionAdvisor,
         mapEvictionListener, true);
-    return new EhcachePersistentConcurrentOffHeapClockCache<K, OffHeapValueHolder<V>>(evictionAdvisor, factory, DEFAULT_CONCURRENCY);
+    return new EhcachePersistentConcurrentOffHeapClockCache<K, OffHeapValueHolder<V>>(evictionAdvisor, factory, diskSegments);
 
   }
 
@@ -364,13 +365,16 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
 
       String threadPoolAlias;
       int writerConcurrency;
+      int diskSegments;
       OffHeapDiskStoreConfiguration config = findSingletonAmongst(OffHeapDiskStoreConfiguration.class, (Object[]) serviceConfigs);
       if (config == null) {
         threadPoolAlias = defaultThreadPool;
-        writerConcurrency = 1;
+        writerConcurrency = OffHeapDiskStoreConfiguration.DEFAULT_WRITER_CONCURRENCY;
+        diskSegments = OffHeapDiskStoreConfiguration.DEFAULT_DISK_SEGMENTS;
       } else {
         threadPoolAlias = config.getThreadPoolAlias();
         writerConcurrency = config.getWriterConcurrency();
+        diskSegments = config.getDiskSegments();
       }
       PersistenceSpaceIdentifier<?> space = findSingletonAmongst(PersistenceSpaceIdentifier.class, (Object[]) serviceConfigs);
       if (space == null) {
@@ -380,7 +384,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
         FileBasedPersistenceContext persistenceContext = diskPersistenceService.createPersistenceContextWithin(space , "offheap-disk-store");
 
         OffHeapDiskStore<K, V> offHeapStore = new OffHeapDiskStore<K, V>(persistenceContext,
-                executionService, threadPoolAlias, writerConcurrency,
+                executionService, threadPoolAlias, writerConcurrency, diskSegments,
                 storeConfig, timeSource, eventDispatcher, unit.toBytes(diskPool.getSize()));
         createdStores.put(offHeapStore, space);
         return offHeapStore;
@@ -526,5 +530,17 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
         }
       }
     });
+  }
+
+  String getThreadPoolAlias() {
+    return threadPoolAlias;
+  }
+
+  int getWriterConcurrency() {
+    return writerConcurrency;
+  }
+
+  int getDiskSegments() {
+    return diskSegments;
   }
 }

--- a/impl/src/test/java/org/ehcache/docs/Tiering.java
+++ b/impl/src/test/java/org/ehcache/docs/Tiering.java
@@ -33,6 +33,7 @@ import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.docs.plugs.ListenerObject;
 import org.ehcache.event.EventType;
+import org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -100,6 +101,23 @@ public class Tiering {
 
     persistentCacheManager.close();
     // end::persistentCacheManager[]
+  }
+
+  @Test
+  public void diskSegments() throws Exception {
+    // tag::diskSegments[]
+    String storagePath = getStoragePath();
+    PersistentCacheManager persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+      .with(CacheManagerBuilder.persistence(new File(storagePath, "myData")))
+      .withCache("less-segments",
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
+          ResourcePoolsBuilder.newResourcePoolsBuilder().disk(10, MemoryUnit.MB))
+        .add(new OffHeapDiskStoreConfiguration(2)) // <1>
+      )
+      .build(true);
+
+    persistentCacheManager.close();
+    // end::diskSegments[]
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreSPITest.java
@@ -56,6 +56,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.ehcache.config.ResourceType.Core.DISK;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.ehcache.core.internal.service.ServiceLocator.dependencySet;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_DISK_SEGMENTS;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_WRITER_CONCURRENCY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -117,7 +119,7 @@ public class OffHeapDiskStoreSPITest extends AuthoritativeTierSPITest<String, St
               evictionAdvisor, getClass().getClassLoader(), expiry, resourcePools, 0, keySerializer, valueSerializer);
           OffHeapDiskStore<String, String> store = new OffHeapDiskStore<String, String>(
                   diskResourceService.createPersistenceContextWithin(space, "store"),
-                  new OnDemandExecutionService(), null, 1,
+                  new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
                   config, timeSource,
                   new TestStoreEventDispatcher<String, String>(),
                   unit.toBytes(diskPool.getSize()));

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
@@ -29,6 +29,7 @@ import org.ehcache.core.spi.store.StoreAccessException;
 import org.ehcache.core.statistics.LowerCachingTierOperationsOutcome;
 import org.ehcache.CachePersistenceException;
 import org.ehcache.expiry.Expiry;
+import org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration;
 import org.ehcache.impl.internal.events.TestStoreEventDispatcher;
 import org.ehcache.impl.internal.executor.OnDemandExecutionService;
 import org.ehcache.impl.internal.persistence.TestDiskResourceService;
@@ -80,6 +81,8 @@ import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsB
 import static org.ehcache.config.units.MemoryUnit.MB;
 import static org.ehcache.core.internal.service.ServiceLocator.dependencySet;
 import static org.ehcache.expiry.Expirations.noExpiration;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_DISK_SEGMENTS;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_WRITER_CONCURRENCY;
 import static org.ehcache.impl.internal.spi.TestServiceProvider.providerContaining;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -212,6 +215,32 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     }
   }
 
+  @Test
+  public void testProvidingOffHeapDiskStoreConfiguration() throws Exception {
+    OffHeapDiskStore.Provider provider = new OffHeapDiskStore.Provider();
+    ServiceLocator serviceLocator = dependencySet().with(diskResourceService).with(provider).build();
+    serviceLocator.startAllServices();
+
+    CacheConfiguration cacheConfiguration = mock(CacheConfiguration.class);
+    when(cacheConfiguration.getResourcePools()).thenReturn(newResourcePoolsBuilder().disk(1, MemoryUnit.MB, false).build());
+    PersistenceSpaceIdentifier space = diskResourceService.getPersistenceSpaceIdentifier("cache", cacheConfiguration);
+
+    @SuppressWarnings("unchecked")
+    Store.Configuration<Long, Object[]> storeConfig1 = mock(Store.Configuration.class);
+    when(storeConfig1.getKeyType()).thenReturn(Long.class);
+    when(storeConfig1.getValueType()).thenReturn(Object[].class);
+    when(storeConfig1.getResourcePools()).thenReturn(ResourcePoolsBuilder.newResourcePoolsBuilder()
+      .disk(10, MB)
+      .build());
+    when(storeConfig1.getDispatcherConcurrency()).thenReturn(1);
+
+    OffHeapDiskStore<Long, Object[]> offHeapDiskStore1 = provider.createStore(storeConfig1, space,
+      new OffHeapDiskStoreConfiguration("pool", 2, 4));
+    assertThat(offHeapDiskStore1.getThreadPoolAlias(), is("pool"));
+    assertThat(offHeapDiskStore1.getWriterConcurrency(), is(2));
+    assertThat(offHeapDiskStore1.getDiskSegments(), is(4));
+  }
+
   @Override
   protected OffHeapDiskStore<String, String> createAndInitStore(final TimeSource timeSource, final Expiry<? super String, ? super String> expiry) {
     try {
@@ -224,7 +253,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
           null, classLoader, expiry, null, 0, keySerializer, valueSerializer);
       OffHeapDiskStore<String, String> offHeapStore = new OffHeapDiskStore<String, String>(
               getPersistenceContext(),
-              new OnDemandExecutionService(), null, 1,
+              new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
               storeConfiguration, timeSource,
               new TestStoreEventDispatcher<String, String>(),
               MB.toBytes(1));
@@ -247,7 +276,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
           evictionAdvisor, getClass().getClassLoader(), expiry, null, 0, keySerializer, valueSerializer);
       OffHeapDiskStore<String, byte[]> offHeapStore = new OffHeapDiskStore<String, byte[]>(
               getPersistenceContext(),
-              new OnDemandExecutionService(), null, 1,
+              new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
               storeConfiguration, timeSource,
               new TestStoreEventDispatcher<String, byte[]>(),
               MB.toBytes(1));

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreSPITest.java
@@ -70,6 +70,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.ehcache.config.units.MemoryUnit.MB;
 import static org.ehcache.core.internal.service.ServiceLocator.dependencySet;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_DISK_SEGMENTS;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_WRITER_CONCURRENCY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -143,7 +145,7 @@ public class TieredStoreSPITest extends StoreSPITest<String, String> {
           long sizeInBytes = unit.toBytes(diskPool.getSize());
           OffHeapDiskStore<String, String> diskStore = new OffHeapDiskStore<String, String>(
                   persistenceContext,
-                  new OnDemandExecutionService(), null, 1,
+                  new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
                   config, timeSource,
                   new TestStoreEventDispatcher<String, String>(),
                   sizeInBytes);

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreWith3TiersSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreWith3TiersSPITest.java
@@ -72,6 +72,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.ehcache.core.internal.service.ServiceLocator.dependencySet;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_DISK_SEGMENTS;
+import static org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration.DEFAULT_WRITER_CONCURRENCY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -150,7 +152,7 @@ public class TieredStoreWith3TiersSPITest extends StoreSPITest<String, String> {
 
           OffHeapDiskStore<String, String> diskStore = new OffHeapDiskStore<String, String>(
                   persistenceContext,
-                  new OnDemandExecutionService(), null, 1,
+                  new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
                   config, timeSource,
                   new TestStoreEventDispatcher<String, String>(),
                   diskSize);

--- a/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
@@ -784,6 +784,8 @@ class ConfigurationParser {
     int writerConcurrency();
 
     String threadPool();
+
+    int diskSegments();
   }
 
 
@@ -1042,6 +1044,10 @@ class ConfigurationParser {
       return this.diskStoreSettings.getThreadPool();
     }
 
+    @Override
+    public int diskSegments() {
+      return this.diskStoreSettings.getDiskSegments().intValue();
+    }
   }
 
 }

--- a/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
@@ -293,7 +293,7 @@ public class XmlConfiguration implements Configuration {
       }
       final ConfigurationParser.DiskStoreSettings parsedDiskStoreSettings = cacheDefinition.diskStoreSettings();
       if (parsedDiskStoreSettings != null) {
-        builder = builder.add(new OffHeapDiskStoreConfiguration(parsedDiskStoreSettings.threadPool(), parsedDiskStoreSettings.writerConcurrency()));
+        builder = builder.add(new OffHeapDiskStoreConfiguration(parsedDiskStoreSettings.threadPool(), parsedDiskStoreSettings.writerConcurrency(), parsedDiskStoreSettings.diskSegments()));
       }
       for (ServiceConfiguration<?> serviceConfig : cacheDefinition.serviceConfigs()) {
         builder = builder.add(serviceConfig);

--- a/xml/src/main/resources/ehcache-core.xsd
+++ b/xml/src/main/resources/ehcache-core.xsd
@@ -34,8 +34,8 @@
         <xs:annotation>
           <xs:documentation xml:lang="en">
             This element represents Serializers.
-            It is a collection of serializer tags that require a type and fully qualified class names of serializers 
-            that are to be registered 
+            It is a collection of serializer tags that require a type and fully qualified class names of serializers
+            that are to be registered
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -43,7 +43,7 @@
         <xs:annotation>
           <xs:documentation xml:lang="en">
             This element represents Copiers.
-            It is a collection of copier tags that require a type and fully qualified class names of copiers 
+            It is a collection of copier tags that require a type and fully qualified class names of copiers
             that are to be registered
           </xs:documentation>
         </xs:annotation>
@@ -68,14 +68,14 @@
             The element configures the default thread pool used for cache event dispatch.
           </xs:documentation>
         </xs:annotation>
-      </xs:element> 
+      </xs:element>
       <xs:element name="write-behind" type="ehcache:thread-pool-reference-type" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation xml:lang="en">
             The element configures the default thread pool used for write behind caches.
           </xs:documentation>
         </xs:annotation>
-      </xs:element> 
+      </xs:element>
       <xs:element name="heap-store" type="ehcache:sizeof-type" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation xml:lang="en">
@@ -89,7 +89,7 @@
             The element configures the default thread pool used for writing to disk resources.
           </xs:documentation>
         </xs:annotation>
-      </xs:element> 
+      </xs:element>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="cache" type="ehcache:cache-type">
           <xs:annotation>
@@ -167,7 +167,7 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  
+
   <xs:complexType name="thread-pool-reference-type">
     <xs:attribute name="thread-pool" use="required" type="xs:string"/>
   </xs:complexType>
@@ -531,6 +531,7 @@
   <xs:complexType name="disk-store-settings-type">
     <xs:attribute name="thread-pool" type="xs:string" use="optional"/>
     <xs:attribute name="writer-concurrency" type="xs:positiveInteger" use="optional" default="1"/>
+    <xs:attribute name="disk-segments" type="xs:positiveInteger" use="optional" default="16"/>
   </xs:complexType>
 
   <xs:simpleType name="time-unit">

--- a/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
@@ -597,6 +597,7 @@ public class XmlConfigurationTest {
 
     assertThat(diskConfig.getThreadPoolAlias(), is("some-pool"));
     assertThat(diskConfig.getWriterConcurrency(), is(2));
+    assertThat(diskConfig.getDiskSegments(), is(4));
   }
 
   @Test

--- a/xml/src/test/resources/configs/ehcache-complete.xml
+++ b/xml/src/test/resources/configs/ehcache-complete.xml
@@ -72,7 +72,7 @@
       <ehcache:max-object-graph-size>10</ehcache:max-object-graph-size>
       <ehcache:max-object-size unit="MB">100</ehcache:max-object-size>
     </ehcache:heap-store-settings>
-    <ehcache:disk-store-settings thread-pool="pool-disk" writer-concurrency="10"/>
+    <ehcache:disk-store-settings thread-pool="pool-disk" writer-concurrency="10" disk-segments="2"/>
     <foo:foo/>
   </ehcache:cache>
 </ehcache:config>

--- a/xml/src/test/resources/configs/resources-caches.xml
+++ b/xml/src/test/resources/configs/resources-caches.xml
@@ -26,7 +26,7 @@
       <ehcache:heap unit="entries">10</ehcache:heap>
       <ehcache:disk unit="MB">100</ehcache:disk>
     </ehcache:resources>
-    <ehcache:disk-store-settings writer-concurrency="2" thread-pool="some-pool"/>
+    <ehcache:disk-store-settings writer-concurrency="2" thread-pool="some-pool" disk-segments="4"/>
   </ehcache:cache>
 
   <ehcache:cache alias="tieredPersistent">


### PR DESCRIPTION
Do no merge now. I will add a unit test and some documentation first.

However, to prevent loosing my time, I would like a global validation on the implementation. An attribute was added to `OffHeapDiskStoreConfiguration`. The other thing is that the XSD is modified to accept this new attribute. So we might have to wait for a 3.4 release.