### PR TITLE
Replace ValueSupplier by Supplier

### DIFF
--- a/107/src/main/java/org/ehcache/jsr107/EhcacheExpiryWrapper.java
+++ b/107/src/main/java/org/ehcache/jsr107/EhcacheExpiryWrapper.java
@@ -15,10 +15,10 @@
  */
 package org.ehcache.jsr107;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.expiry.ExpiryPolicy;
 
 import java.time.Duration;
+import java.util.function.Supplier;
 
 /**
  * EhcacheExpiryWrapper
@@ -37,12 +37,12 @@ class EhcacheExpiryWrapper<K, V> extends Eh107Expiry<K, V> {
   }
 
   @Override
-  public Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
+  public Duration getExpiryForAccess(K key, Supplier<? extends V> value) {
     return wrappedExpiry.getExpiryForAccess(key, value);
   }
 
   @Override
-  public Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
+  public Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue) {
     return wrappedExpiry.getExpiryForUpdate(key, oldValue, newValue);
   }
 }

--- a/107/src/main/java/org/ehcache/jsr107/ExpiryPolicyToEhcacheExpiry.java
+++ b/107/src/main/java/org/ehcache/jsr107/ExpiryPolicyToEhcacheExpiry.java
@@ -15,11 +15,11 @@
  */
 package org.ehcache.jsr107;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.core.config.ExpiryUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
@@ -43,7 +43,7 @@ class ExpiryPolicyToEhcacheExpiry<K, V> extends Eh107Expiry<K, V> implements Clo
   }
 
   @Override
-  public java.time.Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
+  public java.time.Duration getExpiryForAccess(K key, Supplier<? extends V> value) {
     if (isShortCircuitAccessCalls()) {
       return null;
     }
@@ -60,7 +60,7 @@ class ExpiryPolicyToEhcacheExpiry<K, V> extends Eh107Expiry<K, V> implements Clo
   }
 
   @Override
-  public java.time.Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
+  public java.time.Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue) {
     try {
       Duration duration = expiryPolicy.getExpiryForUpdate();
       if (duration == null) {

--- a/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
+++ b/107/src/test/java/org/ehcache/docs/EhCache107ConfigurationIntegrationDocTest.java
@@ -22,7 +22,6 @@ import org.ehcache.config.CacheRuntimeConfiguration;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.core.config.DefaultConfiguration;
-import org.ehcache.core.internal.util.ValueSuppliers;
 import org.ehcache.impl.config.persistence.DefaultPersistenceConfiguration;
 import org.ehcache.jsr107.Eh107Configuration;
 import org.ehcache.jsr107.EhcacheCachingProvider;
@@ -131,9 +130,9 @@ public class EhCache107ConfigurationIntegrationDocTest {
     assertThat(runtimeConfiguration.getExpiryPolicy().getExpiryForCreation(random.nextLong(), Long.toOctalString(random.nextLong())),
                 equalTo(org.ehcache.expiry.ExpiryPolicy.INFINITE));
     assertThat(runtimeConfiguration.getExpiryPolicy().getExpiryForAccess(random.nextLong(),
-                  ValueSuppliers.supplierOf(Long.toOctalString(random.nextLong()))), nullValue());
+      () -> Long.toOctalString(random.nextLong())), nullValue());
     assertThat(runtimeConfiguration.getExpiryPolicy().getExpiryForUpdate(random.nextLong(),
-                  ValueSuppliers.supplierOf(Long.toOctalString(random.nextLong())), Long.toOctalString(random.nextLong())), nullValue());
+      () -> Long.toOctalString(random.nextLong()), Long.toOctalString(random.nextLong())), nullValue());
   }
 
   @Test

--- a/107/src/test/java/org/ehcache/jsr107/ConfigurationMergerTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/ConfigurationMergerTest.java
@@ -51,7 +51,6 @@ import javax.cache.integration.CacheWriter;
 
 import static org.ehcache.config.builders.CacheConfigurationBuilder.newCacheConfigurationBuilder;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.heap;
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -175,8 +174,8 @@ public class ConfigurationMergerTest {
     assertThat(factory.called, is(false));
     Eh107Expiry<Object, Object> expiryPolicy = configHolder.cacheResources.getExpiryPolicy();
     org.ehcache.expiry.ExpiryPolicy<? super Object, ? super Object> expiry = configHolder.cacheConfiguration.getExpiryPolicy();
-    assertThat(expiryPolicy.getExpiryForAccess(42, supplierOf("Yay")), is(expiry.getExpiryForAccess(42, supplierOf("Yay"))));
-    assertThat(expiryPolicy.getExpiryForUpdate(42, supplierOf("Yay"), "Lala"), is(expiry.getExpiryForUpdate(42, supplierOf("Yay"), "Lala")));
+    assertThat(expiryPolicy.getExpiryForAccess(42, () -> "Yay"), is(expiry.getExpiryForAccess(42, () -> "Yay")));
+    assertThat(expiryPolicy.getExpiryForUpdate(42, () -> "Yay", "Lala"), is(expiry.getExpiryForUpdate(42, () -> "Yay", "Lala")));
     assertThat(expiryPolicy.getExpiryForCreation(42, "Yay"), is(expiry.getExpiryForCreation(42, "Yay")));
   }
 

--- a/107/src/test/java/org/ehcache/jsr107/UnwrapTest.java
+++ b/107/src/test/java/org/ehcache/jsr107/UnwrapTest.java
@@ -77,7 +77,6 @@ public class UnwrapTest {
     assertThat(cacheEntryEvent.unwrap(cacheEntryEvent.getClass()), is(instanceOf(Eh107CacheEntryEvent.NormalEvent.class)));
   }
 
-  @SuppressWarnings("unchecked")
   private class EhEvent implements CacheEvent<String,String> {
     @Override
     public org.ehcache.event.EventType getType() {
@@ -99,8 +98,9 @@ public class UnwrapTest {
       throw new UnsupportedOperationException("Implement me!");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public org.ehcache.Cache getSource() {
+    public org.ehcache.Cache<String, String> getSource() {
       throw new UnsupportedOperationException("Implement me!");
     }
   }

--- a/api/src/main/java/org/ehcache/ValueSupplier.java
+++ b/api/src/main/java/org/ehcache/ValueSupplier.java
@@ -22,7 +22,11 @@ package org.ehcache;
  * This indicates that the value needs to be computed before it can be retrieved, such as deserialization.
  *
  * @param <V> the value type
+ *
+ * @deprecated Now using {@code Supplier} for {@link org.ehcache.expiry.ExpiryPolicy}
  */
+@Deprecated
+@FunctionalInterface
 public interface ValueSupplier<V> {
 
   /**

--- a/api/src/main/java/org/ehcache/expiry/ExpiryPolicy.java
+++ b/api/src/main/java/org/ehcache/expiry/ExpiryPolicy.java
@@ -16,24 +16,22 @@
 
 package org.ehcache.expiry;
 
-import org.ehcache.ValueSupplier;
-
 import java.time.Duration;
+import java.util.function.Supplier;
 
 /**
  * A policy object that governs expiration for mappings in a {@link org.ehcache.Cache Cache}.
  * <p>
- * Previous values are not accessible directly but are rather available through a {@link ValueSupplier value supplier}
+ * Previous values are not accessible directly but are rather available through a value {@code Supplier}
  * to indicate that access can require computation (such as deserialization).
  * <p>
  * {@link Duration#isNegative() Negative duration} are not supported, expiry policy implementation returning such a
  * duration will result in immediate expiry, as if the duration was {@link Duration#ZERO zero}.
  * <p>
  * NOTE: Some cache configurations (eg. caches with eventual consistency) may use local (ie. non-consistent) state
- * to decide whether to call {@link #getExpiryForUpdate(Object, ValueSupplier, Object)}  vs.
+ * to decide whether to call {@link #getExpiryForUpdate(Object, Supplier, Object)}  vs.
  * {@link #getExpiryForCreation(Object, Object)}. For these cache configurations it is advised to return the same
  * value for both of these methods
- * <p>
  *
  * @param <K> the key type for the cache
  * @param <V> the value type for the cache
@@ -56,12 +54,12 @@ public interface ExpiryPolicy<K, V> {
     }
 
     @Override
-    public Duration getExpiryForAccess(Object key, ValueSupplier<?> value) {
+    public Duration getExpiryForAccess(Object key, Supplier<?> value) {
       return null;
     }
 
     @Override
-    public Duration getExpiryForUpdate(Object key, ValueSupplier<?> oldValue, Object newValue) {
+    public Duration getExpiryForUpdate(Object key, Supplier<?> oldValue, Object newValue) {
       return null;
     }
   };
@@ -93,7 +91,7 @@ public interface ExpiryPolicy<K, V> {
    * @param value a value supplier for the accessed entry
    * @return an expiration {@code Duration}, {@code null} means unchanged
    */
-  Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value);
+  Duration getExpiryForAccess(K key, Supplier<? extends V> value);
 
 
   /**
@@ -110,6 +108,6 @@ public interface ExpiryPolicy<K, V> {
    * @param newValue the new value of the entry
    * @return an expiration {@code Duration}, {@code null} means unchanged
    */
-  Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue);
+  Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue);
 
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredValueHolder.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredValueHolder.java
@@ -44,7 +44,7 @@ public class ClusteredValueHolder<V> extends AbstractValueHolder<V> {
   }
 
   @Override
-  public V value() {
+  public V get() {
     return value;
   }
 }

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
@@ -139,7 +139,7 @@ public class ClusteredStoreTest {
     assertThat(store.get(1L), nullValue());
     validateStats(store, EnumSet.of(StoreOperationOutcomes.GetOutcome.MISS));
     store.put(1L, "one");
-    assertThat(store.get(1L).value(), is("one"));
+    assertThat(store.get(1L).get(), is("one"));
     validateStats(store, EnumSet.of(StoreOperationOutcomes.GetOutcome.MISS, StoreOperationOutcomes.GetOutcome.HIT));
   }
 
@@ -318,7 +318,7 @@ public class ClusteredStoreTest {
   public void testPutIfAbsent() throws Exception {
     assertThat(store.putIfAbsent(1L, "one"), nullValue());
     validateStats(store, EnumSet.of(StoreOperationOutcomes.PutIfAbsentOutcome.PUT));
-    assertThat(store.putIfAbsent(1L, "another one").value(), is("one"));
+    assertThat(store.putIfAbsent(1L, "another one").get(), is("one"));
     validateStats(store, EnumSet.of(StoreOperationOutcomes.PutIfAbsentOutcome.PUT, StoreOperationOutcomes.PutIfAbsentOutcome.HIT));
   }
 
@@ -387,7 +387,7 @@ public class ClusteredStoreTest {
     assertThat(store.replace(1L, "one"), nullValue());
     validateStats(store, EnumSet.of(StoreOperationOutcomes.ReplaceOutcome.MISS));
     store.put(1L, "one");
-    assertThat(store.replace(1L, "another one").value(), is("one"));
+    assertThat(store.replace(1L, "another one").get(), is("one"));
     validateStats(store, EnumSet.of(StoreOperationOutcomes.ReplaceOutcome.MISS, StoreOperationOutcomes.ReplaceOutcome.REPLACED));
   }
 
@@ -461,10 +461,10 @@ public class ClusteredStoreTest {
     Ehcache.PutAllFunction<Long, String> putAllFunction = new Ehcache.PutAllFunction<>(null, map, null);
     Map<Long, Store.ValueHolder<String>> valueHolderMap = store.bulkCompute(new HashSet<>(Arrays.asList(1L, 2L)), putAllFunction);
 
-    assertThat(valueHolderMap.get(1L).value(), is(map.get(1L)));
-    assertThat(store.get(1L).value(), is(map.get(1L)));
-    assertThat(valueHolderMap.get(2L).value(), is(map.get(2L)));
-    assertThat(store.get(2L).value(), is(map.get(2L)));
+    assertThat(valueHolderMap.get(1L).get(), is(map.get(1L)));
+    assertThat(store.get(1L).get(), is(map.get(1L)));
+    assertThat(valueHolderMap.get(2L).get(), is(map.get(2L)));
+    assertThat(store.get(2L).get(), is(map.get(2L)));
     assertThat(putAllFunction.getActualPutCount().get(), is(2));
     validateStats(store, EnumSet.of(StoreOperationOutcomes.PutOutcome.PUT));  //outcome of the initial store put
   }
@@ -501,10 +501,10 @@ public class ClusteredStoreTest {
     Ehcache.GetAllFunction<Long, String> getAllAllFunction = new Ehcache.GetAllFunction<>();
     Map<Long, Store.ValueHolder<String>> valueHolderMap = store.bulkComputeIfAbsent(new HashSet<>(Arrays.asList(1L, 2L)), getAllAllFunction);
 
-    assertThat(valueHolderMap.get(1L).value(), is("one"));
-    assertThat(store.get(1L).value(), is("one"));
-    assertThat(valueHolderMap.get(2L).value(), is("two"));
-    assertThat(store.get(2L).value(), is("two"));
+    assertThat(valueHolderMap.get(1L).get(), is("one"));
+    assertThat(store.get(1L).get(), is("one"));
+    assertThat(valueHolderMap.get(2L).get(), is("two"));
+    assertThat(store.get(2L).get(), is("two"));
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/ExpiryChainResolverExpiryTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/operations/ExpiryChainResolverExpiryTest.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.clustered.client.internal.store.operations;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.clustered.client.TestTimeSource;
 import org.ehcache.clustered.client.internal.store.ChainBuilder;
 import org.ehcache.clustered.client.internal.store.ResolvedChain;
@@ -75,9 +74,9 @@ public class ExpiryChainResolverExpiryTest {
 
     ResolvedChain<Long, String> resolvedChain = chainResolver.resolve(chain, 1L, timeSource.getTimeMillis());
 
-    verify(expiry, times(0)).getExpiryForAccess(anyLong(), any(ValueSupplier.class));
+    verify(expiry, times(0)).getExpiryForAccess(anyLong(), any());
     verify(expiry, times(1)).getExpiryForCreation(anyLong(), anyString());
-    verify(expiry, times(1)).getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString());
+    verify(expiry, times(1)).getExpiryForUpdate(anyLong(), any(), anyString());
 
     assertThat(resolvedChain.isCompacted(), is(true));
   }
@@ -103,7 +102,7 @@ public class ExpiryChainResolverExpiryTest {
     InOrder inOrder = inOrder(expiry);
 
     inOrder.verify(expiry, times(1)).getExpiryForCreation(anyLong(), anyString());
-    inOrder.verify(expiry, times(3)).getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString());
+    inOrder.verify(expiry, times(3)).getExpiryForUpdate(anyLong(), any(), anyString());
 
     assertThat(resolvedChain.isCompacted(), is(true));
   }
@@ -126,7 +125,7 @@ public class ExpiryChainResolverExpiryTest {
 
     ResolvedChain<Long, String> resolvedChain = chainResolver.resolve(chain, 1L, timeSource.getTimeMillis());
     verify(expiry, times(0)).getExpiryForCreation(anyLong(), anyString());
-    verify(expiry, times(3)).getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString());
+    verify(expiry, times(3)).getExpiryForUpdate(anyLong(), any(), anyString());
 
     assertThat(resolvedChain.isCompacted(), is(true));
   }
@@ -152,8 +151,8 @@ public class ExpiryChainResolverExpiryTest {
 
     InOrder inOrder = inOrder(expiry);
 
-    verify(expiry, times(0)).getExpiryForAccess(anyLong(), any(ValueSupplier.class));
-    inOrder.verify(expiry, times(1)).getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString());
+    verify(expiry, times(0)).getExpiryForAccess(anyLong(), any());
+    inOrder.verify(expiry, times(1)).getExpiryForUpdate(anyLong(), any(), anyString());
     inOrder.verify(expiry, times(1)).getExpiryForCreation(anyLong(), anyString());
 
     assertThat(resolvedChain.isCompacted(), is(true));
@@ -174,9 +173,9 @@ public class ExpiryChainResolverExpiryTest {
 
     inOrder = inOrder(expiry);
 
-    verify(expiry, times(0)).getExpiryForAccess(anyLong(), any(ValueSupplier.class));
+    verify(expiry, times(0)).getExpiryForAccess(anyLong(), any());
     inOrder.verify(expiry, times(1)).getExpiryForCreation(anyLong(), anyString());
-    inOrder.verify(expiry, times(1)).getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString());
+    inOrder.verify(expiry, times(1)).getExpiryForUpdate(anyLong(), any(), anyString());
     inOrder.verify(expiry, times(1)).getExpiryForCreation(anyLong(), anyString());
 
     assertThat(resolvedChain.isCompacted(), is(true));
@@ -207,7 +206,7 @@ public class ExpiryChainResolverExpiryTest {
     ExpiryPolicy<Long, String> expiry = mock(ExpiryPolicy.class);
     ExpiryChainResolver<Long, String> chainResolver = new ExpiryChainResolver<>(codec, expiry);
 
-    when(expiry.getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString())).thenReturn(null);
+    when(expiry.getExpiryForUpdate(anyLong(), any(), anyString())).thenReturn(null);
 
     List<Operation<Long, String>> list = new ArrayList<>();
     list.add(new PutOperation<>(1L, "Replaced", -10L));
