### PR TITLE
Test that StorePassThroughExceptions are handled correctly

### DIFF
--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.internal.store;
 
+import org.ehcache.core.exceptions.StorePassThroughException;
 import org.ehcache.core.spi.store.StoreAccessException;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.spi.test.After;
@@ -24,6 +25,7 @@ import org.ehcache.spi.test.LegalSPITesterException;
 import org.ehcache.spi.test.SPITest;
 
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -276,6 +278,33 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
       //expected
     } catch (StoreAccessException e) {
       throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
+    }
+  }
+
+  @SPITest
+  public void exception() throws Exception {
+    Set<K> inputKeys = Collections.singleton(factory.createKey(0));
+
+    RuntimeException exception = new RuntimeException("error");
+
+    try {
+      kvStore.bulkCompute(inputKeys, entries -> { throw exception; });
+    } catch (StoreAccessException e) {
+      assertThat(e.getCause(), is(exception));
+    }
+  }
+
+  @SPITest
+  public void passThroughException() throws Exception {
+    Set<K> inputKeys = Collections.singleton(factory.createKey(0));
+
+    RuntimeException exception = new RuntimeException("error");
+    StorePassThroughException ste = new StorePassThroughException(exception);
+
+    try {
+      kvStore.bulkCompute(inputKeys, entries -> { throw ste; });
+    } catch (RuntimeException e) {
+      assertThat(e, is(exception));
     }
   }
 }

--- a/core/src/main/java/org/ehcache/core/exceptions/StorePassThroughException.java
+++ b/core/src/main/java/org/ehcache/core/exceptions/StorePassThroughException.java
@@ -48,6 +48,13 @@ public class StorePassThroughException extends RuntimeException {
     super(cause);
   }
 
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    // skip the stack trace filling because this exception is just a placeholder and won't ever be caught outside of
+    // a store
+    return this;
+  }
+
   /**
    * Helper method for handling runtime exceptions.
    * <p>

--- a/core/src/test/java/org/ehcache/core/exceptions/StorePassThroughExceptionTest.java
+++ b/core/src/test/java/org/ehcache/core/exceptions/StorePassThroughExceptionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.core.exceptions;
+
+import org.ehcache.core.spi.store.StoreAccessException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class StorePassThroughExceptionTest {
+
+  @Test
+  public void fillInStackTrace() {
+    StorePassThroughException e = new StorePassThroughException(new Exception());
+    assertThat(e.getStackTrace()).isEmpty();
+  }
+
+  @Test
+  public void handleRuntimeException_runtimeWrappedInStoreAccessException() {
+    RuntimeException re = new RuntimeException();
+    StoreAccessException sae = StorePassThroughException.handleRuntimeException(re);
+    assertThat(sae.getCause()).isSameAs(re);
+  }
+
+  @Test
+  public void handleRuntimeException_storePassThroughExceptionUnwrappedIfRuntime() {
+    RuntimeException re = new RuntimeException();
+    assertThatExceptionOfType(RuntimeException.class)
+      .isThrownBy(() -> StorePassThroughException.handleRuntimeException(new StorePassThroughException(re)))
+      .isSameAs(re);
+  }
+
+  @Test
+  public void handleRuntimeException_storePassThroughExceptionCauseWrapped() {
+    Exception e = new Exception();
+    StoreAccessException sae = StorePassThroughException.handleRuntimeException(new StorePassThroughException(e));
+    assertThat(sae.getCause()).isSameAs(e);
+  }
+}


### PR DESCRIPTION
It is expected that StorePassThroughExceptions thrown are supposed to have their cause being thrown in the end instead of being wrapped in a StoreAccessException.