### PR TITLE
:bug: Offheap as a middle tier does not seem to be used anymore.

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -202,7 +202,12 @@ public class ClusteredStore<K, V> implements AuthoritativeTier<K, V> {
         Result<V> resolvedResult = resolvedChain.getResolvedResult(key);
         if (resolvedResult != null) {
           V value = resolvedResult.getValue();
-          holder = new ClusteredValueHolder<V>(value, resolvedChain.getExpirationTime());
+          long expirationTime = resolvedChain.getExpirationTime();
+          if (expirationTime == Long.MAX_VALUE) {
+            holder = new ClusteredValueHolder<V>(value);
+          } else {
+            holder = new ClusteredValueHolder<V>(value, expirationTime);
+          }
         }
       }
     } catch (RuntimeException re) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/BaseKeyValueOperation.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/BaseKeyValueOperation.java
@@ -25,6 +25,9 @@ abstract class BaseKeyValueOperation<K, V> implements Operation<K, V> {
 
   private final K key;
   private final LazyValueHolder<V> valueHolder;
+
+  //-ve values are expiry times
+  //+ve values are operation timestamps
   private final long timeStamp;
 
   BaseKeyValueOperation(K key, V value, long timeStamp) {

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/ChainResolver.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/ChainResolver.java
@@ -63,7 +63,7 @@ public class ChainResolver<K, V> {
   public ResolvedChain<K, V> resolve(Chain chain, K key, long now) {
     Result<V> result = null;
     ChainBuilder chainBuilder = new ChainBuilder();
-    long expirationTime = Long.MIN_VALUE;
+    long expirationTime = Long.MAX_VALUE;
     int keyMatch = 0;
     boolean compacted = false;
     for (Element element : chain) {
@@ -79,9 +79,6 @@ public class ChainResolver<K, V> {
         if (expiry != Expirations.noExpiration()) {
           if(operation.isExpiryAvailable()) {
             expirationTime = operation.expirationTime();
-            if (expirationTime == Long.MIN_VALUE) {
-              continue;
-            }
             if (now >= expirationTime) {
               result = null;
             }
@@ -111,7 +108,7 @@ public class ChainResolver<K, V> {
             }
             compacted = true;
             if(duration.isInfinite()) {
-              expirationTime = Long.MIN_VALUE;
+              expirationTime = Long.MAX_VALUE;
               continue;
             }
             long time = TIME_UNIT.convert(duration.getLength(), duration.getTimeUnit());

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/Operation.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/operations/Operation.java
@@ -34,10 +34,19 @@ public interface Operation<K, V> {
 
   ByteBuffer encode(Serializer<K> keySerializer, Serializer<V> valueSerializer);
 
+  /**
+   * Time when the operation occurred
+   */
   long timeStamp();
 
+  /**
+   * Does the value installed by this operation have a specific expiry time
+   */
   boolean isExpiryAvailable();
 
+  /**
+   * Time when the operations installed value expires
+   */
   long expirationTime();
 
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
@@ -62,6 +62,7 @@ import static org.ehcache.clustered.client.internal.store.ClusteredStore.DEFAULT
 import static org.ehcache.clustered.client.internal.store.ClusteredStore.CHAIN_COMPACTION_THRESHOLD_PROP;
 import static org.ehcache.clustered.util.StatisticsTestUtils.validateStat;
 import static org.ehcache.clustered.util.StatisticsTestUtils.validateStats;
+import static org.ehcache.core.spi.store.Store.ValueHolder.NO_EXPIRE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.*;
@@ -836,5 +837,35 @@ public class ClusteredStoreTest {
 
     long expirationTime = vh.expirationTime(TimeUnit.MILLISECONDS);
     assertThat(expirationTime, is(1000L));
+  }
+
+  @Test
+  public void testNoExpireIsSentToHigherTiers() throws Exception {
+    @SuppressWarnings("unchecked")
+    Result<String> result = mock(Result.class);
+    when(result.getValue()).thenReturn("bar");
+
+    @SuppressWarnings("unchecked")
+    ResolvedChain<Long, String> resolvedChain = mock(ResolvedChain.class);
+    when(resolvedChain.getResolvedResult(anyLong())).thenReturn(result);
+    when(resolvedChain.getExpirationTime()).thenReturn(Long.MAX_VALUE); // no expire
+
+    @SuppressWarnings("unchecked")
+    ChainResolver<Long, String> resolver = mock(ChainResolver.class);
+    when(resolver.resolve(any(Chain.class), anyLong(), anyLong())).thenReturn(resolvedChain);
+
+    ServerStoreProxy proxy = mock(ServerStoreProxy.class);
+    when(proxy.get(anyLong())).thenReturn(mock(Chain.class));
+
+    @SuppressWarnings("unchecked")
+    OperationsCodec<Long, String> codec = mock(OperationsCodec.class);
+    TimeSource timeSource = mock(TimeSource.class);
+
+    ClusteredStore<Long, String> store = new ClusteredStore<Long, String>(codec, resolver, proxy, timeSource);
+
+    Store.ValueHolder<?> vh = store.get(1L);
+
+    long expirationTime = vh.expirationTime(TimeUnit.MILLISECONDS);
+    assertThat(expirationTime, is(NO_EXPIRE));
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/ChainResolverTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/ChainResolverTest.java
@@ -284,7 +284,7 @@ public class ChainResolverTest {
     Operation<Long, String> operation = getOperationsListFromChain(resolvedChain.getCompactedChain()).get(0);
 
     assertThat(operation.isExpiryAvailable(), is(true));
-    assertThat(operation.expirationTime(), is(Long.MIN_VALUE));
+    assertThat(operation.expirationTime(), is(Long.MAX_VALUE));
     try {
       operation.timeStamp();
       fail();


### PR DESCRIPTION
This is a report about some behavior that has changed in ehcache3 very recently.

### Setup : 
* one cache, with 3 tiers : onheap(10 elements max) , offheap (10 MB max), cluster dedicated (50 MB max)
* do 100 puts , each followed by a get on the same key

### What Used to happen : 
* onHeap mapping count : 10, offheap mapping count : 90

### What is happening now : 
* onHeap mapping count : 10, offheap mapping count : **0**
