### PR TITLE
Support JCache 1.1.0

### DIFF
--- a/107/build.gradle
+++ b/107/build.gradle
@@ -32,8 +32,8 @@ sourceSets {
 dependencies {
   compile project(':impl'), project(':xml')
   provided "javax.cache:cache-api:$parent.jcacheVersion"
-  tckTestRuntime 'javax.cache:cache-tests:1.0.1'
-  tckTestClasses('javax.cache:cache-tests:1.0.1:tests') {
+  tckTestRuntime "javax.cache:cache-tests:$jcacheTckVersion"
+  tckTestClasses("javax.cache:cache-tests:$jcacheTckVersion:tests") {
     transitive = false
   }
 }

--- a/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
@@ -287,18 +287,7 @@ class Eh107CacheManager implements CacheManager {
       throw new NullPointerException();
     }
 
-    Eh107Cache<K, V> cache = safeCacheRetrieval(cacheName);
-
-    if (cache == null) {
-      return null;
-    }
-
-    if (cache.getConfiguration(Configuration.class).getKeyType() != Object.class
-        || cache.getConfiguration(Configuration.class).getValueType() != Object.class) {
-      throw new IllegalArgumentException("Cache [" + cacheName
-          + "] specifies key/value types. Use getCache(String, Class, Class)");
-    }
-    return cache;
+    return safeCacheRetrieval(cacheName);
   }
 
   @SuppressWarnings("unchecked")
@@ -312,6 +301,7 @@ class Eh107CacheManager implements CacheManager {
 
   @Override
   public Iterable<String> getCacheNames() {
+    checkClosed();
     refreshAllCaches();
     return Collections.unmodifiableList(new ArrayList<>(caches.keySet()));
   }

--- a/107/src/main/java/org/ehcache/jsr107/EventListenerAdaptors.java
+++ b/107/src/main/java/org/ehcache/jsr107/EventListenerAdaptors.java
@@ -174,7 +174,7 @@ class EventListenerAdaptors {
     @SuppressWarnings("unchecked")
     @Override
     public void onEvent(org.ehcache.event.CacheEvent<? extends K, ? extends V> ehEvent) {
-      Eh107CacheEntryEvent<K, V> event = new Eh107CacheEntryEvent.NormalEvent<>(source, EventType.CREATED, ehEvent, requestsOld);
+      Eh107CacheEntryEvent<K, V> event = new Eh107CacheEntryEvent.NormalEvent<>(source, EventType.CREATED, ehEvent, false);
       if (filter.evaluate(event)) {
         Set<?> events = Collections.singleton(event);
         listener.onCreated((Iterable<CacheEntryEvent<? extends K, ? extends V>>) events);

--- a/107/src/tck/resources/ExcludeList
+++ b/107/src/tck/resources/ExcludeList
@@ -4,10 +4,3 @@
 
 # This is a dummy test that fails if not in the exclude list.
 org.jsr107.tck.CachingTest#dummyTest
-
-# see https://github.com/jsr107/jsr107tck/issues/63
-org.jsr107.tck.management.CacheMBStatisticsBeanTest#testPutIfAbsent
-
-# see https://github.com/jsr107/jsr107tck/issues/61
-org.jsr107.tck.spi.CachingProviderClassLoaderTest#getCacheManagerSingleton
-

--- a/107/src/test/java/org/ehcache/jsr107/Eh107CacheTypeTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/Eh107CacheTypeTest.java
@@ -63,7 +63,7 @@ public class Eh107CacheTypeTest {
 
 
   @Test
-  public void testRunTimeTypeSafety() throws Exception {
+  public void testRunTimeTypeLaxity() throws Exception {
     CachingProvider provider = Caching.getCachingProvider();
     javax.cache.CacheManager cacheManager =
         provider.getCacheManager(this.getClass().getResource("/ehcache-107-types.xml").toURI(), getClass().getClassLoader());
@@ -79,9 +79,6 @@ public class Eh107CacheTypeTest {
 
     try {
       cacheManager.getCache("cache1");
-      fail("Caches with runtime types should throw illegal argument exception when different types are used in getcache");
-    } catch (IllegalArgumentException e) {
-      //Empty block as nothing is required to be tested
     } finally {
       cacheManager.destroyCache("cache1");
       cacheManager.close();

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Terracotta third parties
 offheapVersion = 2.4.0
 statisticVersion = 1.5.0
-jcacheVersion = 1.0.0
+jcacheVersion = 1.1.0
 slf4jVersion = 1.7.25
 sizeofVersion = 0.3.0
 
@@ -18,6 +18,7 @@ assertjVersion = 3.8.0
 hamcrestVersion = 1.3
 mockitoVersion = 2.12.0
 jacksonVersion = 2.7.5
+jcacheTckVersion = 1.1.0
 
 # Tools
 findbugsVersion = 3.0.1


### PR DESCRIPTION
PR to be ready for JCache 1.1 when it gets released as supporting it for Ehcache 3.5 would be ideal.

PR should fail to build until we can reference a released version though.