### PR TITLE
 Close #2187: Latency statistics (Cache:GetLatency)

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
@@ -18,7 +18,6 @@ package org.ehcache.clustered.management;
 import org.ehcache.Cache;
 import org.ehcache.config.units.EntryUnit;
 import org.ehcache.config.units.MemoryUnit;
-import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -93,7 +92,8 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
     new StatisticDescriptor("Cache:PutCount", "COUNTER"),
     new StatisticDescriptor("Cache:RemovalCount", "COUNTER"),
     new StatisticDescriptor("Cache:EvictionCount", "COUNTER"),
-    new StatisticDescriptor("Cache:ExpirationCount", "COUNTER")
+    new StatisticDescriptor("Cache:ExpirationCount", "COUNTER"),
+    new StatisticDescriptor("Cache:GetLatency", "GAUGE")
   );
   private static final Collection<StatisticDescriptor> POOL_DESCRIPTORS = Arrays.asList(
     new StatisticDescriptor("Pool:AllocatedSize", "GAUGE")

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolStatisticsManagementProvider.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/management/PoolStatisticsManagementProvider.java
@@ -60,10 +60,10 @@ class PoolStatisticsManagementProvider extends AbstractStatisticsManagementProvi
     PoolBinding.AllocationType allocationType = managedObject.getAllocationType();
 
     if (allocationType == PoolBinding.AllocationType.DEDICATED) {
-      return new StatisticRegistry(ehcacheStateService.getDedicatedResourcePageSource(poolName));
+      return new StatisticRegistry(ehcacheStateService.getDedicatedResourcePageSource(poolName), () -> getTimeSource().getTimestamp());
 
     } else {
-      return new StatisticRegistry(ehcacheStateService.getSharedResourcePageSource(poolName));
+      return new StatisticRegistry(ehcacheStateService.getSharedResourcePageSource(poolName), () -> getTimeSource().getTimestamp());
     }
   }
 

--- a/core/src/main/java/org/ehcache/core/spi/service/StatisticsService.java
+++ b/core/src/main/java/org/ehcache/core/spi/service/StatisticsService.java
@@ -24,5 +24,7 @@ import org.ehcache.spi.service.Service;
  */
 public interface StatisticsService extends Service {
 
+  StatisticsServiceConfiguration getConfiguration();
+
   CacheStatistics getCacheStatistics(String cacheName);
 }

--- a/core/src/main/java/org/ehcache/core/spi/service/StatisticsServiceConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/spi/service/StatisticsServiceConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.core.spi.service;
+
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+import java.util.concurrent.TimeUnit;
+
+public interface StatisticsServiceConfiguration extends ServiceCreationConfiguration<StatisticsService> {
+
+  /**
+   * Aggregation is done by keeping the maximum value that has been seen.
+   * A low value (i.e. 500ms) is better.
+   *
+   * @return The interval used to aggregate the latencies of Ehcache operations to create one latency sample.
+   */
+  long getLatencyHistoryWindowInterval();
+
+  /**
+   * @return the unit for the latency history interval
+   */
+  TimeUnit getLatencyHistoryWindowUnit();
+
+  /**
+   * @return the maximum number of maximum latency samples to keep.
+   */
+  int getLatencyHistorySize();
+
+}

--- a/core/src/main/java/org/ehcache/core/statistics/CacheStatistics.java
+++ b/core/src/main/java/org/ehcache/core/statistics/CacheStatistics.java
@@ -16,6 +16,7 @@
 
 package org.ehcache.core.statistics;
 
+import org.terracotta.statistics.SampledStatistic;
 import org.terracotta.statistics.ValueStatistic;
 
 import java.util.Map;