@@ -228,7 +227,7 @@ public class ExpiryChainResolverExpiryTest {
     ExpiryPolicy<Long, String> expiry = mock(ExpiryPolicy.class);
     ExpiryChainResolver<Long, String> chainResolver = new ExpiryChainResolver<>(codec, expiry);
 
-    when(expiry.getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString())).thenReturn(Duration.ofMillis(2L));
+    when(expiry.getExpiryForUpdate(anyLong(), any(), anyString())).thenReturn(Duration.ofMillis(2L));
 
     List<Operation<Long, String>> list = new ArrayList<>();
     list.add(new PutOperation<>(1L, "Replaced", -10L));
@@ -249,7 +248,7 @@ public class ExpiryChainResolverExpiryTest {
     ExpiryPolicy<Long, String> expiry = mock(ExpiryPolicy.class);
     ExpiryChainResolver<Long, String> chainResolver = new ExpiryChainResolver<>(codec, expiry);
 
-    when(expiry.getExpiryForUpdate(anyLong(), any(ValueSupplier.class), anyString())).thenThrow(new RuntimeException("Test Update Expiry"));
+    when(expiry.getExpiryForUpdate(anyLong(), any(), anyString())).thenThrow(new RuntimeException("Test Update Expiry"));
     when(expiry.getExpiryForCreation(anyLong(), anyString())).thenThrow(new RuntimeException("Test Create Expiry"));
 
     List<Operation<Long, String>> list = new ArrayList<>();

--- a/core-spi-test/src/main/java/org/ehcache/internal/TestExpiries.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/TestExpiries.java
@@ -16,10 +16,10 @@
 
 package org.ehcache.internal;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.expiry.ExpiryPolicy;
 
 import java.time.Duration;
+import java.util.function.Supplier;
 
 /**
  * TestExpiries
@@ -34,12 +34,12 @@ public class TestExpiries {
       }
 
       @Override
-      public Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
+      public Duration getExpiryForAccess(K key, Supplier<? extends V> value) {
         return duration;
       }
 
       @Override
-      public Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
+      public Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue) {
         return duration;
       }
     };
@@ -53,12 +53,12 @@ public class TestExpiries {
       }
 
       @Override
-      public Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
+      public Duration getExpiryForAccess(K key, Supplier<? extends V> value) {
         return null;
       }
 
       @Override
-      public Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
+      public Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue) {
         return duration;
       }
     };
@@ -72,12 +72,12 @@ public class TestExpiries {
       }
 
       @Override
-      public Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
+      public Duration getExpiryForAccess(K key, Supplier<? extends V> value) {
         return access;
       }
 
       @Override
-      public Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
+      public Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue) {
         return update;
       }
     };

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeIfAbsentTest.java
@@ -103,7 +103,7 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.bulkComputeIfAbsent(inputKeys, entries -> emptySet());
 
       for (Map.Entry<K, V> mappedEntry : mappedEntries.entrySet()) {
-        assertThat(kvStore.get(mappedEntry.getKey()).value(), is(mappedEntry.getValue()));
+        assertThat(kvStore.get(mappedEntry.getKey()).get(), is(mappedEntry.getValue()));
       }
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
@@ -137,7 +137,7 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       });
 
       for (Map.Entry<K, V> mappedEntry : mappedEntries.entrySet()) {
-        assertThat(kvStore.get(mappedEntry.getKey()).value(), is(mappedEntry.getValue()));
+        assertThat(kvStore.get(mappedEntry.getKey()).get(), is(mappedEntry.getValue()));
       }
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
@@ -192,7 +192,7 @@ public class StoreBulkComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
       });
 
       for (Map.Entry<K, V> entry : computedEntries.entrySet()) {
-        assertThat(kvStore.get(entry.getKey()).value(), is(entry.getValue()));
+        assertThat(kvStore.get(entry.getKey()).get(), is(entry.getValue()));
       }
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -204,7 +204,7 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
       });
 
       for (K inputKey : inputKeys) {
-        assertThat(kvStore.get(inputKey).value(), is(computedEntries.get(inputKey)));
+        assertThat(kvStore.get(inputKey).get(), is(computedEntries.get(inputKey)));
       }
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeIfAbsentTest.java
@@ -128,7 +128,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     assertThat(kvStore.get(key), nullValue());
     try {
       kvStore.computeIfAbsent(key, keyParam -> value);
-      assertThat(kvStore.get(key).value(), is(value));
+      assertThat(kvStore.get(key).get(), is(value));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -151,7 +151,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
-    assertThat(kvStore.get(key).value(), is(value));
+    assertThat(kvStore.get(key).get(), is(value));
   }
 
   @SPITest
@@ -212,7 +212,7 @@ public class StoreComputeIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
         fail("Should not be invoked");
         return newValue;
       });
-      assertThat(result.value(), is(value));
+      assertThat(result.get(), is(value));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreComputeTest.java
@@ -125,7 +125,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
 
     try {
       kvStore.compute(key, (keyParam, oldValue) -> value);
-      assertThat(kvStore.get(key).value(), is(value));
+      assertThat(kvStore.get(key).get(), is(value));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -144,7 +144,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.put(key, value);
       kvStore.compute(key, (keyParam, oldValue) -> value2);
-      assertThat(kvStore.get(key).value(), is(value2));
+      assertThat(kvStore.get(key).get(), is(value2));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -177,7 +177,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
 
     try {
       kvStore.put(key, value);
-      assertThat(kvStore.get(key).value(), is(value));
+      assertThat(kvStore.get(key).get(), is(value));
 
       kvStore.compute(key, (keyParam, oldValue) -> {
         throw re;
@@ -188,7 +188,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
 
-    assertThat(kvStore.get(key).value(), is(value));
+    assertThat(kvStore.get(key).get(), is(value));
   }
 
   @SPITest
@@ -203,7 +203,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.put(key, value);
 
       Store.ValueHolder<V> result = kvStore.compute(key, (k, v) -> v, () -> false);
-      assertThat(result.value(), is(value));
+      assertThat(result.get(), is(value));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -222,7 +222,7 @@ public class StoreComputeTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.put(key, value);
 
       Store.ValueHolder<V> result = kvStore.compute(key, (k, v) -> newValue, () -> false);
-      assertThat(result.value(), is(newValue));
+      assertThat(result.get(), is(newValue));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEvictionEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreEvictionEventListenerTest.java
@@ -89,7 +89,7 @@ public class StoreEvictionEventListenerTest<K, V> extends SPIStoreTester<K, V> {
     kvStore.put(k2, v2);
     verifyListenerInteractions(listener);
     kvStore.replace(getOnlyKey(kvStore.iterator()), v3);
-    assertThat(kvStore.get(getOnlyKey(kvStore.iterator())).value(), is(v3));
+    assertThat(kvStore.get(getOnlyKey(kvStore.iterator())).get(), is(v3));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreExpiryEventListenerTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreExpiryEventListenerTest.java
@@ -137,7 +137,7 @@ public class StoreExpiryEventListenerTest<K, V> extends SPIStoreTester<K, V> {
     kvStore.put(k, v);
     StoreEventListener<K, V> listener = addListener(kvStore);
     timeSource.advanceTime(1);
-    assertThat(kvStore.compute(k, (mappedKey, mappedValue) -> v2).value(), is(v2));
+    assertThat(kvStore.compute(k, (mappedKey, mappedValue) -> v2).get(), is(v2));
     verifyListenerInteractions(listener);
   }
 
@@ -147,7 +147,7 @@ public class StoreExpiryEventListenerTest<K, V> extends SPIStoreTester<K, V> {
     StoreEventListener<K, V> listener = addListener(kvStore);
     timeSource.advanceTime(1);
 
-    assertThat(kvStore.computeIfAbsent(k, mappedKey -> v2).value(), is(v2));
+    assertThat(kvStore.computeIfAbsent(k, mappedKey -> v2).get(), is(v2));
     verifyListenerInteractions(listener);
   }
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -108,7 +108,7 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
     kvStore.put(key, value);
 
     try {
-      assertThat(kvStore.get(key).value(), is(equalTo(value)));
+      assertThat(kvStore.get(key).get(), is(equalTo(value)));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -161,7 +161,7 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
 
     try {
       kvStore.put(key, value);
-      assertThat(kvStore.get(key).value(), is(value));
+      assertThat(kvStore.get(key).get(), is(value));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorNextTest.java
@@ -66,7 +66,7 @@ public class StoreIteratorNextTest<K, V> extends SPIStoreTester<K, V> {
     try {
       Cache.Entry<K, Store.ValueHolder<V>> entry = iterator.next();
       assertThat(entry.getKey(), is(equalTo(key)));
-      assertThat(entry.getValue().value(), is(equalTo(value)));
+      assertThat(entry.getValue().get(), is(equalTo(value)));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreIteratorTest.java
@@ -80,7 +80,7 @@ public class StoreIteratorTest<K, V> extends SPIStoreTester<K, V> {
     while (iterator.hasNext()) {
       Cache.Entry<K, Store.ValueHolder<V>> nextEntry = iterator.next();
       keys.add(nextEntry.getKey());
-      values.add(nextEntry.getValue().value());
+      values.add(nextEntry.getValue().get());
     }
     assertThat(keys, containsInAnyOrder(equalTo(key1), equalTo(key2), equalTo(key3)));
     assertThat(values, containsInAnyOrder(equalTo(value1), equalTo(value2), equalTo(value3)));

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -94,7 +94,7 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
     V updatedValue = factory.createValue(2);
 
     try {
-      assertThat(kvStore.putIfAbsent(key, updatedValue).value(), is(equalTo(value)));
+      assertThat(kvStore.putIfAbsent(key, updatedValue).get(), is(equalTo(value)));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -187,7 +187,7 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
     try {
       kvStore.put(key, value);
-      assertThat(kvStore.putIfAbsent(key, newValue).value(), is(value));
+      assertThat(kvStore.putIfAbsent(key, newValue).get(), is(value));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -75,7 +75,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
 
-    assertThat(kvStore.get(key).value(), is(equalTo(newValue)));
+    assertThat(kvStore.get(key).get(), is(equalTo(newValue)));
   }
 
   @SPITest
@@ -91,7 +91,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     V newValue = factory.createValue(2);
 
     try {
-      assertThat(kvStore.replace(key, newValue).value(), is(equalTo(originalValue)));
+      assertThat(kvStore.replace(key, newValue).get(), is(equalTo(originalValue)));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueValueTest.java
@@ -77,7 +77,7 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
 
-    assertThat(kvStore.get(key).value(), is(equalTo(newValue)));
+    assertThat(kvStore.get(key).get(), is(equalTo(newValue)));
   }
 
   @SPITest
@@ -99,7 +99,7 @@ public class StoreReplaceKeyValueValueTest<K, V> extends SPIStoreTester<K, V> {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
 
-    assertThat(kvStore.get(key).value(), is(not(equalTo(wrongValue))));
+    assertThat(kvStore.get(key).get(), is(not(equalTo(wrongValue))));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreValueHolderValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreValueHolderValueTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 
 /**
- * Test the {@link Store.ValueHolder#value()} contract of the
+ * Test the {@link Store.ValueHolder#get(Object)} contract of the
  * {@link Store.ValueHolder Store.ValueHolder} interface.
  *
  * @author Aurelien Broszniowski
@@ -43,7 +43,7 @@ public class StoreValueHolderValueTest<K, V> extends SPIStoreTester<K, V> {
     Store.ValueHolder<V> valueHolder = factory.newValueHolder(value);
 
     try {
-      assertThat(valueHolder.value(), is(equalTo(value)));
+      assertThat(valueHolder.get(), is(equalTo(value)));
     } catch (Exception e) {
       System.err.println("Warning, an exception is thrown due to the SPI test");
       e.printStackTrace();

--- a/core-spi-test/src/main/java/org/ehcache/internal/tier/AuthoritativeTierComputeIfAbsentAndFault.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/tier/AuthoritativeTierComputeIfAbsentAndFault.java
@@ -81,10 +81,10 @@ public class AuthoritativeTierComputeIfAbsentAndFault<K, V> extends SPIAuthorita
 
     try {
       assertThat(tier.get(key), is(nullValue()));
-      assertThat(tier.computeIfAbsentAndFault(key, k -> factory.createValue(1L)).value(), is(equalTo(value)));
+      assertThat(tier.computeIfAbsentAndFault(key, k -> factory.createValue(1L)).get(), is(equalTo(value)));
 
       fillTierOverCapacity(tier, factory);
-      assertThat(tier.get(key).value(), is(equalTo(value)));
+      assertThat(tier.get(key).get(), is(equalTo(value)));
 
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");

--- a/core-spi-test/src/main/java/org/ehcache/internal/tier/AuthoritativeTierGetAndFault.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/tier/AuthoritativeTierGetAndFault.java
@@ -86,11 +86,11 @@ public class AuthoritativeTierGetAndFault<K, V> extends SPIAuthoritativeTierTest
 
     try {
       tier.put(key, value);
-      assertThat(tier.getAndFault(key).value(), is(equalTo(value)));
+      assertThat(tier.getAndFault(key).get(), is(equalTo(value)));
 
       fillTierOverCapacity(tier, factory);
 
-      assertThat(tier.get(key).value(), is(equalTo(value)));
+      assertThat(tier.get(key).get(), is(equalTo(value)));
 
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");

--- a/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierClear.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierClear.java
@@ -66,7 +66,7 @@ public class CachingTierClear<K, V> extends CachingTierTester<K, V> {
     V newValue= factory.createValue(2);
 
     final Store.ValueHolder<V> originalValueHolder = mock(Store.ValueHolder.class);
-    when(originalValueHolder.value()).thenReturn(originalValue);
+    when(originalValueHolder.get()).thenReturn(originalValue);
 
     try {
       List<K> keys = new ArrayList<>();
@@ -80,13 +80,13 @@ public class CachingTierClear<K, V> extends CachingTierTester<K, V> {
       tier.clear();
 
       final Store.ValueHolder<V> newValueHolder = mock(Store.ValueHolder.class);
-      when(newValueHolder.value()).thenReturn(newValue);
+      when(newValueHolder.get()).thenReturn(newValue);
 
       for (K key : keys) {
         tier.invalidate(key);
         Store.ValueHolder<V> newReturnedValueHolder = tier.getOrComputeIfAbsent(key, o -> newValueHolder);
 
-        assertThat(newReturnedValueHolder.value(), is(equalTo(newValueHolder.value())));
+        assertThat(newReturnedValueHolder.get(), is(equalTo(newValueHolder.get())));
       }
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");

--- a/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierGetOrComputeIfAbsent.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierGetOrComputeIfAbsent.java
@@ -64,14 +64,14 @@ public class CachingTierGetOrComputeIfAbsent<K, V> extends CachingTierTester<K, 
     V value = factory.createValue(1);
 
     final Store.ValueHolder<V> computedValueHolder = mock(Store.ValueHolder.class);
-    when(computedValueHolder.value()).thenReturn(value);
+    when(computedValueHolder.get()).thenReturn(value);
 
     tier = factory.newCachingTier(1L);
 
     try {
       Store.ValueHolder<V> valueHolder = tier.getOrComputeIfAbsent(key, k -> computedValueHolder);
 
-      assertThat(valueHolder.value(), is(equalTo(value)));
+      assertThat(valueHolder.get(), is(equalTo(value)));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }
@@ -83,7 +83,7 @@ public class CachingTierGetOrComputeIfAbsent<K, V> extends CachingTierTester<K, 
     K key = factory.createKey(1);
     V value = factory.createValue(1);
     final Store.ValueHolder<V> computedValueHolder = mock(Store.ValueHolder.class);
-    when(computedValueHolder.value()).thenReturn(value);
+    when(computedValueHolder.get()).thenReturn(value);
     when(computedValueHolder.expirationTime(any(TimeUnit.class))).thenReturn(Store.ValueHolder.NO_EXPIRE);
 
     tier = factory.newCachingTier();
@@ -94,7 +94,7 @@ public class CachingTierGetOrComputeIfAbsent<K, V> extends CachingTierTester<K, 
 
       Store.ValueHolder<V> valueHolder = tier.getOrComputeIfAbsent(key, k -> null);
 
-      assertThat(valueHolder.value(), is(equalTo(value)));
+      assertThat(valueHolder.get(), is(equalTo(value)));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierInvalidate.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierInvalidate.java
@@ -64,7 +64,7 @@ public class CachingTierInvalidate<K, V> extends CachingTierTester<K, V> {
       // register invalidation listener
       final AtomicBoolean invalidated = new AtomicBoolean(false);
       tier.setInvalidationListener((key1, valueHolder) -> {
-        assertThat(valueHolder.value(), is(value));
+        assertThat(valueHolder.get(), is(value));
         invalidated.set(true);
       });
 
@@ -132,7 +132,7 @@ public class CachingTierInvalidate<K, V> extends CachingTierTester<K, V> {
   private Store.ValueHolder<V> wrap(final V value) {
     return new Store.ValueHolder<V>() {
       @Override
-      public V value() {
+      public V get() {
         return value;
       }
 

--- a/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierRemove.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/tier/CachingTierRemove.java
@@ -61,7 +61,7 @@ public class CachingTierRemove<K, V> extends CachingTierTester<K, V> {
     V newValue = factory.createValue(2);
 
     final Store.ValueHolder<V> valueHolder = mock(Store.ValueHolder.class);
-    when(valueHolder.value()).thenReturn(originalValue);
+    when(valueHolder.get()).thenReturn(originalValue);
 
     tier = factory.newCachingTier(1L);
 
@@ -71,10 +71,10 @@ public class CachingTierRemove<K, V> extends CachingTierTester<K, V> {
       tier.invalidate(key);
 
       final Store.ValueHolder<V> newValueHolder = mock(Store.ValueHolder.class);
-      when(newValueHolder.value()).thenReturn(newValue);
+      when(newValueHolder.get()).thenReturn(newValue);
       Store.ValueHolder<V> newReturnedValueHolder = tier.getOrComputeIfAbsent(key, o -> newValueHolder);
 
-      assertThat(newReturnedValueHolder.value(), is(equalTo(newValueHolder.value())));
+      assertThat(newReturnedValueHolder.get(), is(equalTo(newValueHolder.get())));
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
     }

--- a/core/src/main/java/org/ehcache/core/Ehcache.java
+++ b/core/src/main/java/org/ehcache/core/Ehcache.java
@@ -159,7 +159,7 @@ public class Ehcache<K, V> extends EhcacheBase<K, V> {
       for (Map.Entry<K, Store.ValueHolder<V>> entry : computedMap.entrySet()) {
         keyCount++;
         if (entry.getValue() != null) {
-          result.put(entry.getKey(), entry.getValue().value());
+          result.put(entry.getKey(), entry.getValue().get());
           hits++;
         } else if (includeNulls) {
           result.put(entry.getKey(), null);
@@ -268,7 +268,7 @@ public class Ehcache<K, V> extends EhcacheBase<K, V> {
         return null;
       } else {
         putIfAbsentObserver.end(PutIfAbsentOutcome.HIT);
-        return inCache.value();
+        return inCache.get();
       }
     } catch (StoreAccessException e) {
       try {
@@ -331,7 +331,7 @@ public class Ehcache<K, V> extends EhcacheBase<K, V> {
       } else {
         replaceObserver.end(ReplaceOutcome.MISS_NOT_PRESENT);
       }
-      return old == null ? null : old.value();
+      return old == null ? null : old.get();
     } catch (StoreAccessException e) {
       try {
         return resilienceStrategy.replaceFailure(key, value, e);

--- a/core/src/main/java/org/ehcache/core/EhcacheBase.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheBase.java
@@ -58,7 +58,6 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 import static org.ehcache.core.exceptions.ExceptionFactory.newCacheLoadingException;
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 import static org.terracotta.statistics.StatisticBuilder.operation;
 
 /**
@@ -158,7 +157,7 @@ public abstract class EhcacheBase<K, V> implements InternalCache<K, V> {
         return null;
       } else {
         getObserver.end(GetOutcome.HIT);
-        return valueHolder.value();
+        return valueHolder.get();
       }
     } catch (StoreAccessException e) {
       try {
@@ -243,7 +242,7 @@ public abstract class EhcacheBase<K, V> implements InternalCache<K, V> {
       if (oldValue == null) {
         duration = expiry.getExpiryForCreation(key, newValue);
       } else {
-        duration = expiry.getExpiryForUpdate(key, supplierOf(oldValue), newValue);
+        duration = expiry.getExpiryForUpdate(key, () -> oldValue, newValue);
       }
     } catch (RuntimeException re) {
       logger.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
@@ -476,7 +475,7 @@ public abstract class EhcacheBase<K, V> implements InternalCache<K, V> {
       if (current == null) {
         throw new IllegalStateException("No current element");
       }
-      EhcacheBase.this.remove(current.getKey(), current.getValue().value());
+      EhcacheBase.this.remove(current.getKey(), current.getValue().get());
       current = null;
     }
   }
@@ -495,7 +494,7 @@ public abstract class EhcacheBase<K, V> implements InternalCache<K, V> {
 
     @Override
     public V getValue() {
-      return storeEntry.getValue().value();
+      return storeEntry.getValue().get();
     }
 
   }

--- a/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheWithLoaderWriter.java
@@ -142,7 +142,7 @@ public class EhcacheWithLoaderWriter<K, V> extends EhcacheBase<K, V> {
         return null;
       } else {
         getObserver.end(GetOutcome.HIT);
-        return valueHolder.value();
+        return valueHolder.get();
       }
     } catch (StoreAccessException e) {
       try {
@@ -288,7 +288,7 @@ public class EhcacheWithLoaderWriter<K, V> extends EhcacheBase<K, V> {
       for (Map.Entry<K, Store.ValueHolder<V>> entry : computedMap.entrySet()) {
         keyCount++;
         if (entry.getValue() != null) {
-          result.put(entry.getKey(), entry.getValue().value());
+          result.put(entry.getKey(), entry.getValue().get());
           hits++;
         } else if (includeNulls && failures.isEmpty()) {
           result.put(entry.getKey(), null);
@@ -602,7 +602,7 @@ public class EhcacheWithLoaderWriter<K, V> extends EhcacheBase<K, V> {
         return null;
       } else {
         putIfAbsentObserver.end(PutIfAbsentOutcome.HIT);
-        return inCache.value();
+        return inCache.get();
       }
     } catch (StoreAccessException e) {
       try {

--- a/core/src/main/java/org/ehcache/core/SpecIterator.java
+++ b/core/src/main/java/org/ehcache/core/SpecIterator.java
@@ -59,7 +59,7 @@ class SpecIterator<K, V> implements Iterator<Cache.Entry<K, V>> {
 
       current = next;
 
-      final V nextValue = nextValueHolder.value();
+      final V nextValue = nextValueHolder.get();
       return new Cache.Entry<K, V>() {
         @Override
         public K getKey() {

--- a/core/src/main/java/org/ehcache/core/config/ExpiryUtils.java
+++ b/core/src/main/java/org/ehcache/core/config/ExpiryUtils.java
@@ -16,13 +16,13 @@
 
 package org.ehcache.core.config;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.expiry.ExpiryPolicy;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * ExpiryUtils
@@ -50,13 +50,13 @@ public class ExpiryUtils {
       }
 
       @Override
-      public org.ehcache.expiry.Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
-        return convertDuration(expiryPolicy.getExpiryForAccess(key, value));
+      public org.ehcache.expiry.Duration getExpiryForAccess(K key, org.ehcache.ValueSupplier<? extends V> value) {
+        return convertDuration(expiryPolicy.getExpiryForAccess(key, () -> value.value()));
       }
 
       @Override
-      public org.ehcache.expiry.Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
-        return convertDuration(expiryPolicy.getExpiryForUpdate(key, oldValue, newValue));
+      public org.ehcache.expiry.Duration getExpiryForUpdate(K key, org.ehcache.ValueSupplier<? extends V> oldValue, V newValue) {
+        return convertDuration(expiryPolicy.getExpiryForUpdate(key, () -> oldValue.value(), newValue));
       }
 
       @Override
@@ -114,14 +114,14 @@ public class ExpiryUtils {
       }
 
       @Override
-      public Duration getExpiryForAccess(K key, ValueSupplier<? extends V> value) {
-        org.ehcache.expiry.Duration duration = expiry.getExpiryForAccess(key, value);
+      public Duration getExpiryForAccess(K key, Supplier<? extends V> value) {
+        org.ehcache.expiry.Duration duration = expiry.getExpiryForAccess(key, () -> value.get());
         return convertDuration(duration);
       }
 
       @Override
-      public Duration getExpiryForUpdate(K key, ValueSupplier<? extends V> oldValue, V newValue) {
-        org.ehcache.expiry.Duration duration = expiry.getExpiryForUpdate(key, oldValue, newValue);
+      public Duration getExpiryForUpdate(K key, Supplier<? extends V> oldValue, V newValue) {
+        org.ehcache.expiry.Duration duration = expiry.getExpiryForUpdate(key, () -> oldValue.get(), newValue);
         return convertDuration(duration);
       }
 

--- a/core/src/main/java/org/ehcache/core/events/NullStoreEventDispatcher.java
+++ b/core/src/main/java/org/ehcache/core/events/NullStoreEventDispatcher.java
@@ -16,9 +16,10 @@
 
 package org.ehcache.core.events;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
+
+import java.util.function.Supplier;
 
 /**
  * NullStoreEventDispatcher
@@ -31,12 +32,12 @@ public class NullStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
 
   private final StoreEventSink<K, V> storeEventSink = new StoreEventSink<K, V>() {
     @Override
-    public void evicted(K key, ValueSupplier<V> value) {
+    public void evicted(K key, Supplier<V> value) {
       // Do nothing
     }
 
     @Override
-    public void expired(K key, ValueSupplier<V> value) {
+    public void expired(K key, Supplier<V> value) {
       // Do nothing
     }
 
@@ -46,12 +47,12 @@ public class NullStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
     }
 
     @Override
-    public void updated(K key, ValueSupplier<V> previousValue, V newValue) {
+    public void updated(K key, Supplier<V> previousValue, V newValue) {
       // Do nothing
     }
 
     @Override
-    public void removed(K key, ValueSupplier<V> removed) {
+    public void removed(K key, Supplier<V> removed) {
       // Do nothing
     }
   };

--- a/core/src/main/java/org/ehcache/core/events/StoreEventSink.java
+++ b/core/src/main/java/org/ehcache/core/events/StoreEventSink.java
@@ -16,7 +16,7 @@
 
 package org.ehcache.core.events;
 
-import org.ehcache.ValueSupplier;
+import java.util.function.Supplier;
 
 /**
  * Interface on which {@link org.ehcache.core.spi.store.Store} operations are to record events.
@@ -29,7 +29,7 @@ public interface StoreEventSink<K, V> {
    * @param key removed key
    * @param value value supplier of removed value
    */
-  void removed(K key, ValueSupplier<V> value);
+  void removed(K key, Supplier<V> value);
 
   /**
    * Indicates the mapping was updated.
@@ -38,7 +38,7 @@ public interface StoreEventSink<K, V> {
    * @param oldValue value supplier of old value
    * @param newValue the new value
    */
-  void updated(K key, ValueSupplier<V> oldValue, V newValue);
+  void updated(K key, Supplier<V> oldValue, V newValue);
 
   /**
    * Indicates the mapping was expired.
@@ -46,7 +46,7 @@ public interface StoreEventSink<K, V> {
    * @param key the expired key
    * @param value value supplier of expired value
    */
-  void expired(K key, ValueSupplier<V> value);
+  void expired(K key, Supplier<V> value);
 
   /**
    * Indicates a mapping was created.
@@ -62,5 +62,5 @@ public interface StoreEventSink<K, V> {
    * @param key the evicted key
    * @param value value supplier of evicted value
    */
-  void evicted(K key, ValueSupplier<V> value);
+  void evicted(K key, Supplier<V> value);
 }

