### PR TITLE
Using a HashMap to return the invalidated values is a bit heavyweight since we never use the map capabilities

### DIFF
--- a/impl/src/main/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
@@ -29,6 +29,7 @@ import static java.lang.Integer.rotateLeft;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -36,6 +37,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
@@ -62,6 +64,7 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 
 import org.ehcache.config.EvictionAdvisor;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
 
 import sun.misc.Unsafe;
 
@@ -1184,8 +1187,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
    * @param keyHash the keys' hashcode.
    * @return the removed mappings.
    */
-  public final Map<K, V> removeAllWithHash(int keyHash) {
-      Map<K, V> invalidated = new HashMap<>();
+  public final Collection<Map.Entry<K, V>> removeAllWithHash(int keyHash) {
+      List<Map.Entry<K, V>> invalidated = new ArrayList<>();
 
       int hash = spread(keyHash);
       for (Node<K, V>[] tab = table; ; ) {
@@ -2692,26 +2695,26 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
         return hd;
     }
 
-    private static <K,V> int nodesAt(Node<K,V> b, Map<K, V> nodes) {
+    private static <K,V> int nodesAt(Node<K,V> b, Collection<Map.Entry<K, V>> nodes) {
         if (b instanceof TreeBin) {
             return treeNodesAt(((TreeBin<K,V>)b).root, nodes);
         } else {
             int count = 0;
             for (Node<K,V> q = b; q != null; q = q.next) {
-                nodes.put(q.key, q.val);
+                nodes.add(new AbstractMap.SimpleImmutableEntry<>(q.key, q.val));
                 count++;
             }
             return count;
         }
     }
 
-    private static <K,V> int treeNodesAt(TreeNode<K, V> root, Map<K, V> nodes) {
+    private static <K,V> int treeNodesAt(TreeNode<K, V> root, Collection<Map.Entry<K, V>> nodes) {
         if (root == null) {
             return 0;
         }
 
         int count = 1;
-        nodes.put(root.key, root.val);
+        nodes.add(new AbstractMap.SimpleImmutableEntry(root.key, root.val));
         count += treeNodesAt(root.left, nodes);
         count += treeNodesAt(root.right, nodes);
         return count;

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/Backend.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/Backend.java
@@ -20,6 +20,7 @@ import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
@@ -39,7 +40,7 @@ interface Backend<K, V> {
 
   Backend<K, V> clear();
 
-  Map<K, OnHeapValueHolder<V>> removeAllWithHash(int hash);
+  Collection<Map.Entry<K, OnHeapValueHolder<V>>> removeAllWithHash(int hash);
 
   Iterable<K> keySet();
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/KeyCopyBackend.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/KeyCopyBackend.java
@@ -26,6 +26,8 @@ import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
 import org.ehcache.spi.copy.Copier;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -157,13 +159,13 @@ class KeyCopyBackend<K, V> implements Backend<K, V> {
   }
 
   @Override
-  public Map<K, OnHeapValueHolder<V>> removeAllWithHash(int hash) {
-    Map<K, OnHeapValueHolder<V>> result = new HashMap<>();
-    Map<OnHeapKey<K>, OnHeapValueHolder<V>> removed = keyCopyMap.removeAllWithHash(hash);
+  public Collection<Map.Entry<K, OnHeapValueHolder<V>>> removeAllWithHash(int hash) {
+    Collection<Map.Entry<OnHeapKey<K>, OnHeapValueHolder<V>>> removed = keyCopyMap.removeAllWithHash(hash);
+    Collection<Map.Entry<K, OnHeapValueHolder<V>>> result = new ArrayList<>(removed.size());
     long delta = 0L;
-    for (Map.Entry<OnHeapKey<K>, OnHeapValueHolder<V>> entry : removed.entrySet()) {
+    for (Map.Entry<OnHeapKey<K>, OnHeapValueHolder<V>> entry : removed) {
       delta -= entry.getValue().size();
-      result.put(entry.getKey().getActualKeyObject(), entry.getValue());
+      result.add(new AbstractMap.SimpleImmutableEntry<>(entry.getKey().getActualKeyObject(), entry.getValue()));
     }
     updateUsageInBytesIfRequired(delta);
     return result;

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -885,8 +885,8 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
   public void silentInvalidateAllWithHash(long hash, BiFunction<K, ValueHolder<V>, Void> biFunction) throws StoreAccessException {
     silentInvalidateAllWithHashObserver.begin();
     int intHash = HashUtils.longHashToInt(hash);
-    Map<K, OnHeapValueHolder<V>> removed = map.removeAllWithHash(intHash);
-    for (Entry<K, OnHeapValueHolder<V>> entry : removed.entrySet()) {
+    Collection<Entry<K, OnHeapValueHolder<V>>> removed = map.removeAllWithHash(intHash);
+    for (Entry<K, OnHeapValueHolder<V>> entry : removed) {
       biFunction.apply(entry.getKey(), entry.getValue());
     }
     silentInvalidateAllWithHashObserver.end(HigherCachingTierOperationOutcomes.SilentInvalidateAllWithHashOutcome.SUCCESS);
@@ -912,8 +912,8 @@ public class OnHeapStore<K, V> implements Store<K,V>, HigherCachingTier<K, V> {
   public void invalidateAllWithHash(long hash) throws StoreAccessException {
     invalidateAllWithHashObserver.begin();
     int intHash = HashUtils.longHashToInt(hash);
-    Map<K, OnHeapValueHolder<V>> removed = map.removeAllWithHash(intHash);
-    for (Entry<K, OnHeapValueHolder<V>> entry : removed.entrySet()) {
+    Collection<Entry<K, OnHeapValueHolder<V>>> removed = map.removeAllWithHash(intHash);
+    for (Entry<K, OnHeapValueHolder<V>> entry : removed) {
       notifyInvalidation(entry.getKey(), entry.getValue());
     }
     LOG.debug("CLIENT: onheap store removed all with hash {}", intHash);

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/SimpleBackend.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/SimpleBackend.java
@@ -21,6 +21,7 @@ import org.ehcache.core.spi.store.Store;
 import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
 import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Random;
@@ -102,11 +103,11 @@ class SimpleBackend<K, V> implements Backend<K, V> {
   }
 
   @Override
-  public Map<K, OnHeapValueHolder<V>> removeAllWithHash(int hash) {
-    Map<K, OnHeapValueHolder<V>> removed = realMap.removeAllWithHash(hash);
+  public Collection<Map.Entry<K, OnHeapValueHolder<V>>> removeAllWithHash(int hash) {
+    Collection<Map.Entry<K, OnHeapValueHolder<V>>> removed = realMap.removeAllWithHash(hash);
     if (byteSized) {
       long delta = 0L;
-      for (Map.Entry<K, OnHeapValueHolder<V>> entry : removed.entrySet()) {
+      for (Map.Entry<K, OnHeapValueHolder<V>> entry : removed) {
         delta -= entry.getValue().size();
       }
       updateUsageInBytesIfRequired(delta);

--- a/impl/src/test/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMapTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMapTest.java
@@ -18,12 +18,10 @@ package org.ehcache.impl.internal.concurrent;
 
 import org.junit.Test;
 
-import java.util.Comparator;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
-import org.ehcache.config.Eviction;
-import org.ehcache.config.EvictionAdvisor;
 
 import static org.ehcache.config.Eviction.noAdvice;
 import static org.hamcrest.CoreMatchers.is;
@@ -51,13 +49,11 @@ public class ConcurrentHashMapTest {
             map.put(o, "val#" + i);
         }
 
-        Map<Comparable<?>, String> removed = map.removeAllWithHash(lastHash);
+        Collection<Entry<Comparable<?>, String>> removed = map.removeAllWithHash(lastHash);
 
         assertThat(removed.size(), greaterThan(0));
         assertThat(map.size() + removed.size(), is(totalCount));
-        for (Comparable<?> key : map.keySet()) {
-            assertThat(removed.containsKey(key), is(false));
-        }
+        assertRemovedEntriesAreRemoved(map, removed);
     }
 
     @Test
@@ -71,15 +67,18 @@ public class ConcurrentHashMapTest {
             map.put(o, "val#" + i);
         }
 
-        Map<Comparable<?>, String> removed = map.removeAllWithHash(BadHashKey.HASH_CODE);
+        Collection<Map.Entry<Comparable<?>, String>> removed = map.removeAllWithHash(BadHashKey.HASH_CODE);
 
         assertThat(removed.size(), is(totalCount));
         assertThat(map.size(), is(0));
-        for (Comparable<?> removedKey : removed.keySet()) {
-            assertThat(map.containsKey(removedKey), is(false));
-        }
+        assertRemovedEntriesAreRemoved(map, removed);
     }
 
+    private void assertRemovedEntriesAreRemoved(ConcurrentHashMap<Comparable<?>, String> map, Collection<Entry<Comparable<?>, String>> removed) {
+        for (Entry<Comparable<?>, String> entry : map.entrySet()) {
+            assertThat(removed.contains(entry), is(false));
+        }
+    }
     static class BadHashKey implements Comparable<BadHashKey> {
 
         static final int HASH_CODE = 42;

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreProviderTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreProviderTest.java
@@ -22,9 +22,7 @@ import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.time.TimeSourceService;
 import org.ehcache.impl.internal.DefaultTimeSourceService;
 import org.ehcache.impl.internal.store.offheap.OffHeapStore;
-import org.ehcache.spi.persistence.PersistableResourceService;
 import org.ehcache.spi.persistence.StateRepository;
-import org.ehcache.spi.serialization.Serializer;
 import org.ehcache.spi.serialization.StatefulSerializer;
 import org.ehcache.spi.service.ServiceProvider;
 import org.ehcache.transactions.xa.configuration.XAStoreConfiguration;
@@ -36,7 +34,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
A `List` does the job perfectly and removes all the hashing at insertion, the slow traversal and the superior object allocation