### PR TITLE
Bump to latest Terracotta versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 
 *.iml
 .idea
+out/
 
 .nb-gradle
 .nb-gradle-properties

--- a/build.gradle
+++ b/build.gradle
@@ -51,13 +51,13 @@ ext {
   ehcache2Version = '2.10.3'
 
   // Clustered
-  terracottaPlatformVersion = '5.3.0-pre18'
+  terracottaPlatformVersion = '5.3.0-pre19'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.3.0-pre11'
-  terracottaCoreVersion = '5.3.0-pre13'
+  terracottaCoreVersion = '5.3.0-pre15'
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
-  terracottaPassthroughTestingVersion = '1.3.0-pre9'
+  terracottaPassthroughTestingVersion = '1.3.0-pre10'
   entityTestLibVersion = terracottaPassthroughTestingVersion
 
   // Tools

--- a/clustered/clustered-dist/build.gradle
+++ b/clustered/clustered-dist/build.gradle
@@ -45,7 +45,6 @@ configurations {
 
 dependencies {
   compileOnly "org.terracotta.internal:client-runtime:$terracottaCoreVersion"
-  compileOnly "org.terracotta.internal:client-logging:$terracottaCoreVersion"
 
   serverLibs(project(':clustered:server')) {
     exclude group: 'org.terracotta', module: 'entity-server-api'


### PR DESCRIPTION
Includes removing reference to `client-logging` which disappeared.