### PR TITLE
Including pom.xml and pom.properties in all published jars

### DIFF
--- a/buildSrc/src/main/groovy/EhDeploy.groovy
+++ b/buildSrc/src/main/groovy/EhDeploy.groovy
@@ -55,6 +55,8 @@ class EhDeploy implements Plugin<Project> {
     }
 
     def artifactFiltering = {
+      pom.scopeMappings.mappings.remove(project.configurations.testCompile)
+      pom.scopeMappings.mappings.remove(project.configurations.testRuntime)
       pom.scopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY, project.configurations.provided, Conf2ScopeMappingContainer.PROVIDED)
 
       utils.pomFiller(pom, project.subPomName, project.subPomDesc)

--- a/buildSrc/src/main/groovy/EhDeploy.groovy
+++ b/buildSrc/src/main/groovy/EhDeploy.groovy
@@ -33,6 +33,7 @@ class EhDeploy implements Plugin<Project> {
 
     project.plugins.apply 'signing'
     project.plugins.apply 'maven'
+    project.plugins.apply EhPomGenerate // for generating pom.*
 
     project.configurations {
         provided

--- a/buildSrc/src/main/groovy/EhDistribute.groovy
+++ b/buildSrc/src/main/groovy/EhDistribute.groovy
@@ -36,6 +36,7 @@ class EhDistribute implements Plugin<Project> {
     project.plugins.apply EhOsgi
     project.plugins.apply EhPomMangle
     project.plugins.apply EhDocs
+    project.plugins.apply EhPomGenerate
 
     def OSGI_OVERRIDE_KEYS = ['Import-Package', 'Export-Package', 'Private-Package', 'Tool', 'Bnd-LastModified', 'Created-By', 'Require-Capability']
 

--- a/buildSrc/src/main/groovy/EhPomGenerate.groovy
+++ b/buildSrc/src/main/groovy/EhPomGenerate.groovy
@@ -3,6 +3,7 @@
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
+import scripts.Utils
 
 /*
  * Copyright Terracotta, Inc.
@@ -30,6 +31,8 @@ class EhPomGenerate implements Plugin<Project> {
   @Override
   void apply(Project project) {
 
+    def utils = new Utils(project.baseVersion, project.logger)
+
     project.plugins.apply "maven-publish" // for generating pom.*
 
     def mavenTempResourcePath = "${project.buildDir}/mvn/META-INF/maven/${project.group}/${project.archivesBaseName}"
@@ -55,6 +58,7 @@ class EhPomGenerate implements Plugin<Project> {
         mavenJava(MavenPublication) {
           artifactId project.archivesBaseName
           from project.components.java
+          utils.pomFiller(pom, project.subPomName, project.subPomDesc)
         }
       }
     }

--- a/buildSrc/src/main/groovy/EhPomGenerate.groovy
+++ b/buildSrc/src/main/groovy/EhPomGenerate.groovy
@@ -1,0 +1,83 @@
+
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPublication
+
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * EhPomGenerate:
+ * Creates pom.xml and pom.properties to be included in produced jars
+ * Mimics standard maven jar layout.
+ */
+class EhPomGenerate implements Plugin<Project> {
+
+  @Override
+  void apply(Project project) {
+
+    project.plugins.apply "maven-publish" // for generating pom.*
+
+    def mavenTempResourcePath = "${project.buildDir}/mvn/META-INF/maven/${project.group}/${project.archivesBaseName}"
+
+    // Write pom to temp location to be picked up later,
+    // generatePomFileForMavenJavaPublication task comes from maven-publish.
+    project.model {
+      tasks.generatePomFileForMavenJavaPublication {
+        destination = project.file("$mavenTempResourcePath/pom.xml")
+      }
+    }
+    //ensure that we generate maven stuff
+    project.model {
+      tasks.processResources {
+        dependsOn project.tasks.generatePomFileForMavenJavaPublication
+        dependsOn project.tasks.writeMavenProperties
+      }
+    }
+
+    // Configure pom generation
+    project.publishing {
+      publications {
+        mavenJava(MavenPublication) {
+          artifactId project.archivesBaseName
+          from project.components.java
+        }
+      }
+    }
+
+    // Write pom.properties to temp location
+    project.task('writeMavenProperties') {
+      doLast {
+        def propertyFile = project.file "$mavenTempResourcePath/pom.properties"
+        def props = new Properties()
+        props.setProperty("version", project.version)
+        props.setProperty("groupId", project.group)
+        props.setProperty("artifactId", project.archivesBaseName)
+        props.store propertyFile.newWriter(), null
+      }
+    }
+
+    // Pick up pom.xml and pom.properties from temp location
+    project.sourceSets {
+      main {
+        resources {
+          srcDir "${project.buildDir}/mvn"
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/main/groovy/scripts/Utils.groovy
+++ b/buildSrc/src/main/groovy/scripts/Utils.groovy
@@ -51,36 +51,38 @@ class Utils {
   }
 
   def pomFiller(pom, nameVar, descriptionVar) {
-    pom.project {
-      name = nameVar
-      description = descriptionVar
-      url = 'http://ehcache.org'
-      organization {
-        name = 'Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.'
-        url = 'http://terracotta.org'
-      }
-      issueManagement {
-        system = 'Github'
-        url = 'https://github.com/ehcache/ehcache3/issues'
-      }
-      scm {
-        url = 'https://github.com/ehcache/ehcache3'
-        connection = 'scm:git:https://github.com/ehcache/ehcache3.git'
-        developerConnection = 'scm:git:git@github.com:ehcache/ehcache3.git'
-      }
-      licenses {
-        license {
-          name = 'The Apache Software License, Version 2.0'
-          url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-          distribution = 'repo'
+    pom.withXml {
+      asNode().version[0] + {
+        name nameVar
+        description descriptionVar
+        url 'http://ehcache.org'
+        organization {
+          name 'Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.'
+          url 'http://terracotta.org'
         }
-      }
-      developers {
-        developer {
-          name = 'Terracotta Engineers'
-          email = 'tc-oss@softwareag.com'
-          organization = 'Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.'
-          organizationUrl = 'http://ehcache.org'
+        issueManagement {
+          system 'Github'
+          url 'https://github.com/ehcache/ehcache3/issues'
+        }
+        scm {
+          url 'https://github.com/ehcache/ehcache3'
+          connection 'scm:git:https://github.com/ehcache/ehcache3.git'
+          developerConnection 'scm:git:git@github.com:ehcache/ehcache3.git'
+        }
+        licenses {
+          license {
+            name 'The Apache Software License, Version 2.0'
+            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            distribution 'repo'
+          }
+        }
+        developers {
+          developer {
+            name 'Terracotta Engineers'
+            email 'tc-oss@softwareag.com'
+            organization 'Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.'
+            organizationUrl 'http://ehcache.org'
+          }
         }
       }
     }


### PR DESCRIPTION
Including maven metadata (pom.xml/pom.properties) in ehcache-common.jar only.  (primarily for internal use).