### PR TITLE
Give different names to pools in PooledExecutionServiceTest and make the test reliable

### DIFF
--- a/impl/src/main/java/org/ehcache/impl/internal/executor/OutOfBandScheduledExecutor.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/executor/OutOfBandScheduledExecutor.java
@@ -88,6 +88,18 @@ class OutOfBandScheduledExecutor {
     return scheduler.awaitTermination(timeout, unit);
   }
 
+  public boolean isShutdown() {
+    return scheduler.isShutdown();
+  }
+
+  public boolean isTerminating() {
+    return scheduler.isTerminating();
+  }
+
+  public boolean isTerminated() {
+    return scheduler.isTerminated();
+  }
+
   interface ExecutorCarrier {
     ExecutorService executor();
   }

--- a/impl/src/main/java/org/ehcache/impl/internal/executor/PooledExecutionService.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/executor/PooledExecutionService.java
@@ -113,7 +113,9 @@ public class PooledExecutionService implements ExecutionService {
   }
 
   /**
-   * Stop the service. Underlying executors will be stopped calling {@code shutdownNow}. Pending tasks are discarded
+   * Stop the service. Underlying executors will be stopped calling {@code shutdownNow}. Pending tasks are discarded. Currently running tasks are
+   * awaited for termination for 30 seconds. So it is possible to get out of this method after 30 seconds having tasks that are still running. If it
+   * occurs, the event will be logged as a warning.
    */
   @Override
   public void stop() {

--- a/impl/src/test/java/org/ehcache/impl/internal/executor/PooledExecutionServiceTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/executor/PooledExecutionServiceTest.java
@@ -130,12 +130,15 @@ public class PooledExecutionServiceTest {
 
     assertThat(Thread.currentThread().isInterrupted()).isFalse();
 
-    // Note: This test also tends to fail when other tests are not closing stores or cache managers correctly. So it will
-    // also print these threads below and fail. To go look after them, turn ThreadFactoryUtil.DEBUG to true to get a full
-    // stacktrace to the creation point.
-    detectLeakingThreads();
+    assertThat(pooledExecutionService.isStopped()).isTrue();
   }
 
+  /**
+   * This method can be used to debug a failure in {@link #testAllThreadsAreStopped()} but also any other king of thread
+   * leaking. You can enable thread tracking in {@link ThreadFactoryUtil}. Note that on a slow machine, the detector might "lie". Because
+   * even if a thread pool is stopped, it doesn't mean all the underlying threads had the time to die. It only means that they are not
+   * processing any tasks anymore.
+   */
   public static void detectLeakingThreads() {
     Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
     Set<String> leakedThreads = new HashSet<String>();

--- a/impl/src/test/java/org/ehcache/impl/internal/executor/PooledExecutionServiceTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/executor/PooledExecutionServiceTest.java
@@ -63,19 +63,19 @@ public class PooledExecutionServiceTest {
   @Test
   public void testGetOrderedExecutorFailsOnNonExistentPool() throws Exception {
     PooledExecutionServiceConfiguration configuration = new PooledExecutionServiceConfiguration();
-    configuration.addPool("aaa", 0, 1);
+    configuration.addPool("getOrderedExecutorFailsOnNonExistentPool", 0, 1);
     pooledExecutionService = new PooledExecutionService(configuration);
 
     pooledExecutionService.start(null);
 
-    expectedException.expectMessage("Pool 'abc' is not in the set of available pools [aaa]");
+    expectedException.expectMessage("Pool 'abc' is not in the set of available pools [getOrderedExecutorFailsOnNonExistentPool]");
     pooledExecutionService.getOrderedExecutor("abc", new LinkedBlockingDeque<Runnable>());
   }
 
   @Test
   public void testGetOrderedExecutorFailsOnNonExistentDefaultPool() throws Exception {
     PooledExecutionServiceConfiguration configuration = new PooledExecutionServiceConfiguration();
-    configuration.addPool("aaa", 0, 1);
+    configuration.addPool("getOrderedExecutorFailsOnNonExistentDefaultPool", 0, 1);
     pooledExecutionService = new PooledExecutionService(configuration);
 
     pooledExecutionService.start(null);
@@ -87,19 +87,19 @@ public class PooledExecutionServiceTest {
   @Test
   public void testGetOrderedExecutorSucceedsOnExistingPool() throws Exception {
     PooledExecutionServiceConfiguration configuration = new PooledExecutionServiceConfiguration();
-    configuration.addPool("aaa", 0, 1);
+    configuration.addPool("getOrderedExecutorSucceedsOnExistingPool", 0, 1);
     pooledExecutionService = new PooledExecutionService(configuration);
 
     pooledExecutionService.start(null);
 
-    ExecutorService aaa = pooledExecutionService.getOrderedExecutor("aaa", new LinkedBlockingDeque<Runnable>());
+    ExecutorService aaa = pooledExecutionService.getOrderedExecutor("getOrderedExecutorSucceedsOnExistingPool", new LinkedBlockingDeque<Runnable>());
     aaa.shutdown();
   }
 
   @Test
   public void testGetOrderedExecutorSucceedsOnExistingDefaultPool() throws Exception {
     PooledExecutionServiceConfiguration configuration = new PooledExecutionServiceConfiguration();
-    configuration.addDefaultPool("dflt", 0, 1);
+    configuration.addDefaultPool("getOrderedExecutorSucceedsOnExistingDefaultPool", 0, 1);
     pooledExecutionService = new PooledExecutionService(configuration);
 
     pooledExecutionService.start(null);
@@ -111,22 +111,24 @@ public class PooledExecutionServiceTest {
   @Test
   public void testAllThreadsAreStopped() throws Exception {
     PooledExecutionServiceConfiguration configuration = new PooledExecutionServiceConfiguration();
-    configuration.addDefaultPool("dflt", 0, 1);
+    configuration.addDefaultPool("allThreadsAreStopped", 0, 1);
     pooledExecutionService = new PooledExecutionService(configuration);
     pooledExecutionService.start(null);
 
     final CountDownLatch latch = new CountDownLatch(1);
 
-    pooledExecutionService.getScheduledExecutor("dflt")
+    pooledExecutionService.getScheduledExecutor("allThreadsAreStopped")
       .execute(new Runnable() {
         @Override
         public void run() {
           latch.countDown();
         }});
 
-    latch.await(30, TimeUnit.SECONDS);
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 
     pooledExecutionService.stop();
+
+    assertThat(Thread.currentThread().isInterrupted()).isFalse();
 
     // Note: This test also tends to fail when other tests are not closing stores or cache managers correctly. So it will
     // also print these threads below and fail. To go look after them, turn ThreadFactoryUtil.DEBUG to true to get a full


### PR DESCRIPTION
It contains an improved javadoc and better test code that can be permanent but that will also be helpful to diagnose with the test is failing