### PR TITLE
Fix #2068 Add support for java.time.Duration

### DIFF
--- a/api/src/main/java/org/ehcache/expiry/Duration.java
+++ b/api/src/main/java/org/ehcache/expiry/Duration.java
@@ -48,6 +48,40 @@ public final class Duration {
     return new Duration(length, timeUnit);
   }
 
+  public static Duration of(java.time.Duration duration) {
+    if (duration == null) {
+      return null;
+    }
+    if (duration.isNegative()) {
+      throw new IllegalArgumentException("Ehcache duration cannot be negative and so does not accept negative java.time.Duration: " + duration);
+    }
+    if (duration.isZero()) {
+      return Duration.ZERO;
+    } else {
+      long nanos = duration.getNano();
+      if (nanos == 0) {
+        return of(duration.getSeconds(), TimeUnit.SECONDS);
+      }
+      long seconds = duration.getSeconds();
+      long secondsInNanos = TimeUnit.SECONDS.toNanos(seconds);
+      if (secondsInNanos != Long.MAX_VALUE && Long.MAX_VALUE - secondsInNanos > nanos) {
+        return of(duration.toNanos(), TimeUnit.NANOSECONDS);
+      } else {
+        long secondsInMicros = TimeUnit.SECONDS.toMicros(seconds);
+        if (secondsInMicros != Long.MAX_VALUE && Long.MAX_VALUE - secondsInMicros > nanos / 1_000) {
+          return of(secondsInMicros + nanos / 1_000, TimeUnit.MICROSECONDS);
+        } else {
+          long secondsInMillis = TimeUnit.SECONDS.toMillis(seconds);
+          if (secondsInMillis != Long.MAX_VALUE && Long.MAX_VALUE - secondsInMillis > nanos / 1_000_000) {
+            return of(duration.toMillis(), TimeUnit.MILLISECONDS);
+          }
+        }
+      }
+      return of(seconds, TimeUnit.SECONDS);
+    }
+  }
+
+
   private final TimeUnit timeUnit;
   private final long length;
 

--- a/api/src/main/java/org/ehcache/expiry/Expirations.java
+++ b/api/src/main/java/org/ehcache/expiry/Expirations.java
@@ -45,6 +45,19 @@ public final class Expirations {
   }
 
   /**
+   * Get a time-to-live (TTL) {@link Expiry} instance for the given {@link java.time.Duration}.
+   *
+   * @param timeToLive the TTL duration
+   * @return a TTL expiry
+   */
+  public static Expiry<Object, Object> timeToLiveExpiration(java.time.Duration timeToLive) {
+    if (timeToLive == null) {
+      throw new NullPointerException("Duration cannot be null");
+    }
+    return new TimeToLiveExpiry(Duration.of(timeToLive));
+  }
+
+  /**
    * Get a time-to-idle (TTI) {@link Expiry} instance for the given {@link Duration}.
    *
    * @param timeToIdle the TTI duration
@@ -55,6 +68,19 @@ public final class Expirations {
       throw new NullPointerException("Duration cannot be null");
     }
     return new TimeToIdleExpiry(timeToIdle);
+  }
+
+  /**
+   * Get a time-to-idle (TTI) {@link Expiry} instance for the given {@link java.time.Duration}.
+   *
+   * @param timeToIdle the TTI duration
+   * @return a TTI expiry
+   */
+  public static Expiry<Object, Object> timeToIdleExpiration(java.time.Duration timeToIdle) {
+    if (timeToIdle == null) {
+      throw new NullPointerException("Duration cannot be null");
+    }
+    return new TimeToIdleExpiry(Duration.of(timeToIdle));
   }
 
   /**
@@ -183,6 +209,17 @@ public final class Expirations {
     }
 
     /**
+     * Set TTL since creation
+     *
+     * @param create TTL since creation
+     * @return this builder
+     */
+    public ExpiryBuilder<K, V> setCreate(java.time.Duration create) {
+      this.create = Duration.of(create);
+      return this;
+    }
+
+    /**
      * Set TTL since last access
      *
      * @param access TTL since last access
@@ -194,6 +231,17 @@ public final class Expirations {
     }
 
     /**
+     * Set TTL since last access
+     *
+     * @param access TTL since last access
+     * @return this builder
+     */
+    public ExpiryBuilder<K, V> setAccess(java.time.Duration access) {
+      this.access = Duration.of(access);
+      return this;
+    }
+
+    /**
      * Set TTL since last update
      *
      * @param update TTL since last update
@@ -201,6 +249,17 @@ public final class Expirations {
      */
     public ExpiryBuilder<K, V> setUpdate(Duration update) {
       this.update = update;
+      return this;
+    }
+
+    /**
+     * Set TTL since last update
+     *
+     * @param update TTL since last update
+     * @return this builder
+     */
+    public ExpiryBuilder<K, V> setUpdate(java.time.Duration update) {
+      this.update = Duration.of(update);
       return this;
     }
 

