### PR TITLE
Bump to latest Terracotta version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,10 @@ ext {
   ehcache2Version = '2.10.3'
 
   // Clustered
-  terracottaPlatformVersion = '5.3.0-pre22'
+  terracottaPlatformVersion = '5.3.0-pre23'
   managementVersion = terracottaPlatformVersion
   terracottaApisVersion = '1.3.0-pre11'
-  terracottaCoreVersion = '5.3.0-pre17'
+  terracottaCoreVersion = '5.3.0-pre18'
   offheapResourceVersion = terracottaPlatformVersion
   entityApiVersion = terracottaApisVersion
   terracottaPassthroughTestingVersion = '1.3.0-pre10'


### PR DESCRIPTION
This will fix the invalid shading of slf4j-api in `ehcache-clustered`