### PR TITLE
Ehcache base class to mutualize basic and loader-writer code

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/Eh107Cache.java
+++ b/107/src/main/java/org/ehcache/jsr107/Eh107Cache.java
@@ -36,9 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -84,7 +81,7 @@ class Eh107Cache<K, V> implements Cache<K, V> {
       registerEhcacheListeners(entry.getKey(), entry.getValue());
     }
 
-    this.jsr107Cache = ehCache.getJsr107Cache();
+    this.jsr107Cache = ehCache.createJsr107Cache();
   }
 
   @Override

--- a/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
+++ b/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
@@ -200,7 +200,7 @@ public class EhCache107ConfigurationIntegrationDocTest {
     CacheRuntimeConfiguration<Long, Client> foosEhcacheConfig = (CacheRuntimeConfiguration<Long, Client>)foosCache.getConfiguration(
         Eh107Configuration.class).unwrap(CacheRuntimeConfiguration.class);
     Client client1 = new Client("client1", 1);
-    foosEhcacheConfig.getExpiry().getExpiryForCreation(42L, client1).getLength(); // <8>
+    foosEhcacheConfig.getExpiryPolicy().getExpiryForCreation(42L, client1).toMinutes(); // <8>
 
     CompleteConfiguration<String, String> foosConfig = foosCache.getConfiguration(CompleteConfiguration.class);
 

--- a/api/src/main/java/org/ehcache/config/CacheConfiguration.java
+++ b/api/src/main/java/org/ehcache/config/CacheConfiguration.java
@@ -17,7 +17,7 @@
 package org.ehcache.config;
 
 import org.ehcache.Cache;
-import org.ehcache.expiry.Expiry;
+
 import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -92,7 +92,7 @@ public interface CacheConfiguration<K, V> {
    * @deprecated Use {@link #getExpiryPolicy()}
    */
   @Deprecated
-  Expiry<? super K, ? super V> getExpiry();
+  org.ehcache.expiry.Expiry<? super K, ? super V> getExpiry();
 
   /**
    * The {@link ExpiryPolicy} rules for the {@link Cache}.

--- a/api/src/test/java/org/ehcache/expiry/DurationTest.java
+++ b/api/src/test/java/org/ehcache/expiry/DurationTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class DurationTest {
 
   @Test

--- a/api/src/test/java/org/ehcache/expiry/ExpirationsTest.java
+++ b/api/src/test/java/org/ehcache/expiry/ExpirationsTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class ExpirationsTest {
 
   @Test

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/DuplicateTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/DuplicateTest.java
@@ -27,7 +27,7 @@ import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.MemoryUnit;
-import org.ehcache.core.Ehcache;
+import org.ehcache.core.EhcacheBase;
 import org.ehcache.core.internal.resilience.ResilienceStrategy;
 import org.ehcache.core.spi.store.StoreAccessException;
 import org.junit.After;
@@ -104,7 +104,7 @@ public class DuplicateTest extends ClusteredTests {
     //Perform put operations in another thread
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     try {
-      Future<?> puts = executorService.submit((Runnable) () -> {
+      Future<?> puts = executorService.submit(() -> {
         while (true) {
           int i = currentEntry.getAndIncrement();
           if (i >= numEntries) {
@@ -132,13 +132,12 @@ public class DuplicateTest extends ClusteredTests {
   }
 
   private void switchResilienceStrategy(Cache<?,?> cache) throws Exception {
-    Field field = Ehcache.class.getDeclaredField("resilienceStrategy");
+    Field field = EhcacheBase.class.getDeclaredField("resilienceStrategy");
     field.setAccessible(true);
     ResilienceStrategy<?, ?> newResilienceStrategy = (ResilienceStrategy<?, ?>)
       Proxy.newProxyInstance(cache.getClass().getClassLoader(),
         new Class<?>[] { ResilienceStrategy.class},
         (proxy, method, args) -> {
-          System.out.println("In there!!!!!!!!!!!!!!!!!!!!!!!!!");
           fail("Failure on " + method.getName(), findStoreAccessException(args)); // 1 is always the exception
           return null;
         });

--- a/core/src/main/java/org/ehcache/core/EhcacheBase.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheBase.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.core;
+
+import org.ehcache.Cache;
+import org.ehcache.Status;
+import org.ehcache.config.CacheRuntimeConfiguration;
+import org.ehcache.core.events.CacheEventDispatcher;
+import org.ehcache.core.internal.resilience.LoggingRobustResilienceStrategy;
+import org.ehcache.core.internal.resilience.RecoveryCache;
+import org.ehcache.core.internal.resilience.ResilienceStrategy;
+import org.ehcache.core.spi.LifeCycled;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.core.spi.store.Store.ValueHolder;
+import org.ehcache.core.spi.store.StoreAccessException;
+import org.ehcache.core.statistics.BulkOps;
+import org.ehcache.core.statistics.CacheOperationOutcomes.ClearOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.ConditionalRemoveOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.GetAllOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.PutAllOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.PutIfAbsentOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.PutOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.RemoveAllOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.RemoveOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.ReplaceOutcome;
+import org.ehcache.expiry.ExpiryPolicy;
+import org.ehcache.spi.loaderwriter.BulkCacheLoadingException;
+import org.ehcache.spi.loaderwriter.CacheWritingException;
+import org.slf4j.Logger;
+import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.observer.OperationObserver;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+
+import static org.ehcache.core.exceptions.ExceptionFactory.newCacheLoadingException;
+import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
+import static org.terracotta.statistics.StatisticBuilder.operation;
+
+/**
+ * Base implementation of the {@link Cache} interface that is common to all Ehcache implementation
+ */
+public abstract class EhcacheBase<K, V> implements InternalCache<K, V> {
+
+  protected final Logger logger;
+
+  protected final StatusTransitioner statusTransitioner;
+
+  protected final Store<K, V> store;
+  protected final ResilienceStrategy<K, V> resilienceStrategy;
+  protected final EhcacheRuntimeConfiguration<K, V> runtimeConfiguration;
+
+  protected final OperationObserver<GetOutcome> getObserver = operation(GetOutcome.class).named("get").of(this).tag("cache").build();
+  protected final OperationObserver<GetAllOutcome> getAllObserver = operation(GetAllOutcome.class).named("getAll").of(this).tag("cache").build();
+  protected final OperationObserver<PutOutcome> putObserver = operation(PutOutcome.class).named("put").of(this).tag("cache").build();
+  protected final OperationObserver<PutAllOutcome> putAllObserver = operation(PutAllOutcome.class).named("putAll").of(this).tag("cache").build();
+  protected final OperationObserver<RemoveOutcome> removeObserver = operation(RemoveOutcome.class).named("remove").of(this).tag("cache").build();
+  protected final OperationObserver<RemoveAllOutcome> removeAllObserver = operation(RemoveAllOutcome.class).named("removeAll").of(this).tag("cache").build();
+  protected final OperationObserver<ConditionalRemoveOutcome> conditionalRemoveObserver = operation(ConditionalRemoveOutcome.class).named("conditionalRemove").of(this).tag("cache").build();
+  protected final OperationObserver<PutIfAbsentOutcome> putIfAbsentObserver = operation(PutIfAbsentOutcome.class).named("putIfAbsent").of(this).tag("cache").build();
+  protected final OperationObserver<ReplaceOutcome> replaceObserver = operation(ReplaceOutcome.class).named("replace").of(this).tag("cache").build();
+  protected final OperationObserver<ClearOutcome> clearObserver = operation(ClearOutcome.class).named("clear").of(this).tag("cache").build();
+
+  protected final Map<BulkOps, LongAdder> bulkMethodEntries = new EnumMap<>(BulkOps.class);
+
+  /**
+   * Creates a new {@code EhcacheBase} based on the provided parameters.
+   *
+   * @param runtimeConfiguration the cache configuration
+   * @param store the store to use
+   * @param eventDispatcher the event dispatcher
+   * @param logger the logger
+   */
+  EhcacheBase(EhcacheRuntimeConfiguration<K, V> runtimeConfiguration, Store<K, V> store,
+          CacheEventDispatcher<K, V> eventDispatcher, Logger logger, StatusTransitioner statusTransitioner) {
+    this.store = store;
+    runtimeConfiguration.addCacheConfigurationListener(store.getConfigurationChangeListeners());
+    StatisticsManager.associate(store).withParent(this);
+
+    if (store instanceof RecoveryCache) {
+      this.resilienceStrategy = new LoggingRobustResilienceStrategy<>(castToRecoveryCache(store));
+    } else {
+      this.resilienceStrategy = new LoggingRobustResilienceStrategy<>(recoveryCache(store));
+    }
+
+    this.runtimeConfiguration = runtimeConfiguration;
+    runtimeConfiguration.addCacheConfigurationListener(eventDispatcher.getConfigurationChangeListeners());
+
+    this.logger = logger;
+    this.statusTransitioner = statusTransitioner;
+    for (BulkOps bulkOp : BulkOps.values()) {
+      bulkMethodEntries.put(bulkOp, new LongAdder());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private RecoveryCache<K> castToRecoveryCache(Store<K, V> store) {
+    return (RecoveryCache<K>) store;
+  }
+
+  private static <K> RecoveryCache<K> recoveryCache(final Store<K, ?> store) {
+    return new RecoveryCache<K>() {
+
+      @Override
+      public void obliterate() throws StoreAccessException {
+        store.clear();
+      }
+
+      @Override
+      public void obliterate(K key) throws StoreAccessException {
+        store.remove(key);
+      }
+
+      @Override
+      public void obliterate(Iterable<? extends K> keys) throws StoreAccessException {
+        for (K key : keys) {
+          obliterate(key);
+        }
+      }
+    };
+  }
+
+  protected V getNoLoader(K key) {
+    getObserver.begin();
+    statusTransitioner.checkAvailable();
+    checkNonNull(key);
+
+    try {
+      final Store.ValueHolder<V> valueHolder = store.get(key);
+
+      // Check for expiry first
+      if (valueHolder == null) {
+        getObserver.end(GetOutcome.MISS);
+        return null;
+      } else {
+        getObserver.end(GetOutcome.HIT);
+        return valueHolder.value();
+      }
+    } catch (StoreAccessException e) {
+      try {
+        return resilienceStrategy.getFailure(key, e);
+      } finally {
+        getObserver.end(GetOutcome.FAILURE);
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean containsKey(final K key) {
+    statusTransitioner.checkAvailable();
+    checkNonNull(key);
+    try {
+      return store.containsKey(key);
+    } catch (StoreAccessException e) {
+      return resilienceStrategy.containsKeyFailure(key, e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void remove(K key) throws CacheWritingException {
+    removeInternal(key); // ignore return value;
+  }
+
+  protected abstract boolean removeInternal(final K key);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void clear() {
+    clearObserver.begin();
+    statusTransitioner.checkAvailable();
+    try {
+      store.clear();
+      clearObserver.end(ClearOutcome.SUCCESS);
+    } catch (StoreAccessException e) {
+      clearObserver.end(ClearOutcome.FAILURE);
+      resilienceStrategy.clearFailure(e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Iterator<Entry<K, V>> iterator() {
+    statusTransitioner.checkAvailable();
+    return new CacheEntryIterator(false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Map<K, V> getAll(Set<? extends K> keys) throws BulkCacheLoadingException {
+    return getAllInternal(keys, true);
+  }
+
+  protected abstract Map<K,V> getAllInternal(Set<? extends K> keys, boolean b);
+
+
+  protected boolean newValueAlreadyExpired(K key, V oldValue, V newValue) {
+    return newValueAlreadyExpired(logger, runtimeConfiguration.getExpiryPolicy(), key, oldValue, newValue);
+  }
+
+  protected static <K, V> boolean newValueAlreadyExpired(Logger logger, ExpiryPolicy<? super K, ? super V> expiry, K key, V oldValue, V newValue) {
+    if (newValue == null) {
+      return false;
+    }
+
+    Duration duration;
+    try {
+      if (oldValue == null) {
+        duration = expiry.getExpiryForCreation(key, newValue);
+      } else {
+        duration = expiry.getExpiryForUpdate(key, supplierOf(oldValue), newValue);
+      }
+    } catch (RuntimeException re) {
+      logger.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+      return true;
+    }
+
+    return Duration.ZERO.equals(duration);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public CacheRuntimeConfiguration<K, V> getRuntimeConfiguration() {
+    return runtimeConfiguration;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void init() {
+    statusTransitioner.init().succeeded();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() {
+    statusTransitioner.close().succeeded();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Status getStatus() {
+    return statusTransitioner.currentStatus();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void addHook(LifeCycled hook) {
+    statusTransitioner.addHook(hook);
+  }
+
+  void removeHook(LifeCycled hook) {
+    statusTransitioner.removeHook(hook);
+  }
+
+  protected void addBulkMethodEntriesCount(BulkOps op, long count) {
+    bulkMethodEntries.get(op).add(count);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Map<BulkOps, LongAdder> getBulkMethodEntries() {
+    return bulkMethodEntries;
+  }
+
+  protected static void checkNonNull(Object thing) {
+    Objects.requireNonNull(thing);
+  }
+
+  protected static void checkNonNull(Object... things) {
+    for (Object thing : things) {
+      checkNonNull(thing);
+    }
+  }
+
+  protected void checkNonNullContent(Collection<?> collectionOfThings) {
+    checkNonNull(collectionOfThings);
+    for (Object thing : collectionOfThings) {
+      checkNonNull(thing);
+    }
+  }
+
+  protected abstract class Jsr107CacheBase implements Jsr107Cache<K, V> {
+
+    @Override
+    public void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+      if(keys.isEmpty()) {
+        return ;
+      }
+      if (replaceExistingValues) {
+        loadAllReplace(keys, loadFunction);
+      } else {
+        loadAllAbsent(keys, loadFunction);
+      }
+    }
+
+    @Override
+    public Iterator<Entry<K, V>> specIterator() {
+      return new SpecIterator<>(this, store);
+    }
+
+    @Override
+    public V getNoLoader(K key) {
+      return EhcacheBase.this.getNoLoader(key);
+    }
+
+    @Override
+    public Map<K, V> getAll(Set<? extends K> keys) {
+      return getAllInternal(keys, false);
+    }
+
+    private void loadAllAbsent(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+      try {
+        store.bulkComputeIfAbsent(keys, absentKeys -> cacheLoaderWriterLoadAllForKeys(absentKeys, loadFunction).entrySet());
+      } catch (StoreAccessException e) {
+        throw newCacheLoadingException(e);
+      }
+    }
+
+    Map<K, V> cacheLoaderWriterLoadAllForKeys(Iterable<? extends K> keys, Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+      try {
+        Map<? super K, ? extends V> loaded = loadFunction.apply(keys);
+
+        // put into a new map since we can't assume the 107 cache loader returns things ordered, or necessarily with all the desired keys
+        Map<K, V> rv = new LinkedHashMap<>();
+        for (K key : keys) {
+          rv.put(key, loaded.get(key));
+        }
+        return rv;
+      } catch (Exception e) {
+        throw newCacheLoadingException(e);
+      }
+    }
+
+    private void loadAllReplace(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
+      try {
+        store.bulkCompute(keys, entries -> {
+          Collection<K> keys1 = new ArrayList<>();
+          for (Map.Entry<? extends K, ? extends V> entry : entries) {
+            keys1.add(entry.getKey());
+          }
+          return cacheLoaderWriterLoadAllForKeys(keys1, loadFunction).entrySet();
+        });
+      } catch (StoreAccessException e) {
+        throw newCacheLoadingException(e);
+      }
+    }
+
+    @Override
+    public boolean remove(K key) {
+      return EhcacheBase.this.removeInternal(key);
+    }
+
+    @Override
+    public void removeAll() {
+      Store.Iterator<Entry<K, ValueHolder<V>>> iterator = store.iterator();
+      while (iterator.hasNext()) {
+        try {
+          Entry<K, ValueHolder<V>> next = iterator.next();
+          remove(next.getKey());
+        } catch (StoreAccessException cae) {
+          // skip
+        }
+      }
+    }
+
+  }
+
+  private class CacheEntryIterator implements Iterator<Entry<K, V>> {
+
+    private final Store.Iterator<Entry<K, ValueHolder<V>>> iterator;
+    private final boolean quiet;
+    private Cache.Entry<K, ValueHolder<V>> current;
+    private Cache.Entry<K, ValueHolder<V>> next;
+    private StoreAccessException nextException;
+
+    public CacheEntryIterator(boolean quiet) {
+      this.quiet = quiet;
+      this.iterator = store.iterator();
+      advance();
+    }
+
+    private void advance() {
+      try {
+        while (iterator.hasNext()) {
+          next = iterator.next();
+          if (getNoLoader(next.getKey()) != null) {
+            return;
+          }
+        }
+        next = null;
+      } catch (RuntimeException re) {
+        nextException = new StoreAccessException(re);
+        next = null;
+      } catch (StoreAccessException cae) {
+        nextException = cae;
+        next = null;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      statusTransitioner.checkAvailable();
+      return nextException != null || next != null;
+    }
+
+    @Override
+    public Entry<K, V> next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      if (!quiet) getObserver.begin();
+      if (nextException == null) {
+        if (!quiet) getObserver.end(GetOutcome.HIT);
+        current = next;
+        advance();
+        return new ValueHolderBasedEntry<>(current);
+      } else {
+        if (!quiet) getObserver.end(GetOutcome.FAILURE);
+        StoreAccessException cae = nextException;
+        nextException = null;
+        return resilienceStrategy.iteratorFailure(cae);
+      }
+    }
+
+    @Override
+    public void remove() {
+      statusTransitioner.checkAvailable();
+      if (current == null) {
+        throw new IllegalStateException("No current element");
+      }
+      EhcacheBase.this.remove(current.getKey(), current.getValue().value());
+      current = null;
+    }
+  }
+
+  private static class ValueHolderBasedEntry<K, V> implements Cache.Entry<K, V> {
+    private final Cache.Entry<K, ValueHolder<V>> storeEntry;
+
+    ValueHolderBasedEntry(Cache.Entry<K, ValueHolder<V>> storeEntry) {
+      this.storeEntry = storeEntry;
+    }
+
+    @Override
+    public K getKey() {
+      return storeEntry.getKey();
+    }
+
+    @Override
+    public V getValue() {
+      return storeEntry.getValue().value();
+    }
+
+  }
+}
+

--- a/core/src/main/java/org/ehcache/core/EhcacheRuntimeConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheRuntimeConfiguration.java
@@ -26,7 +26,6 @@ import org.ehcache.event.CacheEventListener;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
 import org.ehcache.event.EventType;
-import org.ehcache.expiry.Expiry;
 import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -100,8 +99,9 @@ class EhcacheRuntimeConfiguration<K, V> implements CacheRuntimeConfiguration<K, 
     return this.classLoader;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
-  public Expiry<? super K, ? super V> getExpiry() {
+  public org.ehcache.expiry.Expiry<? super K, ? super V> getExpiry() {
     return ExpiryUtils.convertToExpiry(expiry);
   }
 

--- a/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
@@ -17,9 +17,7 @@
 package org.ehcache.core;
 
 import org.ehcache.Cache;
-import org.ehcache.Status;
 import org.ehcache.config.CacheConfiguration;
-import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.core.events.CacheEventDispatcher;
 import org.ehcache.core.exceptions.StorePassThroughException;
 import org.ehcache.spi.loaderwriter.BulkCacheLoadingException;
@@ -27,11 +25,6 @@ import org.ehcache.spi.loaderwriter.BulkCacheWritingException;
 import org.ehcache.core.spi.store.StoreAccessException;
 import org.ehcache.spi.loaderwriter.CacheLoadingException;
 import org.ehcache.spi.loaderwriter.CacheWritingException;
-import org.ehcache.expiry.Duration;
-import org.ehcache.core.internal.resilience.LoggingRobustResilienceStrategy;
-import org.ehcache.core.internal.resilience.RecoveryCache;
-import org.ehcache.core.internal.resilience.ResilienceStrategy;
-import org.ehcache.core.spi.LifeCycled;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.Store.ValueHolder;
 import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
@@ -47,26 +40,19 @@ import org.ehcache.core.statistics.CacheOperationOutcomes.RemoveAllOutcome;
 import org.ehcache.core.statistics.CacheOperationOutcomes.RemoveOutcome;
 import org.ehcache.core.statistics.CacheOperationOutcomes.ReplaceOutcome;
 import org.slf4j.Logger;
-import org.terracotta.statistics.StatisticsManager;
 import org.terracotta.statistics.observer.OperationObserver;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -74,7 +60,6 @@ import java.util.function.Supplier;
 import static org.ehcache.core.internal.util.Functions.memoize;
 import static org.ehcache.core.exceptions.ExceptionFactory.newCacheLoadingException;
 import static org.ehcache.core.exceptions.ExceptionFactory.newCacheWritingException;
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 import static org.terracotta.statistics.StatisticBuilder.operation;
 
 /**
@@ -85,31 +70,14 @@ import static org.terracotta.statistics.StatisticBuilder.operation;
  *
  * @see Ehcache
  */
-public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
-
-  private final StatusTransitioner statusTransitioner;
-
-  private final Store<K, V> store;
-  private final CacheLoaderWriter<? super K, V> cacheLoaderWriter;
-  private final ResilienceStrategy<K, V> resilienceStrategy;
-  private final EhcacheRuntimeConfiguration<K, V> runtimeConfiguration;
-  private final Jsr107CacheImpl jsr107Cache;
-  private final boolean useLoaderInAtomics;
-  protected final Logger logger;
-
-  private final OperationObserver<GetOutcome> getObserver = operation(GetOutcome.class).named("get").of(this).tag("cache").build();
-  private final OperationObserver<GetAllOutcome> getAllObserver = operation(GetAllOutcome.class).named("getAll").of(this).tag("cache").build();
-  private final OperationObserver<PutOutcome> putObserver = operation(PutOutcome.class).named("put").of(this).tag("cache").build();
-  private final OperationObserver<PutAllOutcome> putAllObserver = operation(PutAllOutcome.class).named("putAll").of(this).tag("cache").build();
-  private final OperationObserver<RemoveOutcome> removeObserver = operation(RemoveOutcome.class).named("remove").of(this).tag("cache").build();
-  private final OperationObserver<RemoveAllOutcome> removeAllObserver = operation(RemoveAllOutcome.class).named("removeAll").of(this).tag("cache").build();
-  private final OperationObserver<ConditionalRemoveOutcome> conditionalRemoveObserver = operation(ConditionalRemoveOutcome.class).named("conditionalRemove").of(this).tag("cache").build();
-  private final OperationObserver<CacheLoadingOutcome> cacheLoadingObserver = operation(CacheLoadingOutcome.class).named("cacheLoading").of(this).tag("cache").build();
-  private final OperationObserver<PutIfAbsentOutcome> putIfAbsentObserver = operation(PutIfAbsentOutcome.class).named("putIfAbsent").of(this).tag("cache").build();
-  private final OperationObserver<ReplaceOutcome> replaceObserver = operation(ReplaceOutcome.class).named("replace").of(this).tag("cache").build();
-  private final Map<BulkOps, LongAdder> bulkMethodEntries = new EnumMap<>(BulkOps.class);
+public class EhcacheWithLoaderWriter<K, V> extends EhcacheBase<K, V> {
 
   private static final Supplier<Boolean> REPLACE_FALSE = () -> Boolean.FALSE;
+
+  private final CacheLoaderWriter<? super K, V> cacheLoaderWriter;
+  private final boolean useLoaderInAtomics;
+
+  private final OperationObserver<CacheLoadingOutcome> cacheLoadingObserver = operation(CacheLoadingOutcome.class).named("cacheLoading").of(this).tag("cache").build();
 
   /**
    * Constructs a new {@code EhcacheWithLoaderWriter} based on the provided parameters.
@@ -136,67 +104,10 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
   EhcacheWithLoaderWriter(EhcacheRuntimeConfiguration<K, V> runtimeConfiguration, Store<K, V> store,
             CacheLoaderWriter<? super K, V> cacheLoaderWriter,
             CacheEventDispatcher<K, V> eventDispatcher, boolean useLoaderInAtomics, Logger logger, StatusTransitioner statusTransitioner) {
-    this.store = store;
-    runtimeConfiguration.addCacheConfigurationListener(store.getConfigurationChangeListeners());
-    StatisticsManager.associate(store).withParent(this);
-    if (cacheLoaderWriter == null) {
-      throw new NullPointerException("CacheLoaderWriter cannot be null.");
-    }
-    this.cacheLoaderWriter = cacheLoaderWriter;
-    if (store instanceof RecoveryCache) {
-      this.resilienceStrategy = new LoggingRobustResilienceStrategy<>(castToRecoveryCache(store));
-    } else {
-      this.resilienceStrategy = new LoggingRobustResilienceStrategy<>(recoveryCache(store));
-    }
+    super(runtimeConfiguration, store, eventDispatcher, logger, statusTransitioner);
 
-    this.runtimeConfiguration = runtimeConfiguration;
-    runtimeConfiguration.addCacheConfigurationListener(eventDispatcher.getConfigurationChangeListeners());
-    this.jsr107Cache = new Jsr107CacheImpl();
-
+    this.cacheLoaderWriter = Objects.requireNonNull(cacheLoaderWriter, "CacheLoaderWriter cannot be null");
     this.useLoaderInAtomics = useLoaderInAtomics;
-    this.logger=logger;
-    this.statusTransitioner = statusTransitioner;
-    for (BulkOps bulkOp : BulkOps.values()) {
-      bulkMethodEntries.put(bulkOp, new LongAdder());
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Map<BulkOps, LongAdder> getBulkMethodEntries() {
-    return bulkMethodEntries;
-  }
-
-  @SuppressWarnings("unchecked")
-  private RecoveryCache<K> castToRecoveryCache(Store<K, V> store) {
-    return (RecoveryCache<K>) store;
-  }
-
-  private V getNoLoader(K key) {
-    getObserver.begin();
-    statusTransitioner.checkAvailable();
-    checkNonNull(key);
-
-    try {
-      final Store.ValueHolder<V> valueHolder = store.get(key);
-
-      // Check for expiry first
-      if (valueHolder == null) {
-        getObserver.end(GetOutcome.MISS);
-        return null;
-      } else {
-        getObserver.end(GetOutcome.HIT);
-        return valueHolder.value();
-      }
-    } catch (StoreAccessException e) {
-      try {
-        return resilienceStrategy.getFailure(key, e);
-      } finally {
-        getObserver.end(GetOutcome.FAILURE);
-      }
-    }
   }
 
   /**
@@ -207,8 +118,9 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     getObserver.begin();
     statusTransitioner.checkAvailable();
     checkNonNull(key);
+
     final Function<K, V> mappingFunction = memoize(k -> {
-      V loaded = null;
+      V loaded;
       try {
         cacheLoadingObserver.begin();
         loaded = cacheLoaderWriter.load(k);
@@ -255,6 +167,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     putObserver.begin();
     statusTransitioner.checkAvailable();
     checkNonNull(key, value);
+
     final BiFunction<K, V, V> remappingFunction = memoize((key1, previousValue) -> {
       try {
         cacheLoaderWriter.write(key1, value);
@@ -282,55 +195,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     }
   }
 
-  private boolean newValueAlreadyExpired(K key, V oldValue, V newValue) {
-    if (newValue == null) {
-      return false;
-    }
-
-    final Duration duration;
-    if (oldValue == null) {
-      try {
-        duration = runtimeConfiguration.getExpiry().getExpiryForCreation(key, newValue);
-      } catch (RuntimeException re) {
-        logger.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
-        return true;
-      }
-    } else {
-      try {
-        duration = runtimeConfiguration.getExpiry().getExpiryForUpdate(key, supplierOf(oldValue), newValue);
-      } catch (RuntimeException re) {
-        logger.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
-        return true;
-      }
-    }
-
-    return Duration.ZERO.equals(duration);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean containsKey(final K key) {
-    statusTransitioner.checkAvailable();
-    checkNonNull(key);
-    try {
-      return store.containsKey(key);
-    } catch (StoreAccessException e) {
-      return resilienceStrategy.containsKeyFailure(key, e);
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void remove(K key) throws CacheWritingException {
-    removeInternal(key); // ignore return value;
-  }
-
-
-  private boolean removeInternal(final K key) throws CacheWritingException {
+  protected boolean removeInternal(final K key) throws CacheWritingException {
     removeObserver.begin();
     statusTransitioner.checkAvailable();
     checkNonNull(key);
@@ -371,37 +236,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     return modified.get();
   }
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void clear() {
-    statusTransitioner.checkAvailable();
-    try {
-      store.clear();
-    } catch (StoreAccessException e) {
-      resilienceStrategy.clearFailure(e);
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Iterator<Entry<K, V>> iterator() {
-    statusTransitioner.checkAvailable();
-    return new CacheEntryIterator(false);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Map<K, V> getAll(Set<? extends K> keys) throws BulkCacheLoadingException {
-    return getAllInternal(keys, true);
-  }
-
-  private Map<K, V> getAllInternal(Set<? extends K> keys, boolean includeNulls) throws BulkCacheLoadingException {
+  protected Map<K, V> getAllInternal(Set<? extends K> keys, boolean includeNulls) throws BulkCacheLoadingException {
     getAllObserver.begin();
     statusTransitioner.checkAvailable();
     checkNonNullContent(keys);
@@ -472,10 +307,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
       }
     } catch (StoreAccessException e) {
       try {
-        Set<K> toLoad = new HashSet<>();
-        for (K key : keys) {
-          toLoad.add(key);
-        }
+        Set<K> toLoad = new HashSet<>(keys);
         toLoad.removeAll(successes.keySet());
         toLoad.removeAll(failures.keySet());
         computeFunction.apply(toLoad);
@@ -488,14 +320,6 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
         getAllObserver.end(GetAllOutcome.FAILURE);
       }
     }
-  }
-
-  LinkedHashSet<Map.Entry<? extends K, ? extends V>> nullValuesForKeys(final Iterable<? extends K> keys) {
-    final LinkedHashSet<Map.Entry<? extends K, ? extends V>> entries = new LinkedHashSet<>();
-    for (K key : keys) {
-      entries.add(new AbstractMap.SimpleEntry<>(key, null));
-    }
-    return entries;
   }
 
   /**
@@ -782,7 +606,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
       }
     } catch (StoreAccessException e) {
       try {
-        V loaded = null;
+        V loaded;
         try {
           loaded = mappingFunction.apply(key);
         } catch (StorePassThroughException f) {
@@ -813,19 +637,9 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     final AtomicBoolean hit = new AtomicBoolean();
     final AtomicBoolean removed = new AtomicBoolean();
     final BiFunction<K, V, V> remappingFunction = memoize((k, inCache) -> {
-      if (inCache == null) {
-        if (useLoaderInAtomics) {
-          try {
-            inCache = cacheLoaderWriter.load(key);
-            if (inCache == null) {
-              return null;
-            }
-          } catch (Exception e) {
-            throw new StorePassThroughException(newCacheLoadingException(e));
-          }
-        } else {
-          return null;
-        }
+      inCache = loadFromLoaderWriter(key, inCache);
+      if(inCache == null) {
+        return null;
       }
 
       hit.set(true);
@@ -883,19 +697,9 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     checkNonNull(key, value);
     final AtomicReference<V> old = new AtomicReference<>();
     final BiFunction<K, V, V> remappingFunction = memoize((k, inCache) -> {
-      if (inCache == null) {
-        if (useLoaderInAtomics) {
-          try {
-            inCache = cacheLoaderWriter.load(key);
-            if (inCache == null) {
-              return null;
-            }
-          } catch (Exception e) {
-            throw new StorePassThroughException(newCacheLoadingException(e));
-          }
-        } else {
-          return null;
-        }
+      inCache = loadFromLoaderWriter(key, inCache);
+      if(inCache == null) {
+        return null;
       }
 
       try {
@@ -941,6 +745,24 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     }
   }
 
+  private V loadFromLoaderWriter(K key, V inCache) {
+    if (inCache == null) {
+      if (useLoaderInAtomics) {
+        try {
+          inCache = cacheLoaderWriter.load(key);
+          if (inCache == null) {
+            return null;
+          }
+        } catch (Exception e) {
+          throw new StorePassThroughException(newCacheLoadingException(e));
+        }
+      } else {
+        return null;
+      }
+    }
+    return inCache;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -954,19 +776,9 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     final AtomicBoolean hit = new AtomicBoolean();
 
     final BiFunction<K, V, V> remappingFunction = memoize((k, inCache) -> {
-      if (inCache == null) {
-        if (useLoaderInAtomics) {
-          try {
-            inCache = cacheLoaderWriter.load(key);
-            if (inCache == null) {
-              return null;
-            }
-          } catch (Exception e) {
-            throw new StorePassThroughException(newCacheLoadingException(e));
-          }
-        } else {
-          return null;
-        }
+      inCache = loadFromLoaderWriter(key, inCache);
+      if(inCache == null) {
+        return null;
       }
 
       hit.set(true);
@@ -1019,79 +831,9 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     }
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
-  public CacheRuntimeConfiguration<K, V> getRuntimeConfiguration() {
-    return runtimeConfiguration;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void init() {
-    statusTransitioner.init().succeeded();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void close() {
-    statusTransitioner.close().succeeded();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Status getStatus() {
-    return statusTransitioner.currentStatus();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void addHook(LifeCycled hook) {
-    statusTransitioner.addHook(hook);
-  }
-
-  void removeHook(LifeCycled hook) {
-    statusTransitioner.removeHook(hook);
-  }
-
-  private static void checkNonNull(Object thing) {
-    if(thing == null) {
-      throw new NullPointerException();
-    }
-  }
-
-  private static void checkNonNull(Object... things) {
-    for (Object thing : things) {
-      checkNonNull(thing);
-    }
-  }
-
-  private void checkNonNullContent(Collection<?> collectionOfThings) {
-    checkNonNull(collectionOfThings);
-    for (Object thing : collectionOfThings) {
-      checkNonNull(thing);
-    }
-  }
-
-  private void addBulkMethodEntriesCount(BulkOps op, long count) {
-    bulkMethodEntries.get(op).add(count);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Jsr107Cache<K, V> getJsr107Cache() {
-    return jsr107Cache;
+  public Jsr107Cache<K, V> createJsr107Cache() {
+    return new Jsr107CacheImpl();
   }
 
   /**
@@ -1102,70 +844,7 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
     return this.cacheLoaderWriter;
   }
 
-  private final class Jsr107CacheImpl implements Jsr107Cache<K, V> {
-    @Override
-    public void loadAll(Set<? extends K> keys, boolean replaceExistingValues, Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
-      if(keys.isEmpty()) {
-        return ;
-      }
-      if (replaceExistingValues) {
-        loadAllReplace(keys, loadFunction);
-      } else {
-        loadAllAbsent(keys, loadFunction);
-      }
-    }
-
-    @Override
-    public Iterator<Entry<K, V>> specIterator() {
-      return new SpecIterator<>(this, store);
-    }
-
-    @Override
-    public V getNoLoader(K key) {
-      return EhcacheWithLoaderWriter.this.getNoLoader(key);
-    }
-
-    @Override
-    public Map<K, V> getAll(Set<? extends K> keys) {
-      return EhcacheWithLoaderWriter.this.getAllInternal(keys, false);
-    }
-
-    private void loadAllAbsent(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
-      try {
-        store.bulkComputeIfAbsent(keys, absentKeys -> cacheLoaderWriterLoadAllForKeys(absentKeys, loadFunction).entrySet());
-      } catch (StoreAccessException e) {
-        throw newCacheLoadingException(e);
-      }
-    }
-
-    Map<K, V> cacheLoaderWriterLoadAllForKeys(Iterable<? extends K> keys, Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
-      try {
-        Map<? super K, ? extends V> loaded = loadFunction.apply(keys);
-
-        // put into a new map since we can't assume the 107 cache loader returns things ordered, or necessarily with all the desired keys
-        Map<K, V> rv = new LinkedHashMap<>();
-        for (K key : keys) {
-          rv.put(key, loaded.get(key));
-        }
-        return rv;
-      } catch (Exception e) {
-        throw newCacheLoadingException(e);
-      }
-    }
-
-    private void loadAllReplace(Set<? extends K> keys, final Function<Iterable<? extends K>, Map<K, V>> loadFunction) {
-      try {
-        store.bulkCompute(keys, entries -> {
-          Collection<K> keys1 = new ArrayList<>();
-          for (Map.Entry<? extends K, ? extends V> entry : entries) {
-            keys1.add(entry.getKey());
-          }
-          return cacheLoaderWriterLoadAllForKeys(keys1, loadFunction).entrySet();
-        });
-      } catch (StoreAccessException e) {
-        throw newCacheLoadingException(e);
-      }
-    }
+  private final class Jsr107CacheImpl extends Jsr107CacheBase {
 
     @Override
     public void compute(K key, final BiFunction<? super K, ? super V, ? extends V> computeFunction,
@@ -1293,135 +972,6 @@ public class EhcacheWithLoaderWriter<K, V> implements InternalCache<K, V> {
       putObserver.end(PutOutcome.PUT);
       return returnValue;
     }
-
-    @Override
-    public boolean remove(K key) {
-      return removeInternal(key);
-    }
-
-    @Override
-    public void removeAll() {
-      Store.Iterator<Entry<K, ValueHolder<V>>> iterator = store.iterator();
-      while (iterator.hasNext()) {
-        try {
-          Entry<K, ValueHolder<V>> next = iterator.next();
-          remove(next.getKey());
-        } catch (StoreAccessException cae) {
-          // skip
-        }
-      }
-    }
-  }
-
-  private class CacheEntryIterator implements Iterator<Entry<K, V>> {
-
-    private final Store.Iterator<Entry<K, Store.ValueHolder<V>>> iterator;
-    private final boolean quiet;
-    private Cache.Entry<K, ValueHolder<V>> current;
-    private Cache.Entry<K, ValueHolder<V>> next;
-    private StoreAccessException nextException;
-
-    public CacheEntryIterator(boolean quiet) {
-      this.quiet = quiet;
-      this.iterator = store.iterator();
-      advance();
-    }
-
-    private void advance() {
-      try {
-        while (iterator.hasNext()) {
-          next = iterator.next();
-          if (getNoLoader(next.getKey()) != null) {
-            return;
-          }
-        }
-        next = null;
-      } catch (RuntimeException re) {
-        nextException = new StoreAccessException(re);
-        next = null;
-      } catch (StoreAccessException cae) {
-        nextException = cae;
-        next = null;
-      }
-    }
-
-    @Override
-    public boolean hasNext() {
-      statusTransitioner.checkAvailable();
-      return nextException != null || next != null;
-    }
-
-    @Override
-    public Entry<K, V> next() {
-      if (!hasNext()) {
-        throw new NoSuchElementException();
-      }
-
-      if (!quiet) getObserver.begin();
-      if (nextException == null) {
-        if (!quiet) getObserver.end(GetOutcome.HIT);
-        current = next;
-        advance();
-        return new ValueHolderBasedEntry<>(current);
-      } else {
-        if (!quiet) getObserver.end(GetOutcome.FAILURE);
-        StoreAccessException cae = nextException;
-        nextException = null;
-        return resilienceStrategy.iteratorFailure(cae);
-      }
-    }
-
-    @Override
-    public void remove() {
-      statusTransitioner.checkAvailable();
-      if (current == null) {
-        throw new IllegalStateException("No current element");
-      }
-      EhcacheWithLoaderWriter.this.remove(current.getKey(), current.getValue().value());
-      current = null;
-    }
-  }
-
-
-  private static <K> RecoveryCache<K> recoveryCache(final Store<K, ?> store) {
-    return new RecoveryCache<K>() {
-
-      @Override
-      public void obliterate() throws StoreAccessException {
-        store.clear();
-      }
-
-      @Override
-      public void obliterate(K key) throws StoreAccessException {
-        store.remove(key);
-      }
-
-      @Override
-      public void obliterate(Iterable<? extends K> keys) throws StoreAccessException {
-        for (K key : keys) {
-          obliterate(key);
-        }
-      }
-    };
-  }
-
-  private static class ValueHolderBasedEntry<K, V> implements Cache.Entry<K, V> {
-    private final Cache.Entry<K, ValueHolder<V>> storeEntry;
-
-    ValueHolderBasedEntry(Cache.Entry<K, Store.ValueHolder<V>> storeEntry) {
-      this.storeEntry = storeEntry;
-    }
-
-    @Override
-    public K getKey() {
-      return storeEntry.getKey();
-    }
-
-    @Override
-    public V getValue() {
-      return storeEntry.getValue().value();
-    }
-
   }
 
 }

--- a/core/src/main/java/org/ehcache/core/InternalCache.java
+++ b/core/src/main/java/org/ehcache/core/InternalCache.java
@@ -44,7 +44,7 @@ public interface InternalCache<K, V> extends UserManagedCache<K, V> {
    *
    * @return Jsr107Cache
    */
-  Jsr107Cache<K, V> getJsr107Cache();
+  Jsr107Cache<K, V> createJsr107Cache();
 
   /**
    * CacheLoaderWriter

--- a/core/src/main/java/org/ehcache/core/config/BaseCacheConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/config/BaseCacheConfiguration.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.config.ResourcePools;
-import org.ehcache.expiry.Expiry;
 import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.spi.service.ServiceConfiguration;
 
@@ -120,8 +119,9 @@ public class BaseCacheConfiguration<K, V> implements CacheConfiguration<K,V> {
   /**
    * {@inheritDoc}
    */
+  @SuppressWarnings("deprecation")
   @Override
-  public Expiry<? super K, ? super V> getExpiry() {
+  public org.ehcache.expiry.Expiry<? super K, ? super V> getExpiry() {
     return ExpiryUtils.convertToExpiry(expiry);
   }
 

--- a/core/src/main/java/org/ehcache/core/config/ExpiryUtils.java
+++ b/core/src/main/java/org/ehcache/core/config/ExpiryUtils.java
@@ -17,8 +17,6 @@
 package org.ehcache.core.config;
 
 import org.ehcache.ValueSupplier;
-import org.ehcache.expiry.Expirations;
-import org.ehcache.expiry.Expiry;
 import org.ehcache.expiry.ExpiryPolicy;
 
 import java.time.Duration;
@@ -29,21 +27,22 @@ import java.util.concurrent.TimeUnit;
 /**
  * ExpiryUtils
  */
+@SuppressWarnings("deprecation")
 public class ExpiryUtils {
 
   public static boolean isExpiryDurationInfinite(Duration duration) {
     return duration.compareTo(ExpiryPolicy.INFINITE) >= 0;
   }
 
-  public static <K, V> Expiry<K, V> convertToExpiry(ExpiryPolicy<K, V> expiryPolicy) {
+  public static <K, V> org.ehcache.expiry.Expiry<K, V> convertToExpiry(ExpiryPolicy<K, V> expiryPolicy) {
 
     if (expiryPolicy == ExpiryPolicy.NO_EXPIRY) {
       @SuppressWarnings("unchecked")
-      Expiry<K, V> expiry = (Expiry<K, V>) Expirations.noExpiration();
+      org.ehcache.expiry.Expiry<K, V> expiry = (org.ehcache.expiry.Expiry<K, V>) org.ehcache.expiry.Expirations.noExpiration();
       return expiry;
     }
 
-    return new Expiry<K, V>() {
+    return new org.ehcache.expiry.Expiry<K, V>() {
 
       @Override
       public org.ehcache.expiry.Duration getExpiryForCreation(K key, V value) {
@@ -100,8 +99,8 @@ public class ExpiryUtils {
     }
   }
 
-  public static <K, V> ExpiryPolicy<K, V> convertToExpiryPolicy(Expiry<K, V> expiry) {
-    if (expiry == Expirations.noExpiration()) {
+  public static <K, V> ExpiryPolicy<K, V> convertToExpiryPolicy(org.ehcache.expiry.Expiry<K, V> expiry) {
+    if (expiry == org.ehcache.expiry.Expirations.noExpiration()) {
       @SuppressWarnings("unchecked")
       ExpiryPolicy<K, V> expiryPolicy = (ExpiryPolicy<K, V>) ExpiryPolicy.NO_EXPIRY;
       return expiryPolicy;

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicCrudBase.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicCrudBase.java
@@ -220,7 +220,7 @@ public abstract class EhcacheBasicCrudBase {
   protected final <K, V> ResilienceStrategy<K, V> setResilienceStrategySpy(final InternalCache<K, V> ehcache) {
     assert ehcache != null;
     try {
-      final Field resilienceStrategyField = ehcache.getClass().getDeclaredField("resilienceStrategy");
+      final Field resilienceStrategyField = EhcacheBase.class.getDeclaredField("resilienceStrategy");
       resilienceStrategyField.setAccessible(true);
       @SuppressWarnings("unchecked")
       ResilienceStrategy<K, V> resilienceStrategy = (ResilienceStrategy<K, V>)resilienceStrategyField.get(ehcache);

--- a/impl/src/main/java/org/ehcache/config/builders/CacheConfigurationBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/CacheConfigurationBuilder.java
@@ -25,7 +25,6 @@ import org.ehcache.core.config.BaseCacheConfiguration;
 import org.ehcache.core.config.ExpiryUtils;
 import org.ehcache.core.config.store.StoreEventSourceConfiguration;
 import org.ehcache.core.spi.store.heap.SizeOfEngine;
-import org.ehcache.expiry.Expiry;
 import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 import org.ehcache.impl.config.event.DefaultCacheEventDispatcherConfiguration;
@@ -284,7 +283,7 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
   }
 
   /**
-   * Adds {@link Expiry} configuration to the returned builder.
+   * Adds {@link org.ehcache.expiry.Expiry} configuration to the returned builder.
    * <p>
    * {@code Expiry} is what controls data freshness in a cache.
    *
@@ -294,7 +293,7 @@ public class CacheConfigurationBuilder<K, V> implements Builder<CacheConfigurati
    * @deprecated Use {@link #withExpiry(ExpiryPolicy)} instead
    */
   @Deprecated
-  public CacheConfigurationBuilder<K, V> withExpiry(Expiry<? super K, ? super V> expiry) {
+  public CacheConfigurationBuilder<K, V> withExpiry(org.ehcache.expiry.Expiry<? super K, ? super V> expiry) {
     if (expiry == null) {
       throw new NullPointerException("Null expiry");
     }

--- a/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -46,7 +46,6 @@ import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.heap.SizeOfEngine;
 import org.ehcache.core.spi.store.heap.SizeOfEngineProvider;
 import org.ehcache.event.CacheEventListener;
-import org.ehcache.expiry.Expiry;
 import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 import org.ehcache.impl.config.serializer.DefaultSerializerConfiguration;
@@ -446,7 +445,7 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> imp
   }
 
   /**
-   * Adds {@link Expiry} configuration to the returned builder.
+   * Adds {@link org.ehcache.expiry.Expiry} configuration to the returned builder.
    *
    * @param expiry the expiry to use
    * @return a new builer with the added expiry
@@ -454,7 +453,7 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> imp
    * @deprecated Use {@link #withExpiry(ExpiryPolicy)} instead
    */
   @Deprecated
-  public final UserManagedCacheBuilder<K, V, T> withExpiry(Expiry<? super K, ? super V> expiry) {
+  public final UserManagedCacheBuilder<K, V, T> withExpiry(org.ehcache.expiry.Expiry<? super K, ? super V> expiry) {
     if (expiry == null) {
       throw new NullPointerException("Null expiry");
     }

--- a/impl/src/test/java/org/ehcache/config/builders/CacheManagerBuilderTest.java
+++ b/impl/src/test/java/org/ehcache/config/builders/CacheManagerBuilderTest.java
@@ -43,12 +43,15 @@ public class CacheManagerBuilderTest {
   @Test
   public void testIsExtensible() {
 
-    final AtomicInteger counter = new AtomicInteger(0);
+    AtomicInteger counter = new AtomicInteger(0);
 
-    final PersistentCacheManager cacheManager = newCacheManagerBuilder().with((CacheManagerConfiguration<PersistentCacheManager>) other -> {
+    @SuppressWarnings("unchecked")
+    CacheManagerConfiguration<PersistentCacheManager> managerConfiguration = other -> {
       counter.getAndIncrement();
       return mock(CacheManagerBuilder.class);
-    }).build(true);
+    };
+
+    PersistentCacheManager cacheManager = newCacheManagerBuilder().with(managerConfiguration).build(true);
 
     assertThat(cacheManager).isNull();
     assertThat(counter.get()).isEqualTo(1);

--- a/impl/src/test/java/org/ehcache/docs/Ehcache3.java
+++ b/impl/src/test/java/org/ehcache/docs/Ehcache3.java
@@ -21,14 +21,12 @@ import org.ehcache.ValueSupplier;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
-import org.ehcache.expiry.Duration;
-import org.ehcache.expiry.Expiry;
+import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.impl.internal.TimeSourceConfiguration;
 import org.ehcache.internal.TestTimeSource;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
-
+import java.time.Duration;
 
 public class Ehcache3 {
 
@@ -41,7 +39,7 @@ public class Ehcache3 {
     CacheConfigurationBuilder<Long, String> configuration =
         CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, ResourcePoolsBuilder
             .heap(100))
-            .withExpiry(new Expiry<Long, String>() {    // <1>
+            .withExpiry(new ExpiryPolicy<Long, String>() {    // <1>
               @Override
               public Duration getExpiryForCreation(Long key, String value) {
                 return getTimeToLiveDuration(key, value);   // <2>
@@ -80,11 +78,11 @@ public class Ehcache3 {
   private Duration getTimeToLiveDuration(Long key, String value) {
     // Returns TTL of 10 seconds for keys less than 1000
     if (key < 1000) {
-      return Duration.of(2, TimeUnit.SECONDS);
+      return Duration.ofSeconds(2);
     }
 
     // Otherwise return 5 seconds TTL
-    return Duration.of(1, TimeUnit.SECONDS);
+    return Duration.ofSeconds(5);
   }
 
 

--- a/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
@@ -33,7 +33,6 @@ import org.ehcache.core.internal.util.ClassLoading;
 import org.ehcache.event.CacheEventListener;
 import org.ehcache.event.EventFiring;
 import org.ehcache.event.EventOrdering;
-import org.ehcache.expiry.Expiry;
 import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.impl.config.copy.DefaultCopierConfiguration;
 import org.ehcache.impl.config.copy.DefaultCopyProviderConfiguration;
@@ -330,7 +329,7 @@ public class XmlConfiguration implements Configuration {
     templates.putAll(configurationParser.getTemplates());
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   private ExpiryPolicy<? super Object, ? super Object> getExpiry(ClassLoader cacheClassLoader, ConfigurationParser.Expiry parsedExpiry)
       throws ClassNotFoundException, InstantiationException, IllegalAccessException {
     final ExpiryPolicy<? super Object, ? super Object> expiry;
@@ -339,7 +338,7 @@ public class XmlConfiguration implements Configuration {
       try {
         tmpExpiry = getInstanceOfName(parsedExpiry.type(), cacheClassLoader, ExpiryPolicy.class);
       } catch (ClassCastException e) {
-        tmpExpiry = ExpiryUtils.convertToExpiryPolicy(getInstanceOfName(parsedExpiry.type(), cacheClassLoader, Expiry.class));
+        tmpExpiry = ExpiryUtils.convertToExpiryPolicy(getInstanceOfName(parsedExpiry.type(), cacheClassLoader, org.ehcache.expiry.Expiry.class));
       }
       expiry = tmpExpiry;
     } else if (parsedExpiry.isTTL()) {

--- a/xml/src/test/java/com/pany/ehcache/DeprecatedExpiry.java
+++ b/xml/src/test/java/com/pany/ehcache/DeprecatedExpiry.java
@@ -17,27 +17,26 @@
 package com.pany.ehcache;
 
 import org.ehcache.ValueSupplier;
-import org.ehcache.expiry.Duration;
-import org.ehcache.expiry.Expiry;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * @author Alex Snaps
  */
-public class DeprecatedExpiry implements Expiry<Object, Object> {
+@SuppressWarnings("deprecation")
+public class DeprecatedExpiry implements org.ehcache.expiry.Expiry<Object, Object> {
   @Override
-  public Duration getExpiryForCreation(final Object key, final Object value) {
-    return Duration.of(42, TimeUnit.SECONDS);
+  public org.ehcache.expiry.Duration getExpiryForCreation(final Object key, final Object value) {
+    return org.ehcache.expiry.Duration.of(42, TimeUnit.SECONDS);
   }
 
   @Override
-  public Duration getExpiryForAccess(final Object key, final ValueSupplier<? extends Object> value) {
-    return Duration.of(42, TimeUnit.SECONDS);
+  public org.ehcache.expiry.Duration getExpiryForAccess(final Object key, final ValueSupplier<? extends Object> value) {
+    return org.ehcache.expiry.Duration.of(42, TimeUnit.SECONDS);
   }
 
   @Override
-  public Duration getExpiryForUpdate(Object key, ValueSupplier<? extends Object> oldValue, Object newValue) {
-    return Duration.of(42, TimeUnit.SECONDS);
+  public org.ehcache.expiry.Duration getExpiryForUpdate(Object key, ValueSupplier<? extends Object> oldValue, Object newValue) {
+    return org.ehcache.expiry.Duration.of(42, TimeUnit.SECONDS);
   }
 }

--- a/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
@@ -211,8 +211,8 @@ public class XmlConfigurationTest {
   public void testExpiryIsParsed() throws Exception {
     final XmlConfiguration xmlConfiguration = new XmlConfiguration(XmlConfigurationTest.class.getResource("/configs/expiry-caches.xml"));
 
-    ExpiryPolicy expiry = xmlConfiguration.getCacheConfigurations().get("none").getExpiryPolicy();
-    ExpiryPolicy value = ExpiryPolicyBuilder.noExpiration();
+    ExpiryPolicy<?, ?> expiry = xmlConfiguration.getCacheConfigurations().get("none").getExpiryPolicy();
+    ExpiryPolicy<?, ?> value = ExpiryPolicyBuilder.noExpiration();
     assertThat(expiry, is(value));
 
     expiry = xmlConfiguration.getCacheConfigurations().get("notSet").getExpiryPolicy();


### PR DESCRIPTION
This is the first step to mutualize the code between Ehcache and EhcacheWithLoaderWriter. A lot more can be done but at least we now have a starting point. This mutualization will be highly useful for implementing resilience.