@@ -130,4 +131,15 @@ public interface CacheStatistics {
    * @return average remove response time
    */
   float getCacheAverageRemoveTime();
+
+  /**
+   * The statistic used to access the latest history of latencies for {@link org.ehcache.Cache#get(Object)}
+   * operations leading to a {@link org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome#HIT}.
+   * <p>
+   * The history and latency aggregation is controlled through the {@link org.ehcache.core.spi.service.StatisticsServiceConfiguration}.
+   *
+   * @return the sampled statistic
+   */
+  SampledStatistic<Long> getCacheGetLatencyHistory();
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 
 # Terracotta third parties
 offheapVersion = 2.4.0
-statisticVersion = 2.0.2
+statisticVersion = 2.0.3
 jcacheVersion = 1.1.0
 slf4jVersion = 1.7.25
 sizeofVersion = 0.3.0
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.4.0-pre15
+terracottaPlatformVersion = 5.4.0-pre16
 terracottaApisVersion = 1.4.0-pre8
 terracottaCoreVersion = 5.4.0-pre18
 terracottaPassthroughTestingVersion = 1.4.0-pre11

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultCacheStatistics.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultCacheStatistics.java
@@ -16,25 +16,32 @@
 
 package org.ehcache.impl.internal.statistics;
 
+import org.ehcache.core.InternalCache;
+import org.ehcache.core.spi.service.StatisticsServiceConfiguration;
+import org.ehcache.core.spi.time.TimeSource;
+import org.ehcache.core.statistics.BulkOps;
+import org.ehcache.core.statistics.CacheOperationOutcomes.GetOutcome;
+import org.ehcache.core.statistics.CacheOperationOutcomes.PutOutcome;
+import org.ehcache.core.statistics.CacheStatistics;
+import org.ehcache.core.statistics.TierStatistics;
+import org.terracotta.statistics.OperationStatistic;
+import org.terracotta.statistics.SampledStatistic;
+import org.terracotta.statistics.ValueStatistic;
+import org.terracotta.statistics.derived.OperationResultFilter;
+import org.terracotta.statistics.derived.latency.Jsr107LatencyMonitor;
+import org.terracotta.statistics.derived.latency.MaximumLatencyHistory;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.LongAdder;
 
-import org.ehcache.core.InternalCache;
-import org.ehcache.core.statistics.BulkOps;
-import org.ehcache.core.statistics.CacheOperationOutcomes;
-import org.ehcache.core.statistics.CacheStatistics;
-import org.ehcache.core.statistics.TierStatistics;
-import org.terracotta.statistics.OperationStatistic;
-import org.terracotta.statistics.ValueStatistic;
-import org.terracotta.statistics.derived.LatencySampling;
-import org.terracotta.statistics.derived.MinMaxAverage;
-import org.terracotta.statistics.observer.ChainedOperationObserver;
-
 import static java.util.EnumSet.allOf;
+import static org.ehcache.core.statistics.CacheOperationOutcomes.ConditionalRemoveOutcome;
+import static org.ehcache.core.statistics.CacheOperationOutcomes.PutIfAbsentOutcome;
+import static org.ehcache.core.statistics.CacheOperationOutcomes.RemoveOutcome;
+import static org.ehcache.core.statistics.CacheOperationOutcomes.ReplaceOutcome;
 import static org.ehcache.impl.internal.statistics.StatsUtils.findLowestTier;
 import static org.ehcache.impl.internal.statistics.StatsUtils.findOperationStatisticOnChildren;
 import static org.ehcache.impl.internal.statistics.StatsUtils.findTiers;
@@ -47,45 +54,54 @@ class DefaultCacheStatistics implements CacheStatistics {
 
   private volatile CompensatingCounters compensatingCounters = CompensatingCounters.empty();
 
-  private final OperationStatistic<CacheOperationOutcomes.GetOutcome> get;
-  private final OperationStatistic<CacheOperationOutcomes.PutOutcome> put;
-  private final OperationStatistic<CacheOperationOutcomes.RemoveOutcome> remove;
-  private final OperationStatistic<CacheOperationOutcomes.PutIfAbsentOutcome> putIfAbsent;
-  private final OperationStatistic<CacheOperationOutcomes.ReplaceOutcome> replace;
-  private final OperationStatistic<CacheOperationOutcomes.ConditionalRemoveOutcome> conditionalRemove;
+  private final OperationStatistic<GetOutcome> get;
+  private final OperationStatistic<PutOutcome> put;
+  private final OperationStatistic<RemoveOutcome> remove;
+  private final OperationStatistic<PutIfAbsentOutcome> putIfAbsent;
+  private final OperationStatistic<ReplaceOutcome> replace;
+  private final OperationStatistic<ConditionalRemoveOutcome> conditionalRemove;
 
   private final Map<BulkOps, LongAdder> bulkMethodEntries;
 
-  private final LatencyMonitor<CacheOperationOutcomes.GetOutcome> averageGetTime;
-  private final LatencyMonitor<CacheOperationOutcomes.PutOutcome> averagePutTime;
-  private final LatencyMonitor<CacheOperationOutcomes.RemoveOutcome> averageRemoveTime;
+  private final Jsr107LatencyMonitor<GetOutcome> averageGetTime;
+  private final Jsr107LatencyMonitor<PutOutcome> averagePutTime;
+  private final Jsr107LatencyMonitor<RemoveOutcome> averageRemoveTime;
 
   private final Map<String, TierStatistics> tierStatistics;
   private final TierStatistics lowestTier;
 
   private final Map<String, ValueStatistic<?>> knownStatistics;
 
-  public DefaultCacheStatistics(InternalCache<?, ?> cache) {
+  private final MaximumLatencyHistory latencyHistory;
+
+  public DefaultCacheStatistics(InternalCache<?, ?> cache, StatisticsServiceConfiguration configuration, TimeSource timeSource) {
     bulkMethodEntries = cache.getBulkMethodEntries();
 
-    get = findOperationStatisticOnChildren(cache, CacheOperationOutcomes.GetOutcome.class, "get");
-    put = findOperationStatisticOnChildren(cache, CacheOperationOutcomes.PutOutcome.class, "put");
-    remove = findOperationStatisticOnChildren(cache, CacheOperationOutcomes.RemoveOutcome.class, "remove");
-    putIfAbsent = findOperationStatisticOnChildren(cache, CacheOperationOutcomes.PutIfAbsentOutcome.class, "putIfAbsent");
-    replace = findOperationStatisticOnChildren(cache, CacheOperationOutcomes.ReplaceOutcome.class, "replace");
-    conditionalRemove = findOperationStatisticOnChildren(cache, CacheOperationOutcomes.ConditionalRemoveOutcome.class, "conditionalRemove");
+    get = findOperationStatisticOnChildren(cache, GetOutcome.class, "get");
+    put = findOperationStatisticOnChildren(cache, PutOutcome.class, "put");
+    remove = findOperationStatisticOnChildren(cache, RemoveOutcome.class, "remove");
+    putIfAbsent = findOperationStatisticOnChildren(cache, PutIfAbsentOutcome.class, "putIfAbsent");
+    replace = findOperationStatisticOnChildren(cache, ReplaceOutcome.class, "replace");
+    conditionalRemove = findOperationStatisticOnChildren(cache, ConditionalRemoveOutcome.class, "conditionalRemove");
 
-    averageGetTime = new LatencyMonitor<>(allOf(CacheOperationOutcomes.GetOutcome.class));
+    averageGetTime = new Jsr107LatencyMonitor<>(allOf(GetOutcome.class), 1.0);
     get.addDerivedStatistic(averageGetTime);
-    averagePutTime = new LatencyMonitor<>(allOf(CacheOperationOutcomes.PutOutcome.class));
+    averagePutTime = new Jsr107LatencyMonitor<>(allOf(PutOutcome.class), 1.0);
     put.addDerivedStatistic(averagePutTime);
-    averageRemoveTime = new LatencyMonitor<>(allOf(CacheOperationOutcomes.RemoveOutcome.class));
+    averageRemoveTime = new Jsr107LatencyMonitor<>(allOf(RemoveOutcome.class), 1.0);
     remove.addDerivedStatistic(averageRemoveTime);
 
     String[] tierNames = findTiers(cache);
 
     String lowestTierName = findLowestTier(tierNames);
     TierStatistics lowestTier = null;
+
+    latencyHistory = new MaximumLatencyHistory(
+      configuration.getLatencyHistorySize(),
+      configuration.getLatencyHistoryWindowInterval(),
+      configuration.getLatencyHistoryWindowUnit(),
+      timeSource::getTimeMillis);
+    get.addDerivedStatistic(new OperationResultFilter<>(EnumSet.of(GetOutcome.HIT, GetOutcome.MISS), latencyHistory));
 
     tierStatistics = new HashMap<>(tierNames.length);
     for (String tierName : tierNames) {
@@ -108,6 +124,7 @@ class DefaultCacheStatistics implements CacheStatistics {
     knownStatistics.put("Cache:RemovalCount", counter(this::getCacheRemovals));
     knownStatistics.put("Cache:EvictionCount", counter(this::getCacheEvictions));
     knownStatistics.put("Cache:ExpirationCount", counter(this::getCacheExpirations));
+    knownStatistics.put("Cache:GetLatency", latencyHistory);
 
     for (TierStatistics tier : tierStatistics.values()) {
       knownStatistics.putAll(tier.getKnownStatistics());
@@ -161,25 +178,24 @@ class DefaultCacheStatistics implements CacheStatistics {
 
   @Override
   public long getCacheGets() {
-    return normalize(getHits() + getMisses()
-                     - compensatingCounters.cacheGets);
+    return normalize(getHits() + getMisses() - compensatingCounters.cacheGets);
   }
 
   @Override
   public long getCachePuts() {
     return normalize(getBulkCount(BulkOps.PUT_ALL) +
-                     put.sum(EnumSet.of(CacheOperationOutcomes.PutOutcome.PUT)) +
-                     putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
-                     replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT)) -
-                     compensatingCounters.cachePuts);
+      put.sum(EnumSet.of(PutOutcome.PUT)) +
+      putIfAbsent.sum(EnumSet.of(PutIfAbsentOutcome.PUT)) +
+      replace.sum(EnumSet.of(ReplaceOutcome.HIT)) -
+      compensatingCounters.cachePuts);
   }
 
   @Override
   public long getCacheRemovals() {
     return normalize(getBulkCount(BulkOps.REMOVE_ALL) +
-                     remove.sum(EnumSet.of(CacheOperationOutcomes.RemoveOutcome.SUCCESS)) +
-                     conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS)) -
-                     compensatingCounters.cacheRemovals);
+      remove.sum(EnumSet.of(RemoveOutcome.SUCCESS)) +
+      conditionalRemove.sum(EnumSet.of(ConditionalRemoveOutcome.SUCCESS)) -
+      compensatingCounters.cacheRemovals);
   }
 
   @Override
@@ -194,33 +210,38 @@ class DefaultCacheStatistics implements CacheStatistics {
 
   @Override
   public float getCacheAverageGetTime() {
-    return (float) averageGetTime.value();
+    return (float) averageGetTime.average();
   }
 
   @Override
   public float getCacheAveragePutTime() {
-    return (float) averagePutTime.value();
+    return (float) averagePutTime.average();
   }
 
   @Override
   public float getCacheAverageRemoveTime() {
-    return (float) averageRemoveTime.value();
+    return (float) averageRemoveTime.average();
+  }
+
+  @Override
+  public SampledStatistic<Long> getCacheGetLatencyHistory() {
+    return latencyHistory;
   }
 
   private long getMisses() {
     return getBulkCount(BulkOps.GET_ALL_MISS) +
-           get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.MISS)) +
-           putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.PUT)) +
-           replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.MISS_NOT_PRESENT)) +
-           conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
+      get.sum(EnumSet.of(GetOutcome.MISS)) +
+      putIfAbsent.sum(EnumSet.of(PutIfAbsentOutcome.PUT)) +
+      replace.sum(EnumSet.of(ReplaceOutcome.MISS_NOT_PRESENT)) +
+      conditionalRemove.sum(EnumSet.of(ConditionalRemoveOutcome.FAILURE_KEY_MISSING));
   }
 
   private long getHits() {
     return getBulkCount(BulkOps.GET_ALL_HITS) +
-           get.sum(EnumSet.of(CacheOperationOutcomes.GetOutcome.HIT)) +
-           putIfAbsent.sum(EnumSet.of(CacheOperationOutcomes.PutIfAbsentOutcome.HIT)) +
-           replace.sum(EnumSet.of(CacheOperationOutcomes.ReplaceOutcome.HIT, CacheOperationOutcomes.ReplaceOutcome.MISS_PRESENT)) +
-           conditionalRemove.sum(EnumSet.of(CacheOperationOutcomes.ConditionalRemoveOutcome.SUCCESS, CacheOperationOutcomes.ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));
+      get.sum(EnumSet.of(GetOutcome.HIT)) +
+      putIfAbsent.sum(EnumSet.of(PutIfAbsentOutcome.HIT)) +
+      replace.sum(EnumSet.of(ReplaceOutcome.HIT, ReplaceOutcome.MISS_PRESENT)) +
+      conditionalRemove.sum(EnumSet.of(ConditionalRemoveOutcome.SUCCESS, ConditionalRemoveOutcome.FAILURE_KEY_PRESENT));
   }
 
   private long getBulkCount(BulkOps bulkOps) {
@@ -267,47 +288,4 @@ class DefaultCacheStatistics implements CacheStatistics {
     }
   }
 