--- a/api/src/test/java/org/ehcache/expiry/DurationTest.java
+++ b/api/src/test/java/org/ehcache/expiry/DurationTest.java
@@ -28,6 +28,10 @@ import org.junit.Test;
 
 public class DurationTest {
 
+  public static final long NANOS_IN_SECOND = 1_000_000_000L;
+  public static final long MICROS_IN_SECOND = 1_000_000L;
+  public static final long MILLIS_IN_SECOND = 1_000L;
+
   @Test
   public void testBasic() {
     Duration duration = new Duration(1, TimeUnit.SECONDS);
@@ -88,6 +92,38 @@ public class DurationTest {
     assertThat(Duration.ZERO.getLength(), equalTo(0L));
     assertThat(Duration.ZERO.getTimeUnit(), any(TimeUnit.class));
     assertThat(Duration.ZERO.equals(Duration.INFINITE), is(false));
+  }
+
+  @Test
+  public void testJavaDurationConversionNoNanos() {
+    assertThat(Duration.of(java.time.Duration.ofSeconds(100)), is(Duration.of(100, TimeUnit.SECONDS)));
+  }
+
+  @Test
+  public void testJavaDurationConversionWithNanos() {
+    assertThat(Duration.of(java.time.Duration.ofSeconds(100, 50)),
+      is(Duration.of(100L * NANOS_IN_SECOND + 50L, TimeUnit.NANOSECONDS)));
+  }
+
+  @Test
+  public void testJavaDurationTooMuchNanos() {
+    long seconds = Long.MAX_VALUE / NANOS_IN_SECOND * 10;
+    assertThat(Duration.of(java.time.Duration.ofSeconds(seconds, 10_000)),
+      is(Duration.of(TimeUnit.SECONDS.toMicros(seconds) + 10, TimeUnit.MICROSECONDS)));
+  }
+
+  @Test
+  public void testJavaDurationTooMuchMicros() {
+    long seconds = Long.MAX_VALUE / MICROS_IN_SECOND * 10;
+    assertThat(Duration.of(java.time.Duration.ofSeconds(seconds, 10_000_000)),
+      is(Duration.of(TimeUnit.SECONDS.toMillis(seconds) + 10, TimeUnit.MILLISECONDS)));
+  }
+
+  @Test
+  public void testJavaDurationTooMuchMillis() {
+    long seconds = Long.MAX_VALUE / MILLIS_IN_SECOND * 10;
+    assertThat(Duration.of(java.time.Duration.ofSeconds(seconds, 100_000_000)),
+      is(Duration.of(seconds, TimeUnit.SECONDS)));
   }
 
 }


### PR DESCRIPTION
* Add static method for converting a java.time.Duration into an Ehcache
Duration
* Add methods on the Expirations utility taking java.time.Duration
parameters