### PR TITLE
Return the real response from StateRepositoryMessages (close #2120)

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicClusteredCacheOpsReplicationMultiThreadedTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicClusteredCacheOpsReplicationMultiThreadedTest.java
@@ -36,27 +36,32 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.testing.rules.Cluster;
 
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
 
 /**
@@ -94,6 +99,14 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
   public static Cluster CLUSTER =
       newCluster(2).in(new File("build/cluster")).withServiceFragment(RESOURCE_CONFIG).build();
 
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private List<Cache<Long, BlobValue>> caches;
+
+  private final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+  private final ExecutorService executorService = Executors.newWorkStealingPool(NUM_OF_THREADS);
+
   @Before
   public void startServers() throws Exception {
     CLUSTER.getClusterControl().startAllServers();
@@ -115,25 +128,28 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
     CACHE1 = CACHE_MANAGER1.createCache("clustered-cache", config);
     CACHE2 = CACHE_MANAGER2.createCache("clustered-cache", config);
+
+    caches = Arrays.asList(CACHE1, CACHE2);
   }
 
   @After
   public void tearDown() throws Exception {
-    CACHE_MANAGER1.close();
-    CACHE_MANAGER2.close();
-    CACHE_MANAGER2.destroy();
+    List<Runnable> unprocessed = executorService.shutdownNow();
+    if(!unprocessed.isEmpty()) {
+      log.warn("Tearing down with {} unprocess task", unprocessed);
+    }
+    if(CACHE_MANAGER1 != null) {
+      CACHE_MANAGER1.close();
+    }
+    if(CACHE_MANAGER2 != null) {
+      CACHE_MANAGER2.close();
+      CACHE_MANAGER2.destroy();
+    }
   }
 
   @Test(timeout=180000)
   public void testCRUD() throws Exception {
-    List<Cache<Long, BlobValue>> caches = new ArrayList<>();
-    caches.add(CACHE1);
-    caches.add(CACHE2);
-    Random random = new Random();
-    Set<Long> universalSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    ExecutorService executorService = Executors.newWorkStealingPool(NUM_OF_THREADS);
-
+    Set<Long> universalSet = ConcurrentHashMap.newKeySet();
     List<Future> futures = new ArrayList<>();
 
     caches.forEach(cache -> {
@@ -153,9 +169,7 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
     CLUSTER.getClusterControl().terminateActive();
 
-    for (Future f : futures ) {
-      f.get();
-    }
+    drainTasks(futures);
 
     Set<Long> readKeysByCache1AfterFailOver = new HashSet<>();
     Set<Long> readKeysByCache2AfterFailOver = new HashSet<>();
@@ -176,14 +190,7 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
   @Test(timeout=180000)
   public void testBulkOps() throws Exception {
-    List<Cache<Long, BlobValue>> caches = new ArrayList<>();
-    caches.add(CACHE1);
-    caches.add(CACHE2);
-    Random random = new Random();
-    Set<Long> universalSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    ExecutorService executorService = Executors.newWorkStealingPool(NUM_OF_THREADS);
-
+    Set<Long> universalSet = ConcurrentHashMap.newKeySet();
     List<Future> futures = new ArrayList<>();
 
     caches.forEach(cache -> {
@@ -206,9 +213,7 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
     CLUSTER.getClusterControl().terminateActive();
 
-    for (Future f : futures ) {
-      f.get();
-    }
+    drainTasks(futures);
 
     Set<Long> readKeysByCache1AfterFailOver = new HashSet<>();
     Set<Long> readKeysByCache2AfterFailOver = new HashSet<>();
@@ -229,15 +234,8 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
   @Test(timeout=180000)
   public void testClear() throws Exception {
-    List<Cache<Long, BlobValue>> caches = new ArrayList<>();
-    caches.add(CACHE1);
-    caches.add(CACHE2);
-    Random random = new Random();
-    Set<Long> universalSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    ExecutorService executorService = Executors.newWorkStealingPool(NUM_OF_THREADS);
-
     List<Future> futures = new ArrayList<>();
+    Set<Long> universalSet = ConcurrentHashMap.newKeySet();
 
     caches.forEach(cache -> {
       for (int i = 0; i < NUM_OF_THREADS; i++) {
@@ -249,9 +247,7 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
       }
     });
 
-    for (Future f : futures ) {
-      f.get();
-    }
+    drainTasks(futures);
 
     universalSet.forEach(x -> {
       CACHE1.get(x);
@@ -266,6 +262,16 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
     universalSet.forEach(x -> assertThat(CACHE2.get(x), nullValue()));
 
+  }
+
+  private void drainTasks(List<Future> futures) throws InterruptedException, java.util.concurrent.ExecutionException {
+    for (int i = 0; i < futures.size(); i++) {
+      try {
+        futures.get(i).get(10, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+        fail("Stuck on number " + i);
+      }
+    }
   }
 
   private static class BlobValue implements Serializable {

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/DuplicateTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/DuplicateTest.java
@@ -115,7 +115,7 @@ public class DuplicateTest {
       // Failover to mirror when put & replication are in progress
       CLUSTER.getClusterControl().terminateActive();
 
-      puts.get(10, TimeUnit.SECONDS);
+      puts.get(30, TimeUnit.SECONDS);
 
       //Verify cache entries on mirror
       for (int i = 0; i < numEntries; i++) {


### PR DESCRIPTION
The PR should be 3.4 compatible.

Two things I noticed that I would like advice on:
* Comment "Reaching here means a lifecycle or sync operation failed" is talking about lifecycle. But no lifecycle message is handled. Only sync messages
* PassiveReplication messages are logging errors and sync messages are throwing an exception. It feels odd. Is that normal?
