### PR TITLE
It is the class, not the class name that is passed #1960

### DIFF
--- a/docs/src/docs/asciidoc/user/serializers-copiers.adoc
+++ b/docs/src/docs/asciidoc/user/serializers-copiers.adoc
@@ -38,7 +38,7 @@ There are two places where serializers can be configured:
 ** `CacheConfigurationBuilder.withValueSerializer(Class<? extends Serializer<V>> valueSerializerClass)`,
 ** and `CacheConfigurationBuilder.withValueSerializer(Serializer<V> valueSerializer)`
 +
-which allow by _instance_ or by _class name_ configuration.
+which allow by _instance_ or by _class_ configuration.
 * at the cache manager level where one can use
 ** `CacheManagerBuilder.withSerializer(Class<C> clazz, Class<? extends Serializer<C>> serializer)`
 


### PR DESCRIPTION
Changed _class name_ to _class_ on line 41 per #1960.