-  private static class LatencyMonitor<T extends Enum<T>> implements ChainedOperationObserver<T> {
-
-    private final LatencySampling<T> sampling;
-    private volatile MinMaxAverage average;
-
-    public LatencyMonitor(Set<T> targets) {
-      this.sampling = new LatencySampling<>(targets, 1.0);
-      this.average = new MinMaxAverage();
-      sampling.addDerivedStatistic(average);
-    }
-
-    @Override
-    public void begin(long time) {
-      sampling.begin(time);
-    }
-
-    @Override
-    public void end(long time, T result) {
-      sampling.end(time, result);
-    }
-
-    @Override
-    public void end(long time, T result, long... parameters) {
-      sampling.end(time, result, parameters);
-    }
-
-    public double value() {
-      Double value = average.mean();
-      if (value == null) {
-        //Someone involved with 107 can't do math
-        return 0;
-      } else {
-        //We use nanoseconds, 107 uses microseconds
-        return value / 1000f;
-      }
-    }
-
-    public synchronized void clear() {
-      sampling.removeDerivedStatistic(average);
-      average = new MinMaxAverage();
-      sampling.addDerivedStatistic(average);
-    }
-  }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsService.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsService.java
@@ -23,7 +23,10 @@ import org.ehcache.core.InternalCache;
 import org.ehcache.core.events.CacheManagerListener;
 import org.ehcache.core.spi.service.CacheManagerProviderService;
 import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.core.spi.service.StatisticsServiceConfiguration;
 import org.ehcache.core.spi.store.InternalCacheManager;
