### PR TITLE
Issue #2078 adds missing properties to ehcache configuration

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteringServiceConfiguration.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/config/ClusteringServiceConfiguration.java
@@ -25,6 +25,7 @@ import org.ehcache.core.HumanReadable;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.ehcache.clustered.common.ServerSideConfiguration;
 
@@ -243,6 +244,17 @@ public class ClusteringServiceConfiguration
     return this.getClass().getName() + ":\n    " +
         "clusterUri: " + getClusterUri()+ "\n    " +
         "readOperationTimeout: " + getReadOperationTimeout()+ "\n    " +
-        "autoCreate: " + isAutoCreate();
+        "autoCreate: " + isAutoCreate() + "\n    " +
+        "defaultServerResource: " + serverConfiguration.getDefaultServerResource() + "\n    " +
+        readablePoolsString();
+  }
+
+  private String readablePoolsString() {
+    String pools = "resourcePools:\n";
+    for(Map.Entry entry : serverConfiguration.getResourcePools().entrySet()) {
+      pools += "        " + entry.getKey() + ": " + entry.getValue() + "\n";
+    }
+
+    return pools;
   }
 }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheManagerToStringTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/EhcacheManagerToStringTest.java
@@ -94,7 +94,8 @@ public class EhcacheManagerToStringTest extends AbstractClusteringManagementTest
         // cluster config
         .with(ClusteringServiceConfigurationBuilder.cluster(uri)
             .autoCreate()
-            .defaultServerResource("primary-server-resource"))
+            .defaultServerResource("primary-server-resource")
+            .resourcePool("resource-pool-a", 32, MemoryUnit.MB))
         // management config
         .using(new DefaultManagementRegistryConfiguration()
             .addTags("webapp-1", "server-node-1")

--- a/clustered/integration-test/src/test/resources/clusteredConfiguration.txt
+++ b/clustered/integration-test/src/test/resources/clusteredConfiguration.txt
@@ -21,4 +21,7 @@ services:
         clusterUri: terracotta://server-1/my-server-entity-2
         readOperationTimeout: TimeoutDuration{20 SECONDS}
         autoCreate: true
+        defaultServerResource: primary-server-resource
+            resourcePools:
+                resource-pool-a: [33554432 bytes from '<default>']
     - org.ehcache.management.registry.DefaultManagementRegistryConfiguration


### PR DESCRIPTION
In the clustered/common/build.gradle file I added a dependency on core.  However there is probably a better solution to get access to org.ehcache.core.HumanReadable from the clustererd:common module.  Any suggestions?  Perhaps another location for org.ehcache.core.HumanReadable?