### PR TITLE
Excluding duplicate pom files from shaded jar.

### DIFF
--- a/buildSrc/src/main/groovy/EhDistribute.groovy
+++ b/buildSrc/src/main/groovy/EhDistribute.groovy
@@ -62,6 +62,7 @@ class EhDistribute implements Plugin<Project> {
       }
       // LICENSE is included in root gradle build
       from "$project.rootDir/NOTICE"
+      duplicatesStrategy = 'exclude'
     }
 
 


### PR DESCRIPTION
This removes duplicate pom.properties and pom.xml for ehcache in the shaded jar:

$ unzip ../ehcache-xxx.jar 
 inflating: META-INF/maven/org.ehcache/ehcache/pom.properties 
 replace META-INF/maven/org.ehcache/ehcache/pom.properties? [y]es, [n]o, [A]ll, [N]one, [r]ename: 