### PR TITLE
Upgrade to platform 5.4.1-pre7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ slf4jVersion = 1.7.25
 sizeofVersion = 0.3.0
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.4.1-pre6
+terracottaPlatformVersion = 5.4.1-pre7
 terracottaApisVersion = 1.4.0
 terracottaCoreVersion = 5.4.1-pre5
 terracottaPassthroughTestingVersion = 1.4.0


### PR DESCRIPTION
Brings m&m bugfix (https://github.com/Terracotta-OSS/terracotta-platform/pull/457).

Note: build will fail because `5.4.1-pre7` is still releasing.