+import org.ehcache.core.spi.time.TimeSource;
+import org.ehcache.core.spi.time.TimeSourceService;
 import org.ehcache.core.statistics.CacheStatistics;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceDependencies;
@@ -32,21 +35,37 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
  * Default implementation using the statistics calculated by the observers set on the caches.
  */
-@ServiceDependencies(CacheManagerProviderService.class)
+@ServiceDependencies({CacheManagerProviderService.class, TimeSourceService.class})
 public class DefaultStatisticsService implements StatisticsService, CacheManagerListener {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultStatisticsService.class);
 
+  private final StatisticsServiceConfiguration configuration;
   private final ConcurrentMap<String, CacheStatistics> cacheStatistics = new ConcurrentHashMap<>();
 
   private volatile InternalCacheManager cacheManager;
+  private volatile TimeSource timeSource;
   private volatile boolean started = false;
+
+  public DefaultStatisticsService() {
+    this(new DefaultStatisticsServiceConfiguration());
+  }
+
+  public DefaultStatisticsService(StatisticsServiceConfiguration configuration) {
+    this.configuration = Objects.requireNonNull(configuration);
+  }
+
+  @Override
+  public StatisticsServiceConfiguration getConfiguration() {
+        return configuration;
+  }
 
   public CacheStatistics getCacheStatistics(String cacheName) {
     CacheStatistics stats = cacheStatistics.get(cacheName);
@@ -63,9 +82,14 @@ public class DefaultStatisticsService implements StatisticsService, CacheManager
   @Override
   public void start(ServiceProvider<Service> serviceProvider) {
     LOGGER.debug("Starting service");
+
+    TimeSourceService timeSourceService = serviceProvider.getService(TimeSourceService.class);
+    timeSource = timeSourceService.getTimeSource();
+
     CacheManagerProviderService cacheManagerProviderService = serviceProvider.getService(CacheManagerProviderService.class);
     cacheManager = cacheManagerProviderService.getCacheManager();
     cacheManager.registerListener(this);
+
     started = true;
   }
 
@@ -80,7 +104,7 @@ public class DefaultStatisticsService implements StatisticsService, CacheManager
   @Override
   public void stateTransition(Status from, Status to) {
     LOGGER.debug("Moving from " + from + " to " + to);
-    switch(to) {
+    switch (to) {
       case AVAILABLE:
         registerAllCaches();
         break;
@@ -107,7 +131,7 @@ public class DefaultStatisticsService implements StatisticsService, CacheManager
   @Override
   public void cacheAdded(String alias, Cache<?, ?> cache) {
     LOGGER.debug("Cache added " + alias);
-    cacheStatistics.put(alias, new DefaultCacheStatistics((InternalCache<?, ?>) cache));
+    cacheStatistics.put(alias, new DefaultCacheStatistics((InternalCache<?, ?>) cache, configuration, timeSource));
   }
 
   @Override

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceConfiguration.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.core.spi.service.StatisticsServiceConfiguration;
+
+import java.util.concurrent.TimeUnit;
+
+public class DefaultStatisticsServiceConfiguration implements StatisticsServiceConfiguration {
+
+  private long latencyHistoryWindow = 500;
+  private TimeUnit latencyHistoryWindowUnit = TimeUnit.MILLISECONDS;
+  private int latencyHistorySize = 60 * 60 * 1_000 / (int) latencyHistoryWindow; // which is equivalent to 1-hour history
+
+  @Override
+  public long getLatencyHistoryWindowInterval() {
+    return latencyHistoryWindow;
+  }
+
+  @Override
+  public TimeUnit getLatencyHistoryWindowUnit() {
+    return latencyHistoryWindowUnit;
+  }
+
+  @Override
+  public int getLatencyHistorySize() {
+    return latencyHistorySize;
+  }
+
+  /**
+   * The interval used to aggregate the latencies of Ehcache operations to create one latency sample.
+   * Aggregation is done by keeping the maximum value that has been seen.
+   * A low value (i.e. 500ms) gives more precision but more overhead.
+   * <p>
+   * Default value is 500ms.
+   *
+   * @param duration Duration of the window
+   * @param unit     Duration unit
+   * @return this
+   */
+  public DefaultStatisticsServiceConfiguration withLatencyHistoryWindow(long duration, TimeUnit unit) {
+    if (duration <= 0) {
+      throw new IllegalArgumentException("Window must be a positive integer");
+    }
+    this.latencyHistoryWindow = duration;
+    this.latencyHistoryWindowUnit = unit;
+    return this;
+  }
+
+  /**
+   * Maximum number of latency samples kept history.
+   * A sample is the maximum latency value seen over the configured window time.
+   * So supposing that we have constantly get operations, the history will cover
+   * a minimal time frame equivalent to the history size multiplied by the latency
+   * window duration.
+   * <p>
+   * Default value is 7200. This means that there will be at least a 1-hour history
+   * in the case where there are constant {@link org.ehcache.Cache#get(Object)} calls
+   * in Ehcache with a sample window of 500ms, because 2 samples will be generated per second.
+   *
+   * @param size maximum history size
+   * @return this
+   */
+  public DefaultStatisticsServiceConfiguration withLatencyHistorySize(int size) {
+    if (size <= 0) {
+      throw new IllegalArgumentException("Latency history size must be a positive integer");
+    }
+    this.latencyHistorySize = size;
+    return this;
+  }
+
+  @Override
+  public Class<StatisticsService> getServiceType() {
+    return StatisticsService.class;
+  }
+
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceFactory.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceFactory.java
@@ -18,13 +18,21 @@ package org.ehcache.impl.internal.statistics;
 
 import org.ehcache.core.spi.service.ServiceFactory;
 import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.core.spi.service.StatisticsServiceConfiguration;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
 
 public class DefaultStatisticsServiceFactory implements ServiceFactory<StatisticsService> {
 
   @Override
-  public StatisticsService create(ServiceCreationConfiguration<StatisticsService> serviceConfiguration) {
-    return new DefaultStatisticsService();
+  public StatisticsService create(ServiceCreationConfiguration<StatisticsService> configuration) {
+    if (configuration != null && !(configuration instanceof StatisticsServiceConfiguration)) {
+      throw new IllegalArgumentException("Expected a configuration of type StatisticsServiceConfiguration but got " + configuration.getClass().getSimpleName());
+    }
+    if (configuration == null) {
+      // configuring this service is optional
+      configuration = new DefaultStatisticsServiceConfiguration();
+    }
+    return new DefaultStatisticsService((StatisticsServiceConfiguration) configuration);
   }
 
   @Override

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultCacheStatisticsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultCacheStatisticsTest.java
@@ -20,19 +20,34 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.ehcache.CacheManager;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheEventListenerConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.core.InternalCache;
+import org.ehcache.event.CacheEvent;
+import org.ehcache.event.CacheEventListener;
+import org.ehcache.event.EventType;
 import org.ehcache.impl.internal.TimeSourceConfiguration;
 import org.ehcache.internal.TestTimeSource;
+import org.ehcache.spi.loaderwriter.CacheLoaderWriter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.terracotta.statistics.Sample;
+import org.terracotta.statistics.SampledStatistic;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.heap;
 
 public class DefaultCacheStatisticsTest {
 
@@ -41,14 +56,42 @@ public class DefaultCacheStatisticsTest {
   private DefaultCacheStatistics cacheStatistics;
   private CacheManager cacheManager;
   private InternalCache<Long, String> cache;
-  private TestTimeSource timeSource = new TestTimeSource(System.currentTimeMillis());
+  private final TestTimeSource timeSource = new TestTimeSource(System.currentTimeMillis());
+  private final AtomicLong latency = new AtomicLong();
+  private final List<CacheEvent<? extends Long, ? extends String>> expirations = new ArrayList<>();
+  private final Map<Long, String> sor = new HashMap<>();
 
   @Before
   public void before() {
+    CacheEventListenerConfigurationBuilder cacheEventListenerConfiguration = CacheEventListenerConfigurationBuilder
+      .newEventListenerConfiguration((CacheEventListener<Long, String>) expirations::add, EventType.EXPIRED)
+      .unordered()
+      .synchronous();
+
+    // We need a loaderWriter to easily test latencies, to simulate a latency when loading from a SOR.
+    CacheLoaderWriter<Long, String> loaderWriter = new CacheLoaderWriter<Long, String>() {
+      @Override
+      public String load(Long key) throws Exception {
+        sleep(latency.get()); // latency simulation
+        return sor.get(key);
+      }
+
+      @Override
+      public void write(Long key, String value) {
+        sor.put(key, value);
+      }
+
+      @Override
+      public void delete(Long key) {
+        sor.remove(key);
+      }
+    };
+
     CacheConfiguration<Long, String> cacheConfiguration =
-      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
-        newResourcePoolsBuilder().heap(10))
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
+        .withLoaderWriter(loaderWriter)
         .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMillis(TIME_TO_EXPIRATION)))
+        .add(cacheEventListenerConfiguration)
         .build();
 
     cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
@@ -58,7 +101,9 @@ public class DefaultCacheStatisticsTest {
 
     cache = (InternalCache<Long, String>) cacheManager.getCache("aCache", Long.class, String.class);
 
-    cacheStatistics = new DefaultCacheStatistics(cache);
+    cacheStatistics = new DefaultCacheStatistics(cache, new DefaultStatisticsServiceConfiguration()
+      .withLatencyHistorySize(2)
+      .withLatencyHistoryWindow(400, MILLISECONDS), timeSource);
   }
 
   @After
@@ -74,7 +119,7 @@ public class DefaultCacheStatisticsTest {
       "Cache:RemovalCount", "Cache:EvictionCount", "Cache:PutCount",
       "OnHeap:ExpirationCount", "Cache:ExpirationCount", "OnHeap:HitCount", "OnHeap:MissCount",
       "OnHeap:PutCount", "OnHeap:RemovalCount", "OnHeap:EvictionCount",
-      "OnHeap:MappingCount");
+      "OnHeap:MappingCount", "Cache:GetLatency");
   }
 
   @Test
@@ -138,8 +183,11 @@ public class DefaultCacheStatisticsTest {
   @Test
   public void getExpirations() throws Exception {
     cache.put(1L, "a");
+    assertThat(expirations).isEmpty();
     timeSource.advanceTime(TIME_TO_EXPIRATION);
-    assertThat(cache.get(1L)).isNull();
+    assertThat(cache.get(1L)).isEqualTo("a");
+    assertThat(expirations).hasSize(1);
+    assertThat(expirations.get(0).getKey()).isEqualTo(1L);
     assertThat(cacheStatistics.getCacheExpirations()).isEqualTo(1L);
     assertStat("Cache:ExpirationCount").isEqualTo(1L);
   }
@@ -160,6 +208,56 @@ public class DefaultCacheStatisticsTest {
   public void getCacheAverageRemoveTime() throws Exception {
     cache.remove(1L);
     assertThat(cacheStatistics.getCacheAverageRemoveTime()).isGreaterThan(0);
+  }
+
+  @Test
+  public void getCacheGetLatencyHistory() throws Exception {
+    sor.put(1L, "a");
+    sor.put(2L, "b");
+    sor.put(3L, "c");
+    sor.put(4L, "d");
+    sor.put(5L, "e");
+
+    SampledStatistic<Long> latencyHistory = cacheStatistics.getCacheGetLatencyHistory();
+    List<Sample<Long>> history = latencyHistory.history();
+    assertThat(history).isEmpty();
+
+    latency.set(100);
+    cache.get(1L);
+
+    latency.set(50);
+    cache.get(2L);
+
+    history = latencyHistory.history();
+    assertThat(history).hasSize(1);
+    assertThat(history.get(0).getSample()).isGreaterThanOrEqualTo(nanos(100L));
+
+    sleep(300); // next window
+
+    latency.set(50);
+    cache.get(3L);
+
+    latency.set(150);
+    cache.get(4L);
+
+    history = latencyHistory.history();
+    assertThat(history).hasSize(2);
+    assertThat(history.get(0).getSample()).isGreaterThanOrEqualTo(nanos(100L));
+    assertThat(history.get(1).getSample()).isGreaterThanOrEqualTo(nanos(150L));
+
+    sleep(300); // next window, first sample it discarded since history size is 2
+
+    latency.set(200);
+    cache.get(5L);
+
+    history = latencyHistory.history();
+    assertThat(history).hasSize(2);
+    assertThat(history.get(0).getSample()).isGreaterThanOrEqualTo(nanos(150L));
+    assertThat(history.get(1).getSample()).isGreaterThanOrEqualTo(nanos(200L));
+  }
+
+  private long nanos(long millis) {
+    return NANOSECONDS.convert(millis, MILLISECONDS);
   }
 
   private AbstractObjectAssert<?, Number> assertStat(String key) {

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceConfigurationTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceConfigurationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.core.spi.service.StatisticsService;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultStatisticsServiceConfigurationTest {
+
+  DefaultStatisticsServiceConfiguration configuration = new DefaultStatisticsServiceConfiguration();
+
+  @Test
+  public void getLatencyHistoryWindowInterval() {
+    assertThat(configuration.getLatencyHistoryWindowInterval()).isEqualTo(500L);
+  }
+
+  @Test
+  public void getLatencyHistoryWindowUnit() {
+    assertThat(configuration.getLatencyHistoryWindowUnit()).isEqualTo(MILLISECONDS);
+  }
+
+  @Test
+  public void getLatencyHistorySize() {
+    assertThat(configuration.getLatencyHistorySize()).isEqualTo(7200);
+  }
+
+  @Test
+  public void withLatencyHistoryWindow() {
+    configuration.withLatencyHistoryWindow(1, SECONDS);
+    assertThat(configuration.getLatencyHistoryWindowInterval()).isEqualTo(1L);
+    assertThat(configuration.getLatencyHistoryWindowUnit()).isEqualTo(SECONDS);
+  }
+
+  @Test
+  public void withLatencyHistorySize() {
+    configuration.withLatencyHistorySize(60);
+    assertThat(configuration.getLatencyHistorySize()).isEqualTo(60);
+  }
+
+  @Test
+  public void getServiceType() {
+    assertThat(configuration.getServiceType()).isEqualTo(StatisticsService.class);
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceFactoryTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultStatisticsServiceFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.impl.internal.statistics;
+
+import org.ehcache.core.spi.service.StatisticsService;
+import org.ehcache.core.spi.service.StatisticsServiceConfiguration;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultStatisticsServiceFactoryTest {
+
+  private final DefaultStatisticsServiceFactory factory = new DefaultStatisticsServiceFactory();
+
+  @Test
+  public void createNoConfig() {
+    StatisticsServiceConfiguration configuration = new DefaultStatisticsServiceConfiguration();
+    StatisticsService statisticsService = factory.create(null);
+    assertThat(statisticsService.getConfiguration().getLatencyHistorySize()).isEqualTo(configuration.getLatencyHistorySize());
+    assertThat(statisticsService.getConfiguration().getLatencyHistoryWindowInterval()).isEqualTo(configuration.getLatencyHistoryWindowInterval());
+    assertThat(statisticsService.getConfiguration().getLatencyHistoryWindowUnit()).isEqualTo(configuration.getLatencyHistoryWindowUnit());
+  }
+
+  @Test
+  public void createWithConfig() {
+    StatisticsService statisticsService = factory.create(new DefaultStatisticsServiceConfiguration()
+      .withLatencyHistorySize(1)
+      .withLatencyHistoryWindow(1, TimeUnit.SECONDS));
+    assertThat(statisticsService.getConfiguration().getLatencyHistorySize()).isEqualTo(1);
+    assertThat(statisticsService.getConfiguration().getLatencyHistoryWindowInterval()).isEqualTo(1L);
+    assertThat(statisticsService.getConfiguration().getLatencyHistoryWindowUnit()).isEqualTo(TimeUnit.SECONDS);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createWithBadConfig() {
+    factory.create(() -> StatisticsService.class);
+  }
+
+  @Test
+  public void getServiceType() {
+    assertThat(factory.getServiceType()).isEqualTo(StatisticsService.class);
+  }
+}

--- a/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
+++ b/management/src/main/java/org/ehcache/management/providers/statistics/StandardEhcacheStatistics.java
@@ -23,12 +23,8 @@ import org.ehcache.management.providers.CacheBinding;
 import org.ehcache.management.providers.ExposedCacheBinding;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.registry.collect.StatisticRegistry;
-import org.terracotta.statistics.registry.Statistic;
 
-import java.io.Serializable;
 import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
 
 public class StandardEhcacheStatistics extends ExposedCacheBinding {
 
@@ -41,14 +37,6 @@ public class StandardEhcacheStatistics extends ExposedCacheBinding {
     String cacheName = cacheBinding.getAlias();
     CacheStatistics cacheStatistics = statisticsService.getCacheStatistics(cacheName);
     cacheStatistics.getKnownStatistics().forEach(statisticRegistry::registerStatistic);
-  }
-
-  public <T extends Serializable> Optional<Statistic<T>> queryStatistic(String fullStatisticName) {
-    return statisticRegistry.queryStatistic(fullStatisticName);
-  }
-
-  public Map<String, Statistic<? extends Serializable>> queryStatistics() {
-    return statisticRegistry.queryStatistics();
   }
 
   @Override

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
@@ -445,5 +445,6 @@ public class DefaultManagementRegistryServiceTest {
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:RemovalCount", "COUNTER"));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:EvictionCount", "COUNTER"));
     CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:ExpirationCount", "COUNTER"));
+    CACHE_DESCRIPTORS.add(new StatisticDescriptor("Cache:GetLatency", "GAUGE"));
   }
 }


### PR DESCRIPTION
Adds `Cache:GetLatency` stat. 

A stat name is linked to a list of samples. For the moment in Ehcache, every stat collection reads a value and returns a sample. So for the moment, at each collection, we had 1 and only 1 sample generated for each stat, at the time of collect.

For the `Cache:GetLatency` stat, this is different. Ehcache will hold a history of by default 7200 samples, each sample being the latency aggregated (by maximum) over a 500ms window. So supposing there constantly some operations in Ehcache, this leads to a history of 1-hour.

At collect time (which is by default each 10 sec), it is possible that the `Cache:GetLatency` stat is not returned if there has been no operation called during the last 10 sec.

So for each collect of stats, `Cache:GetLatency` might return no samples or a list of about 20 samples providing the collect is done each 10 sec. The first time of the collect, the sample list might be longer to recover the full history.