### PR TITLE
Fix findbugs error in ClusteringServiceConfigurationParser.java

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java
@@ -155,6 +155,10 @@ public class ClusteringServiceConfigurationParser implements CacheManagerService
                */
               serverConfig = processServerSideConfig(item);
               break;
+            default:
+              throw new XmlConfigurationException(
+                String.format("Unknown XML configuration element <%s> in <%s>",
+                              item.getNodeName(), fragment.getTagName()));
           }
         }
       }


### PR DESCRIPTION
This PR fixes below findbugs error by throwing XmlConfigurationException in default case. Please review. let me know if any changes needed. 

```xml
  <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE">
    <Class classname="org.ehcache.clustered.client.internal.config.xml.ClusteringServiceConfigurationParser">
      <SourceLine classname="org.ehcache.clustered.client.internal.config.xml.ClusteringServiceConfigurationParser" start="64" end="261" sourcefile="ClusteringServiceConfigurationParser.java" sourcepath="org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java"/>
    </Class>
    <Method classname="org.ehcache.clustered.client.internal.config.xml.ClusteringServiceConfigurationParser" name="parseServiceCreationConfiguration" signature="(Lorg/w3c/dom/Element;)Lorg/ehcache/spi/service/ServiceCreationConfiguration;" isStatic="false">
      <SourceLine classname="org.ehcache.clustered.client.internal.config.xml.ClusteringServiceConfigurationParser" start="106" end="180" startBytecode="0" endBytecode="1147" sourcefile="ClusteringServiceConfigurationParser.java" sourcepath="org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java"/>
    </Method>
    <SourceLine classname="org.ehcache.clustered.client.internal.config.xml.ClusteringServiceConfigurationParser" start="115" end="156" startBytecode="219" endBytecode="384" sourcefile="ClusteringServiceConfigurationParser.java" sourcepath="org/ehcache/clustered/client/internal/config/xml/ClusteringServiceConfigurationParser.java"/>
  </BugInstance>
```