### PR TITLE
[release/3.3] Fix #2159 Proper support of StatefulSerializer in XAStore

### DIFF
--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/SoftLockValueCombinedSerializer.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/SoftLockValueCombinedSerializer.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 class SoftLockValueCombinedSerializer<T> implements Serializer<SoftLock<T>> {
 
   private final AtomicReference<? extends Serializer<SoftLock<T>>> softLockSerializerRef;
-  private final Serializer<T> valueSerializer;
+  final Serializer<T> valueSerializer;
 
   SoftLockValueCombinedSerializer(AtomicReference<? extends Serializer<SoftLock<T>>> softLockSerializerRef, Serializer<T> valueSerializer) {
     this.softLockSerializerRef = softLockSerializerRef;

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/StatefulSoftLockValueCombinedSerializer.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/StatefulSoftLockValueCombinedSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.transactions.xa.internal;
+
+import org.ehcache.spi.persistence.StateRepository;
+import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.serialization.StatefulSerializer;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * StatefulSoftLockValueCombinedSerializer
+ */
+class StatefulSoftLockValueCombinedSerializer<T> extends SoftLockValueCombinedSerializer<T> implements StatefulSerializer<SoftLock<T>> {
+
+  StatefulSoftLockValueCombinedSerializer(AtomicReference<? extends Serializer<SoftLock<T>>> softLockSerializerRef, Serializer<T> valueSerializer) {
+    super(softLockSerializerRef, valueSerializer);
+  }
+
+  @Override
+  public void init(StateRepository stateRepository) {
+    ((StatefulSerializer<T>) valueSerializer).init(stateRepository);
+  }
+}

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
@@ -34,6 +34,7 @@ import org.ehcache.core.spi.function.NullaryFunction;
 import org.ehcache.impl.copy.SerializingCopier;
 import org.ehcache.core.spi.time.TimeSource;
 import org.ehcache.core.spi.time.TimeSourceService;
+import org.ehcache.spi.serialization.StatefulSerializer;
 import org.ehcache.spi.service.ServiceProvider;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.events.StoreEventSource;
@@ -901,7 +902,12 @@ public class XAStore<K, V> implements Store<K, V> {
 
       // create the soft lock serializer
       AtomicReference<SoftLockSerializer<V>> softLockSerializerRef = new AtomicReference<SoftLockSerializer<V>>();
-      SoftLockValueCombinedSerializer<V> softLockValueCombinedSerializer = new SoftLockValueCombinedSerializer<V>(softLockSerializerRef, storeConfig.getValueSerializer());
+      SoftLockValueCombinedSerializer<V> softLockValueCombinedSerializer;
+      if (storeConfig.getValueSerializer() instanceof StatefulSerializer) {
+        softLockValueCombinedSerializer = new StatefulSoftLockValueCombinedSerializer<V>(softLockSerializerRef, storeConfig.getValueSerializer());
+      } else {
+        softLockValueCombinedSerializer = new SoftLockValueCombinedSerializer<V>(softLockSerializerRef, storeConfig.getValueSerializer());
+      }
 
       // create the underlying store
       @SuppressWarnings("unchecked")

--- a/transactions/src/test/java/org/ehcache/transactions/xa/integration/StatefulSerializerTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/integration/StatefulSerializerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.transactions.xa.integration;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.TransactionManagerServices;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.expiry.Expirations;
+import org.ehcache.transactions.xa.configuration.XAStoreConfiguration;
+import org.ehcache.transactions.xa.txmgr.btm.BitronixTransactionManagerLookup;
+import org.ehcache.transactions.xa.txmgr.provider.LookupTransactionManagerProviderConfiguration;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * StatefulSerializerTest
+ */
+public class StatefulSerializerTest {
+
+  @Test
+  public void testXAWithStatefulSerializer() throws Exception {
+    BitronixTransactionManager manager = TransactionManagerServices.getTransactionManager();
+    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+          .using(new LookupTransactionManagerProviderConfiguration(
+            BitronixTransactionManagerLookup.class))
+          .withCache("xaCache",
+            CacheConfigurationBuilder
+              .newCacheConfigurationBuilder(Long.class, Person.class,
+                ResourcePoolsBuilder.heap(5))
+              .withExpiry(Expirations.noExpiration()).add(new XAStoreConfiguration("xaCache"))
+              .build())
+          .build(true);
+
+    Cache<Long, Person> cache = cacheManager.getCache("xaCache", Long.class, Person.class);
+    manager.begin();
+    cache.put(1L, new Person("James", 42));
+    manager.commit();
+
+    manager.begin();
+    assertNotNull(cache.get(1L));
+    manager.commit();
+
+    cacheManager.close();
+    manager.shutdown();
+  }
+
+  public static class Person implements Serializable {
+    public final String name;
+    public final int age;
+
+    public Person(String name, int age) {
+      if (name == null) {
+        throw new NullPointerException("Name cannot be null");
+      }
+      this.name = name;
+      this.age = age;
+    }
+
+    @Override
+    public int hashCode() {
+      return name.hashCode() + 31 * age;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (! (obj instanceof Person)) {
+        return false;
+      }
+      Person other = (Person) obj;
+      return other.name.equals(name) && other.age == age;
+    }
+  }
+}

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreProviderTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreProviderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.transactions.xa.internal;
+
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.core.spi.time.TimeSourceService;
+import org.ehcache.impl.internal.DefaultTimeSourceService;
+import org.ehcache.impl.internal.store.offheap.OffHeapStore;
+import org.ehcache.spi.persistence.PersistableResourceService;
+import org.ehcache.spi.persistence.StateRepository;
+import org.ehcache.spi.serialization.Serializer;
+import org.ehcache.spi.serialization.StatefulSerializer;
+import org.ehcache.spi.service.ServiceProvider;
+import org.ehcache.transactions.xa.configuration.XAStoreConfiguration;
+import org.ehcache.transactions.xa.internal.journal.Journal;
+import org.ehcache.transactions.xa.internal.journal.JournalProvider;
+import org.ehcache.transactions.xa.txmgr.TransactionManagerWrapper;
+import org.ehcache.transactions.xa.txmgr.provider.TransactionManagerProvider;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * XAStoreProviderTest
+ */
+public class XAStoreProviderTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testXAStoreProviderStatefulSerializer() {
+    OffHeapStore.Provider underlyingStoreProvider = new OffHeapStore.Provider();
+
+    JournalProvider journalProvider = mock(JournalProvider.class);
+    when(journalProvider.getJournal(null, null)).thenReturn(mock(Journal.class));
+
+    TransactionManagerProvider transactionManagerProvider = mock(TransactionManagerProvider.class);
+    when(transactionManagerProvider.getTransactionManagerWrapper()).thenReturn(mock(TransactionManagerWrapper.class));
+
+    ServiceProvider serviceProvider = mock(ServiceProvider.class);
+    when(serviceProvider.getService(JournalProvider.class)).thenReturn(journalProvider);
+    when(serviceProvider.getService(TimeSourceService.class)).thenReturn(new DefaultTimeSourceService(null));
+    when(serviceProvider.getService(TransactionManagerProvider.class)).thenReturn(transactionManagerProvider);
+    when(serviceProvider.getServicesOfType(Store.Provider.class)).thenReturn(Collections.singleton(underlyingStoreProvider));
+
+    Store.Configuration configuration = mock(Store.Configuration.class);
+    when(configuration.getResourcePools()).thenReturn(ResourcePoolsBuilder.newResourcePoolsBuilder().offheap(1, MemoryUnit.MB).build());
+    when(configuration.getDispatcherConcurrency()).thenReturn(1);
+    StatefulSerializer valueSerializer = mock(StatefulSerializer.class);
+    when(configuration.getValueSerializer()).thenReturn(valueSerializer);
+
+    underlyingStoreProvider.start(serviceProvider);
+
+    XAStore.Provider provider = new XAStore.Provider();
+    provider.start(serviceProvider);
+
+    Store store = provider.createStore(configuration, mock(XAStoreConfiguration.class));
+    provider.initStore(store);
+
+    verify(valueSerializer).init(any(StateRepository.class));
+  }
+}


### PR DESCRIPTION
The way the serializers were wired hid the fact that the underlying
Store may have to initialize a stateful one.