### PR TITLE
Revert "Issue #2122 Backward compatibility with 3.4.0"

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheMessageTrackerMessage.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheMessageTrackerMessage.java
@@ -31,8 +31,6 @@ import static java.util.stream.Collectors.toMap;
  */
 public class EhcacheMessageTrackerMessage extends EhcacheSyncMessage {
 
-  public static final int UNKNOWN_SEGMENT = -1;
-
   private final int segmentId;
   private final Map<Long, Map<Long, EhcacheEntityResponse>> trackedMessages;
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessageCodec.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/EhcacheSyncMessageCodec.java
@@ -229,10 +229,6 @@ public class EhcacheSyncMessageCodec implements SyncMessageCodec<EhcacheEntityMe
       }
     }
     Integer segmentId = decoder.int32(MESSAGE_TRACKER_SEGMENT_FIELD);
-    if (segmentId == null) {
-      // Support messages coming from 3.4.0 server
-      segmentId = EhcacheMessageTrackerMessage.UNKNOWN_SEGMENT;
-    }
     return new EhcacheMessageTrackerMessage(segmentId, trackedMessages);
   }
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierPassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierPassiveEntity.java
@@ -205,14 +205,8 @@ public class ClusterTierPassiveEntity implements PassiveServerEntity<EhcacheEnti
         break;
       case MESSAGE_TRACKER:
         EhcacheMessageTrackerMessage messageTrackerMessage = (EhcacheMessageTrackerMessage) message;
-        if (messageTrackerMessage.getSegmentId() != EhcacheMessageTrackerMessage.UNKNOWN_SEGMENT) {
-          messageTrackerMessage.getTrackedMessages().forEach((key, value) ->
-            messageHandler.loadTrackedResponsesForSegment(messageTrackerMessage.getSegmentId(), context.makeClientSourceId(key), value));
-        } else {
-          // This happens when a 3.4.0 server is the one sending the message
-          messageTrackerMessage.getTrackedMessages().forEach((key, value) ->
-            messageHandler.loadOnSync(context.makeClientSourceId(key), value));
-        }
+        messageTrackerMessage.getTrackedMessages().forEach((key, value) ->
+          messageHandler.loadTrackedResponsesForSegment(messageTrackerMessage.getSegmentId(), context.makeClientSourceId(key), value));
         break;
       default:
         throw new AssertionError("Unsupported Sync operation " + message.getMessageType());


### PR DESCRIPTION
This reverts commit 89995d8ae27681fd021214869b23d110d7066702.
On the 3.5 line, the backward compatible handling is no longer needed.