### PR TITLE
Fix #2114 Resolve task dependency declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,13 @@
 import scripts.*
 import org.gradle.internal.jvm.Jvm
 
-// This adds tasks to auto close or release nexus staging repos
-// see https://github.com/Codearte/gradle-nexus-staging-plugin/
 plugins {
+  // This adds tasks to auto close or release nexus staging repos
+  // see https://github.com/Codearte/gradle-nexus-staging-plugin/
   id 'io.codearte.nexus-staging' version '0.9.0'
+  // This adds the ability to print a taskTree
+  // ./gradlew <task1> ... <taskN> taskTree
+  id "com.dorongold.task-tree" version "1.3"
 }
 
 if (deployUrl.contains('nexus')) {

--- a/buildSrc/src/main/groovy/EhPomGenerate.groovy
+++ b/buildSrc/src/main/groovy/EhPomGenerate.groovy
@@ -43,10 +43,12 @@ class EhPomGenerate implements Plugin<Project> {
       tasks.generatePomFileForMavenJavaPublication {
         destination = project.file("$mavenTempResourcePath/pom.xml")
       }
-      //ensure that we generate maven stuff
-      tasks.processResources {
-        dependsOn project.tasks.generatePomFileForMavenJavaPublication
-        dependsOn project.tasks.writeMavenProperties
+    }
+
+    //ensure that we generate maven stuff and delay resolution as the first task is created dynamically
+    project.processResources.dependsOn {
+      project.tasks.findAll { task ->
+        task.name == 'generatePomFileForMavenJavaPublication' || task.name == 'writeMavenProperties'
       }
     }
 
@@ -99,6 +101,7 @@ class EhPomGenerate implements Plugin<Project> {
     // Write pom.properties to temp location
     project.task('writeMavenProperties') {
       doLast {
+        project.file(mavenTempResourcePath).mkdirs()
         def propertyFile = project.file "$mavenTempResourcePath/pom.properties"
         def props = new Properties()
         props.setProperty('version', project.version)


### PR DESCRIPTION
The `generatePomFileForMavenJavaPublication` task is dynamic and added
late, so anything that wants to depend on it must do so at the last
moment.
Also added a task graph visualisation plugin