--- a/core/src/main/java/org/ehcache/core/internal/util/ValueSuppliers.java
+++ b/core/src/main/java/org/ehcache/core/internal/util/ValueSuppliers.java
@@ -20,7 +20,10 @@ import org.ehcache.ValueSupplier;
 
 /**
  * Utility for creating basic {@link ValueSupplier} instances
+ *
+ * @deprecated Now using {@code Supplier} for {@link org.ehcache.expiry.ExpiryPolicy}
  */
+@Deprecated
 public class ValueSuppliers {
 
   /**

--- a/core/src/main/java/org/ehcache/core/spi/store/AbstractValueHolder.java
+++ b/core/src/main/java/org/ehcache/core/spi/store/AbstractValueHolder.java
@@ -177,6 +177,6 @@ public abstract class AbstractValueHolder<V> implements Store.ValueHolder<V> {
 
   @Override
   public String toString() {
-    return format("%s", value());
+    return format("%s", get());
   }
 }

--- a/core/src/main/java/org/ehcache/core/spi/store/Store.java
+++ b/core/src/main/java/org/ehcache/core/spi/store/Store.java
@@ -17,7 +17,6 @@
 package org.ehcache.core.spi.store;
 
 import org.ehcache.Cache;
-import org.ehcache.ValueSupplier;
 import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
@@ -461,7 +460,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
    *
    * @param <V> the value type
    */
-  interface ValueHolder<V> extends ValueSupplier<V> {
+  interface ValueHolder<V> extends Supplier<V> {
 
     /**
      * Constant value indicating no expiration - an eternal mapping.

--- a/core/src/test/java/org/ehcache/core/CacheTest.java
+++ b/core/src/test/java/org/ehcache/core/CacheTest.java
@@ -226,7 +226,7 @@ public abstract class CacheTest {
       }
       return new Store.ValueHolder<Object>() {
         @Override
-        public Object value() {
+        public Object get() {
           return existingValue.get();
         }
 
@@ -273,7 +273,7 @@ public abstract class CacheTest {
       }
       return new Store.ValueHolder<Object>() {
         @Override
-        public Object value() {
+        public Object get() {
           return toReturn;
         }
 
@@ -316,9 +316,9 @@ public abstract class CacheTest {
     InternalCache<Object, Object> ehcache = getCache(store);
     ehcache.init();
     assertThat(ehcache.putIfAbsent("foo", value), nullValue());
-    assertThat(ehcache.putIfAbsent("foo", "foo"), CoreMatchers.<Object>is(value));
-    assertThat(ehcache.putIfAbsent("foo", "foobar"), CoreMatchers.<Object>is(value));
-    assertThat(ehcache.putIfAbsent("foo", value), CoreMatchers.<Object>is(value));
+    assertThat(ehcache.putIfAbsent("foo", "foo"), CoreMatchers.is(value));
+    assertThat(ehcache.putIfAbsent("foo", "foobar"), CoreMatchers.is(value));
+    assertThat(ehcache.putIfAbsent("foo", value), CoreMatchers.is(value));
   }
 
   @Test

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicCrudBase.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicCrudBase.java
@@ -258,7 +258,7 @@ public abstract class EhcacheBasicCrudBase {
     private final Set<String> failingKeys;
 
     public FakeStore(final Map<String, String> entries) {
-      this(entries, Collections.<String>emptySet());
+      this(entries, Collections.emptySet());
     }
 
     public FakeStore(final Map<String, String> entries, final Set<String> failingKeys) {
@@ -282,7 +282,7 @@ public abstract class EhcacheBasicCrudBase {
     protected Map<String, String> getEntryMap() {
       final Map<String, String> result = new HashMap<>();
       for (final Map.Entry<String, FakeValueHolder> entry : this.entries.entrySet()) {
-        result.put(entry.getKey(), entry.getValue().value());
+        result.put(entry.getKey(), entry.getValue().get());
       }
       return Collections.unmodifiableMap(result);
     }
@@ -338,7 +338,7 @@ public abstract class EhcacheBasicCrudBase {
       final ValueHolder<String> currentValue = this.entries.get(key);
       if (currentValue == null) {
         return RemoveStatus.KEY_MISSING;
-      } else if (!currentValue.value().equals(value)) {
+      } else if (!currentValue.get().equals(value)) {
         return RemoveStatus.KEY_PRESENT;
       }
       this.entries.remove(key);
@@ -362,7 +362,7 @@ public abstract class EhcacheBasicCrudBase {
       if (currentValue == null) {
         return ReplaceStatus.MISS_NOT_PRESENT;
       }
-      if (!currentValue.value().equals(oldValue)) {
+      if (!currentValue.get().equals(oldValue)) {
         return ReplaceStatus.MISS_PRESENT;
       }
       this.entries.put(key, new FakeValueHolder(newValue));
@@ -457,9 +457,9 @@ public abstract class EhcacheBasicCrudBase {
         final BiFunction<? super String, ? super String, ? extends String> mappingFunction,
         final Supplier<Boolean> replaceEqual) throws StoreAccessException {
 
-      String remappedValue = null;
+      String remappedValue;
       try {
-        remappedValue = mappingFunction.apply(key, (currentValue == null ? null : currentValue.value()));
+        remappedValue = mappingFunction.apply(key, (currentValue == null ? null : currentValue.get()));
       } catch (StorePassThroughException cpte) {
         Throwable cause = cpte.getCause();
         if(cause instanceof RuntimeException) {
@@ -508,7 +508,7 @@ public abstract class EhcacheBasicCrudBase {
       this.checkFailingKey(key);
       FakeValueHolder currentValue = this.entries.get(key);
       if (currentValue == null) {
-        String newValue = null;
+        String newValue;
         try {
           newValue = mappingFunction.apply(key);
         } catch (StorePassThroughException cpte) {
@@ -630,7 +630,7 @@ public abstract class EhcacheBasicCrudBase {
       }
 
       @Override
-      public String value() {
+      public String get() {
         return this.value;
       }
 
@@ -752,7 +752,7 @@ public abstract class EhcacheBasicCrudBase {
       }
 
       this.failingKeys = (failingKeys.isEmpty()
-          ? Collections.<String>emptySet()
+          ? Collections.emptySet()
           : Collections.unmodifiableSet(new HashSet<>(failingKeys)));
     }
 

--- a/core/src/test/java/org/ehcache/core/EhcacheBasicIteratorTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBasicIteratorTest.java
@@ -63,7 +63,7 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
    */
   @Test
   public void testIteratorEmptyStoreGet() throws Exception {
-    this.store = new FakeStore(Collections.<String,String>emptyMap());
+    this.store = new FakeStore(Collections.emptyMap());
     final InternalCache<String, String> ehcache = this.getEhcache();
     assertThat(ehcache.iterator(), is(notNullValue()));
   }
@@ -73,7 +73,7 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
    */
   @Test
   public void testIteratorEmptyStoreHasNext() throws Exception {
-    this.store = new FakeStore(Collections.<String,String>emptyMap());
+    this.store = new FakeStore(Collections.emptyMap());
     final InternalCache<String, String> ehcache = this.getEhcache();
     final Iterator<Cache.Entry<String, String>> iterator = ehcache.iterator();
     assertThat(iterator.hasNext(), is(false));
@@ -84,7 +84,7 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
    */
   @Test
   public void testIteratorEmptyStoreNext() throws Exception {
-    this.store = new FakeStore(Collections.<String,String>emptyMap());
+    this.store = new FakeStore(Collections.emptyMap());
     final InternalCache<String, String> ehcache = this.getEhcache();
     final Iterator<Cache.Entry<String, String>> iterator = ehcache.iterator();
     try {
@@ -100,7 +100,7 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
    */
   @Test
   public void testIteratorEmptyStoreRemoveBeforeNext() throws Exception {
-    this.store = new FakeStore(Collections.<String,String>emptyMap());
+    this.store = new FakeStore(Collections.emptyMap());
     final InternalCache<String, String> ehcache = this.getEhcache();
     final Iterator<Cache.Entry<String, String>> iterator = ehcache.iterator();
     try {
@@ -209,7 +209,7 @@ public class EhcacheBasicIteratorTest extends EhcacheBasicCrudBase {
   public void testIteratorStoreAccessException() throws Exception {
     @SuppressWarnings("unchecked")
     Store.ValueHolder<String> valueHolder = mock(Store.ValueHolder.class);
-    doReturn("bar").when(valueHolder).value();
+    doReturn("bar").when(valueHolder).get();
 
     @SuppressWarnings("unchecked")
     Cache.Entry<String, Store.ValueHolder<String>> storeEntry = mock(Cache.Entry.class);

--- a/core/src/test/java/org/ehcache/core/EhcacheBulkMethodsTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheBulkMethodsTest.java
@@ -149,7 +149,7 @@ public class EhcacheBulkMethodsTest {
   static <V> ValueHolder<V> valueHolder(final V value) {
     return new ValueHolder<V>() {
       @Override
-      public V value() {
+      public V get() {
         return value;
       }
 

--- a/core/src/test/java/org/ehcache/core/EhcacheLoaderWriterTest.java
+++ b/core/src/test/java/org/ehcache/core/EhcacheLoaderWriterTest.java
@@ -29,7 +29,6 @@ import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.BiFunction;
@@ -84,7 +83,7 @@ public class EhcacheLoaderWriterTest {
   public void testGetThrowsOnCompute() throws Exception {
     when(store.computeIfAbsent(any(Number.class), anyFunction())).thenThrow(new StoreAccessException("boom"));
     String expected = "foo";
-    when((String)cache.getCacheLoaderWriter().load(any(Number.class))).thenReturn(expected);
+    when(cache.getCacheLoaderWriter().load(any(Number.class))).thenReturn(expected);
     assertThat(cache.get(1), is(expected));
     verify(store).remove(1);
   }
@@ -382,7 +381,7 @@ public class EhcacheLoaderWriterTest {
       @SuppressWarnings("unchecked")
       final Store.ValueHolder<Object> mock = mock(Store.ValueHolder.class);
 
-      when(mock.value()).thenReturn(applied);
+      when(mock.get()).thenReturn(applied);
       return mock;
     });
     doThrow(new Exception()).when(cache.getCacheLoaderWriter()).write(any(Number.class), anyString());

--- a/core/src/test/java/org/ehcache/core/spi/store/AbstractValueHolderTest.java
+++ b/core/src/test/java/org/ehcache/core/spi/store/AbstractValueHolderTest.java
@@ -107,7 +107,7 @@ public class AbstractValueHolderTest {
   public void testSubclassEquals() throws Exception {
     assertThat(new AbstractValueHolder<String>(-1, 1000L) {
       @Override
-      public String value() {
+      public String get() {
         return "aaa";
       }
 
@@ -118,19 +118,19 @@ public class AbstractValueHolderTest {
 
       @Override
       public int hashCode() {
-        return super.hashCode() + value().hashCode();
+        return super.hashCode() + get().hashCode();
       }
       @Override
       public boolean equals(Object obj) {
         if (obj instanceof AbstractValueHolder) {
           AbstractValueHolder<?> other = (AbstractValueHolder<?>) obj;
-          return super.equals(obj) && value().equals(other.value());
+          return super.equals(obj) && get().equals(other.get());
         }
         return false;
       }
     }.equals(new AbstractValueHolder<String>(-1, 1L) {
       @Override
-      public String value() {
+      public String get() {
         return "aaa";
       }
 
@@ -141,14 +141,14 @@ public class AbstractValueHolderTest {
 
       @Override
       public int hashCode() {
-        return super.hashCode() + value().hashCode();
+        return super.hashCode() + get().hashCode();
       }
 
       @Override
       public boolean equals(Object obj) {
         if (obj instanceof AbstractValueHolder) {
           AbstractValueHolder<?> other = (AbstractValueHolder<?>)obj;
-          return super.equals(obj) && value().equals(other.value());
+          return super.equals(obj) && get().equals(other.get());
         }
         return false;
       }
@@ -156,7 +156,7 @@ public class AbstractValueHolderTest {
 
     assertThat(new AbstractValueHolder<String>(-1, 1000L) {
       @Override
-      public String value() {
+      public String get() {
         return "aaa";
       }
 
@@ -167,19 +167,19 @@ public class AbstractValueHolderTest {
 
       @Override
       public int hashCode() {
-        return super.hashCode() + value().hashCode();
+        return super.hashCode() + get().hashCode();
       }
       @Override
       public boolean equals(Object obj) {
         if (obj instanceof AbstractValueHolder) {
           AbstractValueHolder<?> other = (AbstractValueHolder<?>) obj;
-          return super.equals(obj) && value().equals(other.value());
+          return super.equals(obj) && get().equals(other.get());
         }
         return false;
       }
     }.equals(new AbstractValueHolder<String>(-1, 1L) {
       @Override
-      public String value() {
+      public String get() {
         return "bbb";
       }
 
@@ -190,14 +190,14 @@ public class AbstractValueHolderTest {
 
       @Override
       public int hashCode() {
-        return super.hashCode() + value().hashCode();
+        return super.hashCode() + get().hashCode();
       }
 
       @Override
       public boolean equals(Object obj) {
         if (obj instanceof AbstractValueHolder) {
           AbstractValueHolder<?> other = (AbstractValueHolder<?>)obj;
-          return super.equals(obj) && value().equals(other.value());
+          return super.equals(obj) && get().equals(other.get());
         }
         return false;
       }
@@ -215,7 +215,7 @@ public class AbstractValueHolderTest {
       }
 
       @Override
-      public String value() {
+      public String get() {
         return "abc";
       }
     };
@@ -233,7 +233,7 @@ public class AbstractValueHolderTest {
         return timeUnit;
       }
       @Override
-      public String value() {
+      public String get() {
         throw new UnsupportedOperationException();
       }
     };
@@ -245,7 +245,7 @@ public class AbstractValueHolderTest {
         return timeUnit;
       }
       @Override
-      public String value() {
+      public String get() {
         throw new UnsupportedOperationException();
       }
     };
@@ -258,7 +258,7 @@ public class AbstractValueHolderTest {
       }
 
       @Override
-      public String value() {
+      public String get() {
         throw new UnsupportedOperationException();
       }
     };

--- a/core/src/test/java/org/ehcache/core/util/Matchers.java
+++ b/core/src/test/java/org/ehcache/core/util/Matchers.java
@@ -16,10 +16,11 @@
 
 package org.ehcache.core.util;
 
-import org.ehcache.ValueSupplier;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -28,15 +29,15 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class Matchers {
 
-  public static <V> Matcher<ValueSupplier<V>> holding(final V value) {
+  public static <V> Matcher<Supplier<V>> holding(final V value) {
     return holding(equalTo(value));
   }
 
-  public static <V> Matcher<ValueSupplier<V>> holding(final Matcher<? super V> matcher) {
-    return new TypeSafeMatcher<ValueSupplier<V>>() {
+  public static <V> Matcher<Supplier<V>> holding(final Matcher<? super V> matcher) {
+    return new TypeSafeMatcher<Supplier<V>>() {
       @Override
-      protected boolean matchesSafely(ValueSupplier<V> item) {
-        return matcher.matches(item.value());
+      protected boolean matchesSafely(Supplier<V> item) {
+        return matcher.matches(item.get());
       }
 
       @Override

--- a/impl/src/main/java/org/ehcache/config/builders/ExpiryPolicyBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/ExpiryPolicyBuilder.java
@@ -15,12 +15,12 @@
  */
 package org.ehcache.config.builders;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.config.Builder;
 import org.ehcache.expiry.ExpiryPolicy;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Builder and utilities for getting predefined {@link ExpiryPolicy} instances.
@@ -152,12 +152,12 @@ public final class ExpiryPolicyBuilder implements Builder<ExpiryPolicy<Object, O
     }
 
     @Override
-    public Duration getExpiryForAccess(Object key, ValueSupplier<? extends Object> value) {
+    public Duration getExpiryForAccess(Object key, Supplier<? extends Object> value) {
       return access;
     }
 
     @Override
-    public Duration getExpiryForUpdate(Object key, ValueSupplier<? extends Object> oldValue, Object newValue) {
+    public Duration getExpiryForUpdate(Object key, Supplier<? extends Object> oldValue, Object newValue) {
       return update;
     }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/events/AbstractStoreEventDispatcher.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/AbstractStoreEventDispatcher.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.events;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.core.events.StoreEventSink;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
@@ -26,6 +25,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
 
 /**
  * AbstractStoreEventDispatcher
@@ -49,17 +49,17 @@ abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDispatche
     }
 
     @Override
-    public void removed(Object key, ValueSupplier<Object> value) {
+    public void removed(Object key, Supplier<Object> value) {
       // Do nothing
     }
 
     @Override
-    public void updated(Object key, ValueSupplier<Object> oldValue, Object newValue) {
+    public void updated(Object key, Supplier<Object> oldValue, Object newValue) {
       // Do nothing
     }
 
     @Override
-    public void expired(Object key, ValueSupplier<Object> value) {
+    public void expired(Object key, Supplier<Object> value) {
       // Do nothing
     }
 
@@ -69,7 +69,7 @@ abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDispatche
     }
 
     @Override
-    public void evicted(Object key, ValueSupplier<Object> value) {
+    public void evicted(Object key, Supplier<Object> value) {
       // Do nothing
     }
   };

--- a/impl/src/main/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSink.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSink.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.events;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.event.EventType;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
@@ -24,6 +23,7 @@ import org.ehcache.core.spi.store.events.StoreEventListener;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.function.Supplier;
 
 /**
  * This class is responsible for handling the event fudging that needs to happen
@@ -45,7 +45,7 @@ class FudgingInvocationScopedEventSink<K, V> extends InvocationScopedEventSink<K
   }
 
   @Override
-  public void evicted(K key, ValueSupplier<V> value) {
+  public void evicted(K key, Supplier<V> value) {
     V eventFudgingValue = handleEvictionPostWriteOnSameKey(key);
     super.evicted(key, value);
     if (eventFudgingValue != null) {

--- a/impl/src/main/java/org/ehcache/impl/internal/events/InvocationScopedEventSink.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/events/InvocationScopedEventSink.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.events;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.event.EventType;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
@@ -26,6 +25,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.function.Supplier;
 
 import static org.ehcache.impl.internal.events.StoreEvents.createEvent;
 import static org.ehcache.impl.internal.events.StoreEvents.evictEvent;
@@ -54,24 +54,24 @@ class InvocationScopedEventSink<K, V> implements CloseableStoreEventSink<K, V> {
   }
 
   @Override
-  public void removed(K key, ValueSupplier<V> value) {
-    V removedValue = value.value();
+  public void removed(K key, Supplier<V> value) {
+    V removedValue = value.get();
     if (acceptEvent(EventType.REMOVED, key, removedValue, null)) {
       handleEvent(key, new FireableStoreEventHolder<>(removeEvent(key, removedValue)));
     }
   }
 
   @Override
-  public void updated(K key, ValueSupplier<V> oldValue, V newValue) {
-    V oldValueValue = oldValue.value();
+  public void updated(K key, Supplier<V> oldValue, V newValue) {
+    V oldValueValue = oldValue.get();
     if (acceptEvent(EventType.UPDATED, key, oldValueValue, newValue)) {
       handleEvent(key, new FireableStoreEventHolder<>(updateEvent(key, oldValueValue, newValue)));
     }
   }
 
   @Override
-  public void expired(K key, ValueSupplier<V> value) {
-    V expired = value.value();
+  public void expired(K key, Supplier<V> value) {
+    V expired = value.get();
     if (acceptEvent(EventType.EXPIRED, key, expired, null)) {
       handleEvent(key, new FireableStoreEventHolder<>(expireEvent(key, expired)));
     }
@@ -85,8 +85,8 @@ class InvocationScopedEventSink<K, V> implements CloseableStoreEventSink<K, V> {
   }
 
   @Override
-  public void evicted(K key, ValueSupplier<V> value) {
-    V evicted = value.value();
+  public void evicted(K key, Supplier<V> value) {
+    V evicted = value.get();
     if (acceptEvent(EventType.EVICTED, key, evicted, null)) {
       handleEvent(key, new FireableStoreEventHolder<>(evictEvent(key, evicted)));
     }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/basic/EmptyValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/basic/EmptyValueHolder.java
@@ -34,7 +34,7 @@ public class EmptyValueHolder<V> implements Store.ValueHolder<V> {
   }
 
   @Override
-  public V value() {
+  public V get() {
     return null;
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/holders/CopiedOnHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/holders/CopiedOnHeapValueHolder.java
@@ -73,7 +73,7 @@ public class CopiedOnHeapValueHolder<V> extends OnHeapValueHolder<V> {
   }
 
   @Override
-  public V value() {
+  public V get() {
     return valueCopier.copyForRead(copiedValue);
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/holders/SerializedOnHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/holders/SerializedOnHeapValueHolder.java
@@ -63,7 +63,7 @@ public class SerializedOnHeapValueHolder<V> extends OnHeapValueHolder<V> impleme
   }
 
   @Override
-  public final V value() {
+  public final V get() {
     try {
       return serializer.read(buffer.duplicate());
     } catch (ClassNotFoundException cnfe) {
@@ -91,7 +91,7 @@ public class SerializedOnHeapValueHolder<V> extends OnHeapValueHolder<V> impleme
 
     if (!super.equals(that)) return false;
     try {
-      if (!serializer.equals(that.value(), buffer)) return false;
+      if (!serializer.equals(that.get(), buffer)) return false;
     } catch (ClassNotFoundException cnfe) {
       throw new SerializerException(cnfe);
     }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/BasicOffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/BasicOffHeapValueHolder.java
@@ -57,7 +57,7 @@ public class BasicOffHeapValueHolder<V> extends OffHeapValueHolder<V> {
   }
 
   @Override
-  public V value() {
+  public V get() {
     return value;
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/BinaryOffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/BinaryOffHeapValueHolder.java
@@ -70,7 +70,7 @@ final class BinaryOffHeapValueHolder<V> extends OffHeapValueHolder<V> implements
   }
 
   @Override
-  public V value() {
+  public V get() {
     return value;
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/LazyOffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/LazyOffHeapValueHolder.java
@@ -49,7 +49,7 @@ public final class LazyOffHeapValueHolder<V> extends OffHeapValueHolder<V> imple
   }
 
   @Override
-  public V value() {
+  public V get() {
     forceDeserialization();
     return value;
   }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapValueHolder.java
@@ -45,14 +45,14 @@ public abstract class OffHeapValueHolder<V> extends AbstractValueHolder<V> {
     OffHeapValueHolder<?> that = (OffHeapValueHolder<?>)other;
 
     if (!super.equals(that)) return false;
-    return value().equals(that.value());
+    return get().equals(that.get());
 
   }
 
   @Override
   public int hashCode() {
     int result = 1;
-    result = 31 * result + value().hashCode();
+    result = 31 * result + get().hashCode();
     result = 31 * result + super.hashCode();
     return result;
   }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/portability/OffHeapValueHolderPortability.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/portability/OffHeapValueHolderPortability.java
@@ -49,7 +49,7 @@ public class OffHeapValueHolderPortability<V> implements WriteBackPortability<Of
     if (valueHolder instanceof BinaryValueHolder && ((BinaryValueHolder)valueHolder).isBinaryValueAvailable()) {
       serialized = ((BinaryValueHolder)valueHolder).getBinaryValue();
     } else {
-      serialized = serializer.serialize(valueHolder.value());
+      serialized = serializer.serialize(valueHolder.get());
     }
     ByteBuffer byteBuffer = ByteBuffer.allocate(serialized.remaining() + FIELDS_OVERHEAD);
     byteBuffer.putLong(valueHolder.getId());

--- a/impl/src/test/java/org/ehcache/docs/Ehcache3.java
+++ b/impl/src/test/java/org/ehcache/docs/Ehcache3.java
@@ -17,7 +17,6 @@ package org.ehcache.docs;
 
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
-import org.ehcache.ValueSupplier;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
@@ -27,6 +26,7 @@ import org.ehcache.internal.TestTimeSource;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.function.Supplier;
 
 public class Ehcache3 {
 
@@ -46,12 +46,12 @@ public class Ehcache3 {
               }
 
               @Override
-              public Duration getExpiryForAccess(Long key, ValueSupplier<? extends String> value) {
+              public Duration getExpiryForAccess(Long key, Supplier<? extends String> value) {
                 return null;  // Keeping the existing expiry
               }
 
               @Override
-              public Duration getExpiryForUpdate(Long key, ValueSupplier<? extends String> oldValue, String newValue) {
+              public Duration getExpiryForUpdate(Long key, Supplier<? extends String> oldValue, String newValue) {
                 return null;  // Keeping the existing expiry
               }
             });
@@ -96,7 +96,7 @@ public class Ehcache3 {
       .build(true);
   }
 
-  private void sleep(int millisecondsToSleep) throws Exception {
+  private void sleep(int millisecondsToSleep) {
     timeSource.advanceTime(millisecondsToSleep);
   }
 }

--- a/impl/src/test/java/org/ehcache/docs/GettingStarted.java
+++ b/impl/src/test/java/org/ehcache/docs/GettingStarted.java
@@ -19,7 +19,6 @@ package org.ehcache.docs;
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
 import org.ehcache.PersistentCacheManager;
-import org.ehcache.ValueSupplier;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
@@ -46,6 +45,7 @@ import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.equalTo;
@@ -130,7 +130,7 @@ public class GettingStarted {
   }
 
   @Test
-  public void writeThroughCache() throws ClassNotFoundException {
+  public void writeThroughCache() {
     // tag::writeThroughCache[]
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
 
@@ -148,7 +148,7 @@ public class GettingStarted {
   }
 
   @Test
-  public void writeBehindCache() throws ClassNotFoundException {
+  public void writeBehindCache() {
     // tag::writeBehindCache[]
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
 
@@ -173,7 +173,7 @@ public class GettingStarted {
   }
 
   @Test
-  public void registerListenerAtRuntime() throws InterruptedException {
+  public void registerListenerAtRuntime() {
     CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
             ResourcePoolsBuilder.heap(10L)))
@@ -362,12 +362,12 @@ public class GettingStarted {
     }
 
     @Override
-    public Duration getExpiryForAccess(Long key, ValueSupplier<? extends String> value) {
+    public Duration getExpiryForAccess(Long key, Supplier<? extends String> value) {
       throw new UnsupportedOperationException("TODO Implement me!");
     }
 
     @Override
-    public Duration getExpiryForUpdate(Long key, ValueSupplier<? extends String> oldValue, String newValue) {
+    public Duration getExpiryForUpdate(Long key, Supplier<? extends String> oldValue, String newValue) {
       throw new UnsupportedOperationException("TODO Implement me!");
     }
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
@@ -18,7 +18,6 @@ package org.ehcache.impl.internal.events;
 
 import org.ehcache.core.spi.store.events.StoreEvent;
 import org.ehcache.event.EventType;
-import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -29,7 +28,6 @@ import java.util.HashSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -61,7 +59,7 @@ public class FudgingInvocationScopedEventSinkTest {
   @Test
   public void testEvictedDifferentKeyNoImpact() {
     eventSink.created("k1", "v1");
-    eventSink.evicted("k2", supplierOf("v2"));
+    eventSink.evicted("k2", () -> "v2");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
@@ -72,8 +70,8 @@ public class FudgingInvocationScopedEventSinkTest {
 
   @Test
   public void testEvictedSameKeyAfterUpdateReplacesWithEvictCreate() {
-    eventSink.updated("k1", supplierOf("v0"), "v1");
-    eventSink.evicted("k1", supplierOf("v0"));
+    eventSink.updated("k1", () -> "v0", "v1");
+    eventSink.evicted("k1", () -> "v0");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
@@ -84,9 +82,9 @@ public class FudgingInvocationScopedEventSinkTest {
 
   @Test
   public void testEvictedSameKeyAfterCreateFudgesExpiryToo() {
-    eventSink.expired("k1", supplierOf("v0"));
+    eventSink.expired("k1", () -> "v0");
     eventSink.created("k1", "v1");
-    eventSink.evicted("k1", supplierOf("v0"));
+    eventSink.evicted("k1", () -> "v0");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
@@ -97,10 +95,10 @@ public class FudgingInvocationScopedEventSinkTest {
 
   @Test
   public void testEvictedSameKeyAfterUpdateReplacesWithEvictCreateEvenWithMultipleEvictsInBetween() {
-    eventSink.updated("k1", supplierOf("v0"), "v1");
-    eventSink.evicted("k2", supplierOf("v2"));
-    eventSink.evicted("k3", supplierOf("v3"));
-    eventSink.evicted("k1", supplierOf("v0"));
+    eventSink.updated("k1", () -> "v0", "v1");
+    eventSink.evicted("k2", () -> "v2");
+    eventSink.evicted("k3", () -> "v3");
+    eventSink.evicted("k1", () -> "v0");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
@@ -111,11 +109,11 @@ public class FudgingInvocationScopedEventSinkTest {
 
   @Test
   public void testEvictedSameKeyAfterCreateFudgesExpiryTooEvenWithMultipleEvictsInBetween() {
-    eventSink.expired("k1", supplierOf("v0"));
+    eventSink.expired("k1", () -> "v0");
     eventSink.created("k1", "v1");
-    eventSink.evicted("k2", supplierOf("v2"));
-    eventSink.evicted("k3", supplierOf("v3"));
-    eventSink.evicted("k1", supplierOf("v0"));
+    eventSink.evicted("k2", () -> "v2");
+    eventSink.evicted("k3", () -> "v3");
+    eventSink.evicted("k1", () -> "v0");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
@@ -126,9 +124,9 @@ public class FudgingInvocationScopedEventSinkTest {
 
   @Test
   public void testEvictedKeyDoesNotFudgeOlderEvents() {
-    eventSink.updated("k1", supplierOf("v0"), "v1");
+    eventSink.updated("k1", () -> "v0", "v1");
     eventSink.created("k2", "v2");
-    eventSink.evicted("k1", supplierOf("v0"));
+    eventSink.evicted("k1", () -> "v0");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);

--- a/impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
@@ -17,7 +17,6 @@
 package org.ehcache.impl.internal.events;
 
 import org.ehcache.core.spi.store.events.StoreEvent;
-import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
 import org.ehcache.event.EventType;
 import org.hamcrest.Matcher;
@@ -29,7 +28,6 @@ import java.util.HashSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -58,11 +56,11 @@ public class InvocationScopedEventSinkTest {
   @Test
   public void testReset() {
     eventSink.created("k1", "v1");
-    eventSink.evicted("k1", supplierOf("v2"));
+    eventSink.evicted("k1", () -> "v2");
     eventSink.reset();
     eventSink.created("k1", "v1");
-    eventSink.updated("k1", supplierOf("v1"), "v2");
-    eventSink.evicted("k1", supplierOf("v2"));
+    eventSink.updated("k1", () -> "v1", "v2");
+    eventSink.evicted("k1", () -> "v2");
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);

--- a/impl/src/test/java/org/ehcache/impl/internal/events/ScopedStoreEventDispatcherTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/ScopedStoreEventDispatcherTest.java
@@ -30,9 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
-import java.util.function.BiFunction;
 
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 import static org.ehcache.impl.internal.util.Matchers.eventOfType;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -109,7 +107,7 @@ public class ScopedStoreEventDispatcherTest {
     dispatcher.addEventFilter(filter);
 
     StoreEventSink<String, String> sink = dispatcher.eventSink();
-    sink.removed("gone", supplierOf("really gone"));
+    sink.removed("gone", () -> "really gone");
     sink.created("new", "and shiny");
     dispatcher.releaseEventSink(sink);
 

--- a/impl/src/test/java/org/ehcache/impl/internal/events/TestStoreEventDispatcher.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/events/TestStoreEventDispatcher.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.events;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.event.EventType;
 import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.core.events.StoreEventSink;
@@ -26,6 +25,7 @@ import org.ehcache.core.spi.store.events.StoreEventListener;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * TestStoreEventDispatcher
@@ -92,9 +92,9 @@ public class TestStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
 
   private class EventBridge implements StoreEventSink<K, V> {
     @Override
-    public void evicted(K key, ValueSupplier<V> value) {
-      if (accepted(EventType.EVICTED, key, value.value(), null)) {
-        StoreEvent<K, V> event = StoreEvents.evictEvent(key, value.value());
+    public void evicted(K key, Supplier<V> value) {
+      if (accepted(EventType.EVICTED, key, value.get(), null)) {
+        StoreEvent<K, V> event = StoreEvents.evictEvent(key, value.get());
         for (StoreEventListener<K, V> listener : listeners) {
           listener.onEvent(event);
         }
@@ -102,9 +102,9 @@ public class TestStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
     }
 
     @Override
-    public void expired(K key, ValueSupplier<V> value) {
-      if (accepted(EventType.EXPIRED, key, value.value(), null)) {
-        StoreEvent<K, V> event = StoreEvents.expireEvent(key, value.value());
+    public void expired(K key, Supplier<V> value) {
+      if (accepted(EventType.EXPIRED, key, value.get(), null)) {
+        StoreEvent<K, V> event = StoreEvents.expireEvent(key, value.get());
         for (StoreEventListener<K, V> listener : listeners) {
           listener.onEvent(event);
         }
@@ -122,9 +122,9 @@ public class TestStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
     }
 
     @Override
-    public void updated(K key, ValueSupplier<V> previousValue, V newValue) {
-      if (accepted(EventType.UPDATED, key, previousValue.value(), newValue)) {
-        StoreEvent<K, V> event = StoreEvents.updateEvent(key, previousValue.value(), newValue);
+    public void updated(K key, Supplier<V> previousValue, V newValue) {
+      if (accepted(EventType.UPDATED, key, previousValue.get(), newValue)) {
+        StoreEvent<K, V> event = StoreEvents.updateEvent(key, previousValue.get(), newValue);
         for (StoreEventListener<K, V> listener : listeners) {
           listener.onEvent(event);
         }
@@ -132,9 +132,9 @@ public class TestStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
     }
 
     @Override
-    public void removed(K key, ValueSupplier<V> removed) {
-      if (accepted(EventType.REMOVED, key, removed.value(), null)) {
-        StoreEvent<K, V> event = StoreEvents.removeEvent(key, removed.value());
+    public void removed(K key, Supplier<V> removed) {
+      if (accepted(EventType.REMOVED, key, removed.get(), null)) {
+        StoreEvent<K, V> event = StoreEvents.removeEvent(key, removed.get());
         for (StoreEventListener<K, V> listener : listeners) {
           listener.onEvent(event);
         }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreBulkMethodsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreBulkMethodsTest.java
@@ -77,10 +77,9 @@ public class OnHeapStoreBulkMethodsTest {
     when(config.getKeyType()).thenReturn(Number.class);
     when(config.getValueType()).thenReturn(Number.class);
     when(config.getResourcePools()).thenReturn(newResourcePoolsBuilder().heap(Long.MAX_VALUE, EntryUnit.ENTRIES).build());
-    Store.Configuration<Number, Number> configuration = config;
 
-    OnHeapStore<Number, Number> store = new OnHeapStore<Number, Number>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER,
-        new NoopSizeOfEngine(), NullStoreEventDispatcher.<Number, Number>nullStoreEventDispatcher());
+    OnHeapStore<Number, Number> store = new OnHeapStore<>(config, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER,
+        new NoopSizeOfEngine(), NullStoreEventDispatcher.nullStoreEventDispatcher());
     store.put(1, 2);
     store.put(2, 3);
     store.put(3, 4);
@@ -111,17 +110,17 @@ public class OnHeapStoreBulkMethodsTest {
     check.put(5, 0);
     check.put(6, 0);
 
-    assertThat(result.get(1).value(), Matchers.<Number>is(check.get(1)));
-    assertThat(result.get(2).value(), Matchers.<Number>is(check.get(2)));
-    assertThat(result.get(3).value(), Matchers.<Number>is(check.get(3)));
+    assertThat(result.get(1).get(), Matchers.is(check.get(1)));
+    assertThat(result.get(2).get(), Matchers.is(check.get(2)));
+    assertThat(result.get(3).get(), Matchers.is(check.get(3)));
     assertThat(result.get(4), nullValue());
-    assertThat(result.get(5).value(), Matchers.<Number>is(check.get(5)));
-    assertThat(result.get(6).value(), Matchers.<Number>is(check.get(6)));
+    assertThat(result.get(5).get(), Matchers.is(check.get(5)));
+    assertThat(result.get(6).get(), Matchers.is(check.get(6)));
 
     for (Number key : check.keySet()) {
       final Store.ValueHolder<Number> holder = store.get(key);
       if(holder != null) {
-        check.remove(key, holder.value());
+        check.remove(key, holder.get());
       }
     }
     assertThat(check.size(), is(1));
@@ -147,11 +146,11 @@ public class OnHeapStoreBulkMethodsTest {
     });
 
     assertThat(result.size(), is(2));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("un"));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("deux"));
+    assertThat(result.get(1).get(), Matchers.equalTo("un"));
+    assertThat(result.get(2).get(), Matchers.equalTo("deux"));
 
-    assertThat(store.get(1).value(), Matchers.<CharSequence>equalTo("un"));
-    assertThat(store.get(2).value(), Matchers.<CharSequence>equalTo("deux"));
+    assertThat(store.get(1).get(), Matchers.equalTo("un"));
+    assertThat(store.get(2).get(), Matchers.equalTo("deux"));
   }
 
   @Test
@@ -159,7 +158,7 @@ public class OnHeapStoreBulkMethodsTest {
     Store.Configuration<Number, CharSequence> configuration = mockStoreConfig();
 
     @SuppressWarnings("unchecked")
-    OnHeapStore<Number, CharSequence> store = new OnHeapStore<Number, CharSequence>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER, new NoopSizeOfEngine(), NullStoreEventDispatcher.<Number, CharSequence>nullStoreEventDispatcher());
+    OnHeapStore<Number, CharSequence> store = new OnHeapStore<Number, CharSequence>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER, new NoopSizeOfEngine(), NullStoreEventDispatcher.nullStoreEventDispatcher());
     store.put(1, "one");
     store.put(2, "two");
     store.put(3, "three");
@@ -176,7 +175,7 @@ public class OnHeapStoreBulkMethodsTest {
 
     assertThat(store.get(1), is(nullValue()));
     assertThat(store.get(2), is(nullValue()));
-    assertThat(store.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(store.get(3).get(), Matchers.equalTo("three"));
     assertThat(store.get(5), is(nullValue()));
   }
 
@@ -204,11 +203,11 @@ public class OnHeapStoreBulkMethodsTest {
 
     assertThat(result.size(), is(3));
     assertThat(result.get(1), is(nullValue()));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(result.get(2).get(), Matchers.equalTo("two"));
     assertThat(result.get(3), is(nullValue()));
 
     assertThat(store.get(1),is(nullValue()));
-    assertThat(store.get(2).value(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(store.get(2).get(), Matchers.equalTo("two"));
     assertThat(store.get(3),is(nullValue()));
 
   }
@@ -239,16 +238,16 @@ public class OnHeapStoreBulkMethodsTest {
     });
 
     assertThat(result.size(), is(6));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(result.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(result.get(1).get(), Matchers.equalTo("one"));
+    assertThat(result.get(2).get(), Matchers.equalTo("two"));
+    assertThat(result.get(3).get(), Matchers.equalTo("three"));
     assertThat(result.get(4), is(nullValue()));
     assertThat(result.get(5), is(nullValue()));
     assertThat(result.get(6), is(nullValue()));
 
-    assertThat(store.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(store.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(store.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(store.get(1).get(), Matchers.equalTo("one"));
+    assertThat(store.get(2).get(), Matchers.equalTo("two"));
+    assertThat(store.get(3).get(), Matchers.equalTo("three"));
     assertThat(store.get(4), is(nullValue()));
     assertThat(store.get(5), is(nullValue()));
     assertThat(store.get(6), is(nullValue()));
@@ -279,19 +278,19 @@ public class OnHeapStoreBulkMethodsTest {
     });
 
     assertThat(result.size(), is(6));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(result.get(3).value(), Matchers.<CharSequence>equalTo("three"));
-    assertThat(result.get(4).value(), Matchers.<CharSequence>equalTo("quatre"));
-    assertThat(result.get(5).value(), Matchers.<CharSequence>equalTo("cinq"));
-    assertThat(result.get(6).value(), Matchers.<CharSequence>equalTo("six"));
+    assertThat(result.get(1).get(), Matchers.equalTo("one"));
+    assertThat(result.get(2).get(), Matchers.equalTo("two"));
+    assertThat(result.get(3).get(), Matchers.equalTo("three"));
+    assertThat(result.get(4).get(), Matchers.equalTo("quatre"));
+    assertThat(result.get(5).get(), Matchers.equalTo("cinq"));
+    assertThat(result.get(6).get(), Matchers.equalTo("six"));
 
-    assertThat(store.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(store.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(store.get(3).value(), Matchers.<CharSequence>equalTo("three"));
-    assertThat(store.get(4).value(), Matchers.<CharSequence>equalTo("quatre"));
-    assertThat(store.get(5).value(), Matchers.<CharSequence>equalTo("cinq"));
-    assertThat(store.get(6).value(), Matchers.<CharSequence>equalTo("six"));
+    assertThat(store.get(1).get(), Matchers.equalTo("one"));
+    assertThat(store.get(2).get(), Matchers.equalTo("two"));
+    assertThat(store.get(3).get(), Matchers.equalTo("three"));
+    assertThat(store.get(4).get(), Matchers.equalTo("quatre"));
+    assertThat(store.get(5).get(), Matchers.equalTo("cinq"));
+    assertThat(store.get(6).get(), Matchers.equalTo("six"));
   }
 
   @Test
@@ -321,13 +320,13 @@ public class OnHeapStoreBulkMethodsTest {
     });
 
     assertThat(result.size(), is(3));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(result.get(2).get(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(result.get(1).get(), Matchers.<CharSequence>equalTo("one"));
     assertThat(result.get(5), is(nullValue()));
 
-    assertThat(store.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(store.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(store.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(store.get(1).get(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(store.get(2).get(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(store.get(3).get(), Matchers.<CharSequence>equalTo("three"));
     assertThat(store.get(5), is(nullValue()));
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreByValueTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreByValueTest.java
@@ -75,7 +75,7 @@ public abstract class OnHeapStoreByValueTest extends BaseOnHeapStoreTest {
 
     ValueHolder<Long> computed = store.getOrComputeIfAbsent(1L, key -> new AbstractValueHolder<Long>(-1, -1) {
       @Override
-      public Long value() {
+      public Long get() {
         return key * 1000L;
       }
 
@@ -84,7 +84,7 @@ public abstract class OnHeapStoreByValueTest extends BaseOnHeapStoreTest {
         return TimeUnit.MILLISECONDS;
       }
     });
-    assertThat(computed.value(), is(1000L));
+    assertThat(computed.get(), is(1000L));
     assertThat(keyCopier.copyForWriteCount, is(1));
     assertThat(keyCopier.copyForReadCount, is(0));
   }
@@ -125,7 +125,7 @@ public abstract class OnHeapStoreByValueTest extends BaseOnHeapStoreTest {
     value.clear();
 
     ValueHolder<Serializable> valueHolder = store.get(key);
-    if (valueHolder.value() == value || ! valueHolder.value().equals(Collections.singletonList("value"))) {
+    if (valueHolder.get() == value || ! valueHolder.get().equals(Collections.singletonList("value"))) {
       throw new AssertionError();
     }
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreEvictionTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreEvictionTest.java
@@ -87,7 +87,7 @@ public class OnHeapStoreEvictionTest {
         semaphore.acquireUninterruptibly();
         return new OnHeapValueHolder<String>(0, 0, false) {
           @Override
-          public String value() {
+          public String get() {
             return key;
           }
         };
@@ -180,12 +180,12 @@ public class OnHeapStoreEvictionTest {
 
     @SuppressWarnings("unchecked")
     public OnHeapStoreForTests(final Configuration<K, V> config, final TimeSource timeSource) {
-      super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER,  new NoopSizeOfEngine(), NullStoreEventDispatcher.<K, V>nullStoreEventDispatcher());
+      super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER,  new NoopSizeOfEngine(), NullStoreEventDispatcher.nullStoreEventDispatcher());
     }
 
     @SuppressWarnings("unchecked")
     public OnHeapStoreForTests(final Configuration<K, V> config, final TimeSource timeSource, final SizeOfEngine engine) {
-      super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER, engine, NullStoreEventDispatcher.<K, V>nullStoreEventDispatcher());
+      super(config, timeSource, DEFAULT_COPIER, DEFAULT_COPIER, engine, NullStoreEventDispatcher.nullStoreEventDispatcher());
     }
 
     private boolean enforceCapacityWasCalled = false;

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreKeyCopierTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreKeyCopierTest.java
@@ -101,7 +101,7 @@ public class OnHeapStoreKeyCopierTest {
       }
     };
 
-    store = new OnHeapStore<>(config, SystemTimeSource.INSTANCE, keyCopier, new IdentityCopier<>(), new NoopSizeOfEngine(), NullStoreEventDispatcher.<Key, String>nullStoreEventDispatcher());
+    store = new OnHeapStore<>(config, SystemTimeSource.INSTANCE, keyCopier, new IdentityCopier<>(), new NoopSizeOfEngine(), NullStoreEventDispatcher.nullStoreEventDispatcher());
   }
 
   @Test
@@ -114,11 +114,11 @@ public class OnHeapStoreKeyCopierTest {
     Store.ValueHolder<String> firstStoreValue = store.get(KEY);
     Store.ValueHolder<String> secondStoreValue = store.get(copyKey);
     if (copyForWrite) {
-      assertThat(firstStoreValue.value(), is(VALUE));
+      assertThat(firstStoreValue.get(), is(VALUE));
       assertThat(secondStoreValue, nullValue());
     } else {
       assertThat(firstStoreValue, nullValue());
-      assertThat(secondStoreValue.value(), is(VALUE));
+      assertThat(secondStoreValue.get(), is(VALUE));
     }
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreValueCopierTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreValueCopierTest.java
@@ -110,42 +110,42 @@ public class OnHeapStoreValueCopierTest {
 
     Store.ValueHolder<Value> firstStoreValue = store.get(KEY);
     Store.ValueHolder<Value> secondStoreValue = store.get(KEY);
-    compareValues(VALUE, firstStoreValue.value());
-    compareValues(VALUE, secondStoreValue.value());
-    compareReadValues(firstStoreValue.value(), secondStoreValue.value());
+    compareValues(VALUE, firstStoreValue.get());
+    compareValues(VALUE, secondStoreValue.get());
+    compareReadValues(firstStoreValue.get(), secondStoreValue.get());
   }
 
   @Test
   public void testCompute() throws StoreAccessException {
     final Store.ValueHolder<Value> firstValue = store.compute(KEY, (aLong, value) -> VALUE);
     store.compute(KEY, (aLong, value) -> {
-      compareReadValues(value, firstValue.value());
+      compareReadValues(value, firstValue.get());
       return value;
     });
 
-    compareValues(VALUE, firstValue.value());
+    compareValues(VALUE, firstValue.get());
   }
 
   @Test
   public void testComputeWithoutReplaceEqual() throws StoreAccessException {
     final Store.ValueHolder<Value> firstValue = store.compute(KEY, (aLong, value) -> VALUE, NOT_REPLACE_EQUAL);
     store.compute(KEY, (aLong, value) -> {
-      compareReadValues(value, firstValue.value());
+      compareReadValues(value, firstValue.get());
       return value;
     }, NOT_REPLACE_EQUAL);
 
-    compareValues(VALUE, firstValue.value());
+    compareValues(VALUE, firstValue.get());
   }
 
   @Test
   public void testComputeWithReplaceEqual() throws StoreAccessException {
     final Store.ValueHolder<Value> firstValue = store.compute(KEY, (aLong, value) -> VALUE, REPLACE_EQUAL);
     store.compute(KEY, (aLong, value) -> {
-      compareReadValues(value, firstValue.value());
+      compareReadValues(value, firstValue.get());
       return value;
     }, REPLACE_EQUAL);
 
-    compareValues(VALUE, firstValue.value());
+    compareValues(VALUE, firstValue.get());
   }
 
   @Test
@@ -155,38 +155,38 @@ public class OnHeapStoreValueCopierTest {
       fail("There should have been a mapping");
       return null;
     });
-    compareValues(VALUE, computedValue.value());
-    compareReadValues(computedValue.value(), secondComputedValue.value());
+    compareValues(VALUE, computedValue.get());
+    compareReadValues(computedValue.get(), secondComputedValue.get());
   }
 
   @Test
   public void testBulkCompute() throws StoreAccessException {
     final Map<Long, Store.ValueHolder<Value>> results = store.bulkCompute(singleton(KEY), entries -> singletonMap(KEY, VALUE).entrySet());
     store.bulkCompute(singleton(KEY), entries -> {
-      compareReadValues(results.get(KEY).value(), entries.iterator().next().getValue());
+      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue());
       return entries;
     });
-    compareValues(VALUE, results.get(KEY).value());
+    compareValues(VALUE, results.get(KEY).get());
   }
 
   @Test
   public void testBulkComputeWithoutReplaceEqual() throws StoreAccessException {
     final Map<Long, Store.ValueHolder<Value>> results = store.bulkCompute(singleton(KEY), entries -> singletonMap(KEY, VALUE).entrySet(), NOT_REPLACE_EQUAL);
     store.bulkCompute(singleton(KEY), entries -> {
-      compareReadValues(results.get(KEY).value(), entries.iterator().next().getValue());
+      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue());
       return entries;
     }, NOT_REPLACE_EQUAL);
-    compareValues(VALUE, results.get(KEY).value());
+    compareValues(VALUE, results.get(KEY).get());
   }
 
   @Test
   public void testBulkComputeWithReplaceEqual() throws StoreAccessException {
     final Map<Long, Store.ValueHolder<Value>> results = store.bulkCompute(singleton(KEY), entries -> singletonMap(KEY, VALUE).entrySet(), REPLACE_EQUAL);
     store.bulkCompute(singleton(KEY), entries -> {
-      compareReadValues(results.get(KEY).value(), entries.iterator().next().getValue());
+      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue());
       return entries;
     }, REPLACE_EQUAL);
-    compareValues(VALUE, results.get(KEY).value());
+    compareValues(VALUE, results.get(KEY).get());
   }
 
   @Test
@@ -196,8 +196,8 @@ public class OnHeapStoreValueCopierTest {
       fail("There should have been a mapping!");
       return null;
     });
-    compareValues(VALUE, results.get(KEY).value());
-    compareReadValues(results.get(KEY).value(), secondResults.get(KEY).value());
+    compareValues(VALUE, results.get(KEY).get());
+    compareReadValues(results.get(KEY).get(), secondResults.get(KEY).get());
   }
 
   @Test
@@ -207,7 +207,7 @@ public class OnHeapStoreValueCopierTest {
     assertThat(iterator.hasNext(), is(true));
     while (iterator.hasNext()) {
       Cache.Entry<Long, Store.ValueHolder<Value>> entry = iterator.next();
-      compareValues(entry.getValue().value(), VALUE);
+      compareValues(entry.getValue().get(), VALUE);
     }
   }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreBulkMethodsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreBulkMethodsTest.java
@@ -54,7 +54,7 @@ public class OnHeapStoreBulkMethodsTest extends org.ehcache.impl.internal.store.
   }
 
   @SuppressWarnings("unchecked")
-  protected <Number, CharSequence> OnHeapStore<Number, CharSequence> newStore() {
+  protected OnHeapStore<Number, CharSequence> newStore() {
     Store.Configuration<Number, CharSequence> configuration = mockStoreConfig();
     return new OnHeapStore<Number, CharSequence>(configuration, SystemTimeSource.INSTANCE, DEFAULT_COPIER, DEFAULT_COPIER,
         new DefaultSizeOfEngine(Long.MAX_VALUE, Long.MAX_VALUE), NullStoreEventDispatcher.<Number, CharSequence>nullStoreEventDispatcher());
@@ -103,17 +103,17 @@ public class OnHeapStoreBulkMethodsTest extends org.ehcache.impl.internal.store.
     check.put(5, 0);
     check.put(6, 0);
 
-    assertThat(result.get(1).value(), Matchers.<Number>is(check.get(1)));
-    assertThat(result.get(2).value(), Matchers.<Number>is(check.get(2)));
-    assertThat(result.get(3).value(), Matchers.<Number>is(check.get(3)));
+    assertThat(result.get(1).get(), Matchers.is(check.get(1)));
+    assertThat(result.get(2).get(), Matchers.is(check.get(2)));
+    assertThat(result.get(3).get(), Matchers.is(check.get(3)));
     assertThat(result.get(4), nullValue());
-    assertThat(result.get(5).value(), Matchers.<Number>is(check.get(5)));
-    assertThat(result.get(6).value(), Matchers.<Number>is(check.get(6)));
+    assertThat(result.get(5).get(), Matchers.is(check.get(5)));
+    assertThat(result.get(6).get(), Matchers.is(check.get(6)));
 
     for (Number key : check.keySet()) {
       final Store.ValueHolder<Number> holder = store.get(key);
       if(holder != null) {
-        check.remove(key, holder.value());
+        check.remove(key, holder.get());
       }
     }
     assertThat(check.size(), is(1));

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OversizeMappingTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OversizeMappingTest.java
@@ -109,7 +109,7 @@ public class OversizeMappingTest {
   }
 
   private static void assertNotNullMapping(OnHeapStore<String, String> store) throws Exception {
-    assertThat(store.get(KEY).value(), equalTo(VALUE));
+    assertThat(store.get(KEY).get(), equalTo(VALUE));
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/holders/CopiedOnHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/holders/CopiedOnHeapValueHolderTest.java
@@ -35,7 +35,7 @@ public class CopiedOnHeapValueHolderTest {
     CopiedOnHeapValueHolder<Person> valueHolder = new CopiedOnHeapValueHolder<>(person, -1, false, copier);
     person.age = 25;
 
-    assertNotSame(person, valueHolder.value());
+    assertNotSame(person, valueHolder.get());
   }
 
   @Test
@@ -44,7 +44,7 @@ public class CopiedOnHeapValueHolderTest {
     CopiedOnHeapValueHolder<Person> valueHolder = new CopiedOnHeapValueHolder<>(person, -1, false, new IdentityCopier<>());
     person.age = 25;
 
-    assertSame(person, valueHolder.value());
+    assertSame(person, valueHolder.get());
   }
 
   private static class Person {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/holders/SerializedOnHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/holders/SerializedOnHeapValueHolderTest.java
@@ -46,9 +46,9 @@ public class SerializedOnHeapValueHolderTest {
     String o = "foo";
     ValueHolder<?> vh1 = newValueHolder(o);
     ValueHolder<?> vh2 = newValueHolder(o);
-    assertFalse(vh1.value() == vh2.value());
-    assertEquals(vh1.value(), vh2.value());
-    assertNotSame(vh1.value(), vh1.value());
+    assertFalse(vh1.get() == vh2.get());
+    assertEquals(vh1.get(), vh2.get());
+    assertNotSame(vh1.get(), vh1.get());
   }
 
   @Test
@@ -56,10 +56,10 @@ public class SerializedOnHeapValueHolderTest {
     ValueHolder<Integer> vh1 = newValueHolder(10);
     ValueHolder<Integer> vh2 = newValueHolder(10);
     // make sure reading the value multiple times doesn't change the hashcode
-    vh1.value();
-    vh1.value();
-    vh2.value();
-    vh2.value();
+    vh1.get();
+    vh1.get();
+    vh2.get();
+    vh2.get();
     assertThat(vh1.hashCode(), is(vh2.hashCode()));
   }
 
@@ -87,9 +87,9 @@ public class SerializedOnHeapValueHolderTest {
     final SerializedOnHeapValueHolder<String> valueHolder = new SerializedOnHeapValueHolder<>("test it!", System
       .currentTimeMillis(), false, serializer);
 
-    new Thread(valueHolder::value).start();
+    new Thread(valueHolder::get).start();
 
-    valueHolder.value();
+    valueHolder.get();
   }
 
   private static class ReadExchangeSerializer implements Serializer<String> {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/BasicOffHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/BasicOffHeapValueHolderTest.java
@@ -38,7 +38,7 @@ public class BasicOffHeapValueHolderTest {
 
   @Test
   public void testCanAccessValue() {
-    assertThat(valueHolder.value(), is(value));
+    assertThat(valueHolder.get(), is(value));
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/BinaryOffHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/BinaryOffHeapValueHolderTest.java
@@ -50,7 +50,7 @@ public class BinaryOffHeapValueHolderTest {
 
   @Test
   public void testCanAccessValue() {
-    assertThat(valueHolder.value(), is(value));
+    assertThat(valueHolder.get(), is(value));
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/LazyOffHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/LazyOffHeapValueHolderTest.java
@@ -42,7 +42,7 @@ public class LazyOffHeapValueHolderTest {
 
     valueHolder.detach();
     serialized.clear();
-    assertThat(valueHolder.value(), is(testValue));
+    assertThat(valueHolder.get(), is(testValue));
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreMutatorTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreMutatorTest.java
@@ -212,7 +212,7 @@ public class TieredStoreMutatorTest {
     // 4. Test Thread receives a value from putIfAbsent. We would expect the get to receive the same value right after
     //    a. Test Thread -> TieredStore.putIfAbsent
     //    b. Test Thread -> AuthoritativeTierMock.putIfAbsent - returns VALUE
-    assertThat(putIfAbsentToTieredStore().value(), is(VALUE));
+    assertThat(putIfAbsentToTieredStore().get(), is(VALUE));
 
     // 5. Test Thread -> TieredStore.get()
     //    If Test Thread bugged -> Fault.get() - synchronized - blocked on the fault because thread 2 already locks the fault
@@ -222,7 +222,7 @@ public class TieredStoreMutatorTest {
     // These assertions will in fact work most of the time even if a failure occurred. Because as soon as the latches are
     // released by thread 3, the thread 2 will invalidate the fault
     assertThat(value, notNullValue());
-    assertThat(value.value(), is(VALUE));
+    assertThat(value.get(), is(VALUE));
 
     // If the Test thread was blocked, Thread 3 will eventually flag the failure
     assertThat(failed, is(false));
@@ -251,7 +251,7 @@ public class TieredStoreMutatorTest {
     //    Else Test Thread fixed -> new Fault ... correct value
     Store.ValueHolder<String> value = getFromTieredStore();
     assertThat(value, notNullValue());
-    assertThat(value.value(), is(VALUE));
+    assertThat(value.get(), is(VALUE));
 
     assertThat(failed, is(false));
   }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreSPITest.java
@@ -225,7 +225,7 @@ public class TieredStoreSPITest extends StoreSPITest<String, String> {
         return new Store.ValueHolder<String>() {
 
           @Override
-          public String value() {
+          public String get() {
             return value;
           }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.AbstractMap;
@@ -98,7 +97,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.get(1).value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(tieredStore.get(1).get(), Matchers.<CharSequence>equalTo("one"));
 
     verify(numberAuthoritativeTier, times(0)).getAndFault(any(Number.class));
   }
@@ -116,7 +115,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.get(1).value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(tieredStore.get(1).get(), Matchers.<CharSequence>equalTo("one"));
 
     verify(numberCachingTier, times(1)).getOrComputeIfAbsent(eq(1), any(Function.class));
     verify(numberAuthoritativeTier, times(1)).getAndFault(any(Number.class));
@@ -166,7 +165,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.putIfAbsent(1, "one").value(), Matchers.<CharSequence>equalTo("un"));
+    assertThat(tieredStore.putIfAbsent(1, "one").get(), Matchers.<CharSequence>equalTo("un"));
 
     verify(numberCachingTier, times(1)).invalidate(1);
     verify(numberAuthoritativeTier, times(1)).putIfAbsent(1, "one");
@@ -212,7 +211,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.replace(1, "one").value(), Matchers.<CharSequence>equalTo("un"));
+    assertThat(tieredStore.replace(1, "one").get(), Matchers.<CharSequence>equalTo("un"));
 
     verify(numberCachingTier, times(1)).invalidate(eq(1));
     verify(numberAuthoritativeTier, times(1)).replace(eq(1), eq("one"));
@@ -275,7 +274,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.compute(1, (number, charSequence) -> "one").value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(tieredStore.compute(1, (number, charSequence) -> "one").get(), Matchers.<CharSequence>equalTo("one"));
 
     verify(numberCachingTier, times(1)).invalidate(any(Number.class));
     verify(numberAuthoritativeTier, times(1)).compute(eq(1), any(BiFunction.class));
@@ -292,7 +291,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.compute(1, (number, charSequence) -> "one", () -> true).value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(tieredStore.compute(1, (number, charSequence) -> "one", () -> true).get(), Matchers.<CharSequence>equalTo("one"));
 
     verify(numberCachingTier, times(1)).invalidate(any(Number.class));
     verify(numberAuthoritativeTier, times(1)).compute(eq(1), any(BiFunction.class), any(Supplier.class));
@@ -314,7 +313,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.computeIfAbsent(1, number -> "one").value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(tieredStore.computeIfAbsent(1, number -> "one").get(), Matchers.<CharSequence>equalTo("one"));
 
     verify(numberCachingTier, times(1)).getOrComputeIfAbsent(eq(1), any(Function.class));
     verify(numberAuthoritativeTier, times(1)).computeIfAbsentAndFault(eq(1), any(Function.class));
@@ -328,7 +327,7 @@ public class TieredStoreTest {
 
     TieredStore<Number, CharSequence> tieredStore = new TieredStore<>(numberCachingTier, numberAuthoritativeTier);
 
-    assertThat(tieredStore.computeIfAbsent(1, number -> "one").value(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(tieredStore.computeIfAbsent(1, number -> "one").get(), Matchers.<CharSequence>equalTo("one"));
 
     verify(numberCachingTier, times(1)).getOrComputeIfAbsent(eq(1), any(Function.class));
     verify(numberAuthoritativeTier, times(0)).computeIfAbsentAndFault(eq(1), any(Function.class));
@@ -362,9 +361,9 @@ public class TieredStoreTest {
       .asList(newMapEntry(1, "one"), newMapEntry(2, "two"), newMapEntry(3, "three"))));
 
     assertThat(result.size(), is(3));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(result.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(result.get(1).get(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(result.get(2).get(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(result.get(3).get(), Matchers.<CharSequence>equalTo("three"));
 
     verify(numberCachingTier, times(1)).invalidate(1);
     verify(numberCachingTier, times(1)).invalidate(2);
@@ -401,9 +400,9 @@ public class TieredStoreTest {
       .asList(newMapEntry(1, "one"), newMapEntry(2, "two"), newMapEntry(3, "three"))), () -> true);
 
     assertThat(result.size(), is(3));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(result.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(result.get(1).get(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(result.get(2).get(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(result.get(3).get(), Matchers.<CharSequence>equalTo("three"));
 
     verify(numberCachingTier, times(1)).invalidate(1);
     verify(numberCachingTier, times(1)).invalidate(2);
@@ -439,9 +438,9 @@ public class TieredStoreTest {
     Map<Number, Store.ValueHolder<CharSequence>> result = tieredStore.bulkComputeIfAbsent(new HashSet<Number>(Arrays.asList(1, 2, 3)), numbers -> Arrays.asList(newMapEntry(1, "one"), newMapEntry(2, "two"), newMapEntry(3, "three")));
 
     assertThat(result.size(), is(3));
-    assertThat(result.get(1).value(), Matchers.<CharSequence>equalTo("one"));
-    assertThat(result.get(2).value(), Matchers.<CharSequence>equalTo("two"));
-    assertThat(result.get(3).value(), Matchers.<CharSequence>equalTo("three"));
+    assertThat(result.get(1).get(), Matchers.<CharSequence>equalTo("one"));
+    assertThat(result.get(2).get(), Matchers.<CharSequence>equalTo("two"));
+    assertThat(result.get(3).get(), Matchers.<CharSequence>equalTo("three"));
 
     verify(numberCachingTier, times(1)).invalidate(1);
     verify(numberCachingTier, times(1)).invalidate(2);
@@ -576,7 +575,7 @@ public class TieredStoreTest {
     return new Store.ValueHolder<CharSequence>() {
 
       @Override
-      public CharSequence value() {
+      public CharSequence get() {
         return v;
       }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreWith3TiersSPITest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreWith3TiersSPITest.java
@@ -239,7 +239,7 @@ public class TieredStoreWith3TiersSPITest extends StoreSPITest<String, String> {
         return new Store.ValueHolder<String>() {
 
           @Override
-          public String value() {
+          public String get() {
             return value;
           }
 

--- a/impl/src/test/java/org/ehcache/impl/internal/util/Matchers.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/util/Matchers.java
@@ -17,7 +17,6 @@
 package org.ehcache.impl.internal.util;
 
 import org.ehcache.Cache;
-import org.ehcache.ValueSupplier;
 import org.ehcache.event.EventType;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.events.StoreEvent;
@@ -25,26 +24,13 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import java.util.function.Supplier;
+
 /**
  *
  * @author cdennis
  */
 public class Matchers {
-
-  public static <K> Matcher<Cache<? super K, ?>> hasKey(final K key) {
-    return new TypeSafeMatcher<Cache<? super K, ?>>() {
-
-      @Override
-      protected boolean matchesSafely(Cache<? super K, ?> item) {
-        return item.containsKey(key);
-      }
-
-      @Override
-      public void describeTo(Description description) {
-        description.appendText("cache containing key '").appendValue(key).appendText("'");
-      }
-    };
-  }
 
   public static <K, V> Matcher<Cache<? super K, ? super V>> hasEntry(final K key, final V value) {
     return new TypeSafeMatcher<Cache<? super K, ? super V>>() {
@@ -65,7 +51,7 @@ public class Matchers {
     return new TypeSafeMatcher<Store.ValueHolder<V>>() {
       @Override
       protected boolean matchesSafely(Store.ValueHolder<V> item) {
-        return item.value().equals(value);
+        return item.get().equals(value);
       }
 
       @Override
@@ -75,11 +61,11 @@ public class Matchers {
     };
   }
 
-  public static <V> Matcher<ValueSupplier<V>> holding(final V value) {
-    return new TypeSafeMatcher<ValueSupplier<V>>() {
+  public static <V> Matcher<Supplier<V>> holding(final V value) {
+    return new TypeSafeMatcher<Supplier<V>>() {
       @Override
-      protected boolean matchesSafely(ValueSupplier<V> item) {
-        return item.value().equals(value);
+      protected boolean matchesSafely(Supplier<V> item) {
+        return item.get().equals(value);
       }
 
       @Override

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/SoftLockValueCombinedCopier.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/SoftLockValueCombinedCopier.java
@@ -36,7 +36,7 @@ class SoftLockValueCombinedCopier<T> implements Copier<SoftLock<T>> {
     T oldValue = valueCopier.copyForRead(obj.getOldValue());
     XAValueHolder<T> valueHolder = obj.getNewValueHolder();
     XAValueHolder<T> newValueHolder = valueHolder == null ? null : new XAValueHolder<>(valueHolder, valueCopier.copyForRead(valueHolder
-      .value()));
+      .get()));
     return new SoftLock<>(obj.getTransactionId(), oldValue, newValueHolder);
   }
 
@@ -45,7 +45,7 @@ class SoftLockValueCombinedCopier<T> implements Copier<SoftLock<T>> {
     T oldValue = valueCopier.copyForWrite(obj.getOldValue());
     XAValueHolder<T> valueHolder = obj.getNewValueHolder();
     XAValueHolder<T> newValueHolder = valueHolder == null ? null : new XAValueHolder<>(valueHolder, valueCopier.copyForWrite(valueHolder
-      .value()));
+      .get()));
     return new SoftLock<>(obj.getTransactionId(), oldValue, newValueHolder);
   }
 

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAStore.java
@@ -17,7 +17,6 @@
 package org.ehcache.transactions.xa.internal;
 
 import org.ehcache.Cache;
-import org.ehcache.ValueSupplier;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.CacheConfigurationChangeListener;
 import org.ehcache.config.EvictionAdvisor;
@@ -78,7 +77,6 @@ import javax.transaction.Transaction;
 
 import static org.ehcache.core.spi.service.ServiceUtils.findAmongst;
 import static org.ehcache.core.spi.service.ServiceUtils.findSingletonAmongst;
-import static org.ehcache.core.internal.util.ValueSuppliers.supplierOf;
 
 /**
  * A {@link Store} implementation wrapping another {@link Store} driven by a JTA
@@ -203,7 +201,7 @@ public class XAStore<K, V> implements Store<K, V> {
       return null;
     }
 
-    SoftLock<V> softLock = softLockValueHolder.value();
+    SoftLock<V> softLock = softLockValueHolder.get();
     if (isInDoubt(softLock)) {
       currentContext.addCommand(key, new StoreEvictCommand<>(softLock.getOldValue()));
       return null;
@@ -219,7 +217,7 @@ public class XAStore<K, V> implements Store<K, V> {
       return getCurrentContext().newValueHolderOf(key) != null;
     }
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
-    return softLockValueHolder != null && softLockValueHolder.value().getTransactionId() == null && softLockValueHolder.value().getOldValue() != null;
+    return softLockValueHolder != null && softLockValueHolder.get().getTransactionId() == null && softLockValueHolder.get().getOldValue() != null;
   }
 
   @Override
@@ -235,7 +233,7 @@ public class XAStore<K, V> implements Store<K, V> {
 
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
     if (softLockValueHolder != null) {
-      SoftLock<V> softLock = softLockValueHolder.value();
+      SoftLock<V> softLock = softLockValueHolder.get();
       if (isInDoubt(softLock)) {
         currentContext.addCommand(key, new StoreEvictCommand<>(softLock.getOldValue()));
       } else {
@@ -266,7 +264,7 @@ public class XAStore<K, V> implements Store<K, V> {
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
     boolean status = false;
     if (softLockValueHolder != null) {
-      SoftLock<V> softLock = softLockValueHolder.value();
+      SoftLock<V> softLock = softLockValueHolder.get();
       if (isInDoubt(softLock)) {
         currentContext.addCommand(key, new StoreEvictCommand<>(softLock.getOldValue()));
       } else {
@@ -294,7 +292,7 @@ public class XAStore<K, V> implements Store<K, V> {
 
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
     if (softLockValueHolder != null) {
-      SoftLock<V> softLock = softLockValueHolder.value();
+      SoftLock<V> softLock = softLockValueHolder.get();
       if (isInDoubt(softLock)) {
         currentContext.addCommand(key, new StoreEvictCommand<>(softLock.getOldValue()));
         return null;
@@ -327,7 +325,7 @@ public class XAStore<K, V> implements Store<K, V> {
 
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
     if (softLockValueHolder != null) {
-      SoftLock<V> softLock = softLockValueHolder.value();
+      SoftLock<V> softLock = softLockValueHolder.get();
       if (isInDoubt(softLock)) {
         currentContext.addCommand(key, new StoreEvictCommand<>(softLock.getOldValue()));
         return RemoveStatus.KEY_MISSING;
@@ -361,7 +359,7 @@ public class XAStore<K, V> implements Store<K, V> {
 
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
     if (softLockValueHolder != null) {
-      SoftLock<V> softLock = softLockValueHolder.value();
+      SoftLock<V> softLock = softLockValueHolder.get();
       if (isInDoubt(softLock)) {
         currentContext.addCommand(key, new StoreEvictCommand<>(softLock.getOldValue()));
         return null;
@@ -396,7 +394,7 @@ public class XAStore<K, V> implements Store<K, V> {
 
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
     if (softLockValueHolder != null) {
-      SoftLock<V> softLock = softLockValueHolder.value();
+      SoftLock<V> softLock = softLockValueHolder.get();
       V previousValue = softLock.getOldValue();
       if (isInDoubt(softLock)) {
         currentContext.addCommand(key, new StoreEvictCommand<>(previousValue));
@@ -476,10 +474,10 @@ public class XAStore<K, V> implements Store<K, V> {
 
         if (!transactionContextFactory.isTouched(transactionId, next.getKey())) {
           ValueHolder<SoftLock<V>> valueHolder = next.getValue();
-          SoftLock<V> softLock = valueHolder.value();
+          SoftLock<V> softLock = valueHolder.get();
           final XAValueHolder<V> xaValueHolder;
           if (softLock.getTransactionId() == transactionId) {
-            xaValueHolder = new XAValueHolder<>(valueHolder, softLock.getNewValueHolder().value());
+            xaValueHolder = new XAValueHolder<>(valueHolder, softLock.getNewValueHolder().get());
           } else if (isInDoubt(softLock)) {
             continue;
           } else {
@@ -537,7 +535,7 @@ public class XAStore<K, V> implements Store<K, V> {
 
     ValueHolder<SoftLock<V>> softLockValueHolder = getSoftLockValueHolderFromUnderlyingStore(key);
 
-    SoftLock<V> softLock = softLockValueHolder == null ? null : softLockValueHolder.value();
+    SoftLock<V> softLock = softLockValueHolder == null ? null : softLockValueHolder.get();
     V oldValue = softLock == null ? null : softLock.getOldValue();
     V newValue = mappingFunction.apply(key, oldValue);
     XAValueHolder<V> xaValueHolder = newValue == null ? null : new XAValueHolder<>(newValue, timeSource.getTimeMillis());
@@ -594,14 +592,14 @@ public class XAStore<K, V> implements Store<K, V> {
           xaValueHolder = null;
         }
       }
-    } else if (isInDoubt(softLockValueHolder.value())) {
-      currentContext.addCommand(key, new StoreEvictCommand<>(softLockValueHolder.value().getOldValue()));
-      xaValueHolder = new XAValueHolder<>(softLockValueHolder, softLockValueHolder.value().getNewValueHolder().value());
+    } else if (isInDoubt(softLockValueHolder.get())) {
+      currentContext.addCommand(key, new StoreEvictCommand<>(softLockValueHolder.get().getOldValue()));
+      xaValueHolder = new XAValueHolder<>(softLockValueHolder, softLockValueHolder.get().getNewValueHolder().get());
     } else {
       if (updated) {
         xaValueHolder = currentContext.newValueHolderOf(key);
       } else {
-        xaValueHolder = new XAValueHolder<>(softLockValueHolder, softLockValueHolder.value().getOldValue());
+        xaValueHolder = new XAValueHolder<>(softLockValueHolder, softLockValueHolder.get().getOldValue());
       }
     }
 
@@ -801,15 +799,15 @@ public class XAStore<K, V> implements Store<K, V> {
         }
 
         @Override
-        public Duration getExpiryForAccess(K key, final ValueSupplier<? extends SoftLock<V>> softLock) {
-          if (softLock.value().getTransactionId() != null) {
+        public Duration getExpiryForAccess(K key, Supplier<? extends SoftLock<V>> softLock) {
+          if (softLock.get().getTransactionId() != null) {
             // phase 1 prepare, access -> forever
             return ExpiryPolicy.INFINITE;
           } else {
             // phase 2 commit, or during a TX's lifetime, access -> some time
             Duration duration;
             try {
-              duration = configuredExpiry.getExpiryForAccess(key, supplierOf(softLock.value().getOldValue()));
+              duration = configuredExpiry.getExpiryForAccess(key, () -> softLock.get().getOldValue());
             } catch (RuntimeException re) {
               LOGGER.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
               return Duration.ZERO;
@@ -819,8 +817,8 @@ public class XAStore<K, V> implements Store<K, V> {
         }
 
         @Override
-        public Duration getExpiryForUpdate(K key, ValueSupplier<? extends SoftLock<V>> oldSoftLockSupplier, SoftLock<V> newSoftLock) {
-          SoftLock<V> oldSoftLock = oldSoftLockSupplier.value();
+        public Duration getExpiryForUpdate(K key, Supplier<? extends SoftLock<V>> oldSoftLockSupplier, SoftLock<V> newSoftLock) {
+          SoftLock<V> oldSoftLock = oldSoftLockSupplier.get();
           if (oldSoftLock.getTransactionId() == null) {
             // phase 1 prepare, update -> forever
             return ExpiryPolicy.INFINITE;
@@ -839,10 +837,10 @@ public class XAStore<K, V> implements Store<K, V> {
             } else {
               // there is an old value -> it's an UPDATE, update -> some time
               V value = oldSoftLock.getNewValueHolder() == null ? null : oldSoftLock
-                  .getNewValueHolder().value();
+                  .getNewValueHolder().get();
               Duration duration;
               try {
-                duration = configuredExpiry.getExpiryForUpdate(key, supplierOf(oldSoftLock.getOldValue()), value);
+                duration = configuredExpiry.getExpiryForUpdate(key, oldSoftLock::getOldValue, value);
               } catch (RuntimeException re) {
                 LOGGER.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
                 return Duration.ZERO;

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/XATransactionContext.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/XATransactionContext.java
@@ -123,7 +123,7 @@ public class XATransactionContext<K, V> {
   public V newValueOf(K key) {
     Command<V> command = commands.get(key);
     XAValueHolder<V> valueHolder = command == null ? null : command.getNewValueHolder();
-    return valueHolder == null ? null : valueHolder.value();
+    return valueHolder == null ? null : valueHolder.get();
   }
 
   public int prepare() throws StoreAccessException, IllegalStateException, TransactionTimeoutException {
@@ -186,7 +186,7 @@ public class XATransactionContext<K, V> {
     for (K key : keys) {
       SoftLock<V> preparedSoftLock = getFromUnderlyingStore(key);
       XAValueHolder<V> newValueHolder = preparedSoftLock == null ? null : preparedSoftLock.getNewValueHolder();
-      SoftLock<V> definitiveSoftLock = newValueHolder == null ? null : new SoftLock<>(null, newValueHolder.value(), null);
+      SoftLock<V> definitiveSoftLock = newValueHolder == null ? null : new SoftLock<>(null, newValueHolder.get(), null);
 
       if (preparedSoftLock != null) {
         if (preparedSoftLock.getTransactionId() != null && !preparedSoftLock.getTransactionId().equals(transactionId)) {
@@ -298,7 +298,7 @@ public class XATransactionContext<K, V> {
 
   private SoftLock<V> getFromUnderlyingStore(K key) throws StoreAccessException {
     Store.ValueHolder<SoftLock<V>> softLockValueHolder = underlyingStore.get(key);
-    return softLockValueHolder == null ? null : softLockValueHolder.value();
+    return softLockValueHolder == null ? null : softLockValueHolder.get();
   }
 
   private void evictFromUnderlyingStore(K key) throws StoreAccessException {

--- a/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAValueHolder.java
+++ b/transactions/src/main/java/org/ehcache/transactions/xa/internal/XAValueHolder.java
@@ -90,7 +90,7 @@ public class XAValueHolder<V> extends AbstractValueHolder<V> implements Serializ
   }
 
   @Override
-  public V value() {
+  public V get() {
     return value;
   }
 
@@ -116,7 +116,7 @@ public class XAValueHolder<V> extends AbstractValueHolder<V> implements Serializ
 
   private Object writeReplace() {
     return new SerializedXAValueHolder<>(getId(), creationTime(NATIVE_TIME_UNIT), lastAccessTime(NATIVE_TIME_UNIT), expirationTime(NATIVE_TIME_UNIT),
-      hits(), value(), valueSerialized);
+      hits(), get(), valueSerialized);
   }
 
   /**

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XATransactionContextTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XATransactionContextTest.java
@@ -97,7 +97,7 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.removed(1L), is(false));
     assertThat(xaTransactionContext.updated(1L), is(true));
     assertThat(xaTransactionContext.evicted(1L), is(false));
-    assertThat(xaTransactionContext.newValueHolderOf(1L).value(), equalTo("new"));
+    assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
     assertThat(xaTransactionContext.newValueOf(1L), equalTo("new"));
 
@@ -132,7 +132,7 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.removed(1L), is(false));
     assertThat(xaTransactionContext.updated(1L), is(true));
     assertThat(xaTransactionContext.evicted(1L), is(false));
-    assertThat(xaTransactionContext.newValueHolderOf(1L).value(), equalTo("new"));
+    assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
     assertThat(xaTransactionContext.newValueOf(1L), equalTo("new"));
 
@@ -159,7 +159,7 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.removed(1L), is(false));
     assertThat(xaTransactionContext.updated(1L), is(true));
     assertThat(xaTransactionContext.evicted(1L), is(false));
-    assertThat(xaTransactionContext.newValueHolderOf(1L).value(), equalTo("new2"));
+    assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new2"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old2"));
     assertThat(xaTransactionContext.newValueOf(1L), equalTo("new2"));
   }
@@ -176,7 +176,7 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.removed(1L), is(false));
     assertThat(xaTransactionContext.updated(1L), is(true));
     assertThat(xaTransactionContext.evicted(1L), is(false));
-    assertThat(xaTransactionContext.newValueHolderOf(1L).value(), equalTo("new"));
+    assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
     assertThat(xaTransactionContext.newValueOf(1L), equalTo("new"));
 
@@ -238,7 +238,7 @@ public class XATransactionContextTest {
     xaTransactionContext.addCommand(3L, new StoreEvictCommand<>("three"));
 
     Store.ValueHolder<SoftLock<String>> mockValueHolder = mock(Store.ValueHolder.class);
-    when(mockValueHolder.value()).thenReturn(new SoftLock<>(null, "two", null));
+    when(mockValueHolder.get()).thenReturn(new SoftLock<>(null, "two", null));
     when(underlyingStore.get(eq(2L))).thenReturn(mockValueHolder);
     when(underlyingStore.replace(eq(2L), eq(new SoftLock<>(null, "two", null)), eq(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "two", null)))).thenReturn(ReplaceStatus.HIT);
 
@@ -280,7 +280,7 @@ public class XATransactionContextTest {
 
     @SuppressWarnings("unchecked")
     Store.ValueHolder<SoftLock<String>> mockValueHolder = mock(Store.ValueHolder.class);
-    when(mockValueHolder.value()).thenReturn(new SoftLock<>(null, "two", null));
+    when(mockValueHolder.get()).thenReturn(new SoftLock<>(null, "two", null));
     when(underlyingStore.get(eq(2L))).thenReturn(mockValueHolder);
 
     try {
@@ -304,14 +304,14 @@ public class XATransactionContextTest {
     xaTransactionContext.addCommand(3L, new StoreEvictCommand<>("three"));
 
     Store.ValueHolder<SoftLock<String>> mockValueHolder1 = mock(Store.ValueHolder.class);
-    when(mockValueHolder1.value()).thenReturn(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "one", new XAValueHolder<>("un", timeSource
+    when(mockValueHolder1.get()).thenReturn(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "one", new XAValueHolder<>("un", timeSource
       .getTimeMillis())));
     when(underlyingStore.get(eq(1L))).thenReturn(mockValueHolder1);
     Store.ValueHolder<SoftLock<String>> mockValueHolder2 = mock(Store.ValueHolder.class);
-    when(mockValueHolder2.value()).thenReturn(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "two", null));
+    when(mockValueHolder2.get()).thenReturn(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "two", null));
     when(underlyingStore.get(eq(2L))).thenReturn(mockValueHolder2);
     Store.ValueHolder<SoftLock<String>> mockValueHolder3 = mock(Store.ValueHolder.class);
-    when(mockValueHolder3.value()).thenReturn(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "three", null));
+    when(mockValueHolder3.get()).thenReturn(new SoftLock<>(new TransactionId(new TestXid(0, 0)), "three", null));
     when(underlyingStore.get(eq(3L))).thenReturn(mockValueHolder3);
 
     when(journal.isInDoubt(eq(new TransactionId(new TestXid(0, 0))))).thenReturn(true);
@@ -364,7 +364,7 @@ public class XATransactionContextTest {
     xaTransactionContext.addCommand(3L, new StoreEvictCommand<>("three"));
 
     Store.ValueHolder<SoftLock<String>> mockValueHolder = mock(Store.ValueHolder.class);
-    when(mockValueHolder.value()).thenReturn(new SoftLock<>(null, "two", null));
+    when(mockValueHolder.get()).thenReturn(new SoftLock<>(null, "two", null));
     when(underlyingStore.get(eq(2L))).thenReturn(mockValueHolder);
 
     final AtomicReference<Collection<Long>> savedInDoubtCollectionRef = new AtomicReference<>();
@@ -377,7 +377,7 @@ public class XATransactionContextTest {
     final AtomicReference<SoftLock> softLock1Ref = new AtomicReference<>();
     when(underlyingStore.get(eq(1L))).then(invocation -> softLock1Ref.get() == null ? null : new AbstractValueHolder(-1, -1) {
       @Override
-      public Object value() {
+      public Object get() {
         return softLock1Ref.get();
       }
       @Override
@@ -398,7 +398,7 @@ public class XATransactionContextTest {
     final AtomicReference<SoftLock> softLock2Ref = new AtomicReference<>(new SoftLock(null, "two", null));
     when(underlyingStore.get(eq(2L))).then(invocation -> softLock2Ref.get() == null ? null : new AbstractValueHolder(-1, -1) {
       @Override
-      public Object value() {
+      public Object get() {
         return softLock2Ref.get();
       }
       @Override
@@ -470,7 +470,7 @@ public class XATransactionContextTest {
         return TimeUnit.MILLISECONDS;
       }
       @Override
-      public SoftLock<String> value() {
+      public SoftLock<String> get() {
         return new SoftLock<>(new TransactionId(new TestXid(0, 0)), "one", new XAValueHolder<>("un", timeSource.getTimeMillis()));
       }
     });
@@ -480,7 +480,7 @@ public class XATransactionContextTest {
         return TimeUnit.MILLISECONDS;
       }
       @Override
-      public SoftLock<String> value() {
+      public SoftLock<String> get() {
         return new SoftLock<>(new TransactionId(new TestXid(0, 0)), "two", null);
       }
     });
@@ -551,7 +551,7 @@ public class XATransactionContextTest {
         return TimeUnit.MILLISECONDS;
       }
       @Override
-      public SoftLock<String> value() {
+      public SoftLock<String> get() {
         return new SoftLock<>(new TransactionId(new TestXid(0, 0)), "old1", new XAValueHolder<>("new1", timeSource
           .getTimeMillis()));
       }
@@ -562,7 +562,7 @@ public class XATransactionContextTest {
         return TimeUnit.MILLISECONDS;
       }
       @Override
-      public SoftLock<String> value() {
+      public SoftLock<String> get() {
         return new SoftLock<>(new TransactionId(new TestXid(0, 0)), "old2", null);
       }
     });
@@ -617,7 +617,7 @@ public class XATransactionContextTest {
         return TimeUnit.MILLISECONDS;
       }
       @Override
-      public SoftLock<String> value() {
+      public SoftLock<String> get() {
         return new SoftLock<>(new TransactionId(new TestXid(0, 0)), "old1", new XAValueHolder<>("new1", timeSource
           .getTimeMillis()));
       }
@@ -628,7 +628,7 @@ public class XATransactionContextTest {
         return TimeUnit.MILLISECONDS;
       }
       @Override
-      public SoftLock<String> value() {
+      public SoftLock<String> get() {
         return new SoftLock<>(new TransactionId(new TestXid(0, 0)), "old2", null);
       }
     });

--- a/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAValueHolderTest.java
+++ b/transactions/src/test/java/org/ehcache/transactions/xa/internal/XAValueHolderTest.java
@@ -52,7 +52,7 @@ public class XAValueHolderTest {
     assertThat(result.creationTime(TimeUnit.MILLISECONDS), is(valueHolder.creationTime(TimeUnit.MILLISECONDS)));
     assertThat(result.lastAccessTime(TimeUnit.MILLISECONDS), is(valueHolder.lastAccessTime(TimeUnit.MILLISECONDS)));
     assertThat(result.expirationTime(TimeUnit.MILLISECONDS), is(valueHolder.expirationTime(TimeUnit.MILLISECONDS)));
-    assertThat(result.value(), is(valueHolder.value()));
+    assertThat(result.get(), is(valueHolder.get()));
     assertThat(result.hits(), is(valueHolder.hits()));
   }
 }

--- a/xml/src/test/java/com/pany/ehcache/MyExpiry.java
+++ b/xml/src/test/java/com/pany/ehcache/MyExpiry.java
@@ -16,27 +16,27 @@
 
 package com.pany.ehcache;
 
-import org.ehcache.ValueSupplier;
 import org.ehcache.expiry.ExpiryPolicy;
 
 import java.time.Duration;
+import java.util.function.Supplier;
 
 /**
  * @author Alex Snaps
  */
 public class MyExpiry implements ExpiryPolicy<Object, Object> {
   @Override
-  public Duration getExpiryForCreation(final Object key, final Object value) {
+  public Duration getExpiryForCreation(Object key, Object value) {
     return Duration.ofSeconds(42);
   }
 
   @Override
-  public Duration getExpiryForAccess(final Object key, final ValueSupplier<? extends Object> value) {
+  public Duration getExpiryForAccess(Object key, Supplier<? extends Object> value) {
     return Duration.ofSeconds(42);
   }
 
   @Override
-  public Duration getExpiryForUpdate(Object key, ValueSupplier<? extends Object> oldValue, Object newValue) {
+  public Duration getExpiryForUpdate(Object key, Supplier<? extends Object> oldValue, Object newValue) {
     return Duration.ofSeconds(42);
   }
 }


### PR DESCRIPTION
Since we just replaced Expiry by ExpiryPolicy, I fell that we can also remove ValueSupplier. It is currently deprecated to keep the Expiry API.