### PR TITLE
Fix #2204 : Handle empty chains that may get replicated

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/OversizedCacheOpsPassiveTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/OversizedCacheOpsPassiveTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered.replication;
+
+import org.ehcache.Cache;
+import org.ehcache.PersistentCacheManager;
+import org.ehcache.clustered.ClusteredTests;
+import org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder;
+import org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.MemoryUnit;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.terracotta.testing.rules.Cluster;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
+
+/**
+ * Test the effect of cache eviction during passive sync.
+ */
+public class OversizedCacheOpsPassiveTest extends ClusteredTests {
+  private static final int MAX_PUTS = 3000;
+  private static final int MAX_SWITCH_OVER = 3;
+  private static final int PER_ELEMENT_SIZE = 256 * 1024;
+  private static final int CACHE_SIZE_IN_MB = 2;
+  private static final String LARGE_VALUE = buildLargeString();
+
+  private static final String RESOURCE_CONFIG =
+      "<config xmlns:ohr='http://www.terracotta.org/config/offheap-resource'>"
+      + "<ohr:offheap-resources>"
+      + "<ohr:resource name=\"primary-server-resource\" unit=\"MB\">2</ohr:resource>"
+      + "</ohr:offheap-resources>" +
+      "</config>\n";
+
+  @ClassRule
+  public static Cluster CLUSTER =
+      newCluster(2).in(Paths.get("build", "cluster").toFile())
+        .withSystemProperty("ehcache.sync.data.gets.threshold", "2")
+        .withServiceFragment(RESOURCE_CONFIG)
+        .build();
+
+  @BeforeClass
+  public static void waitForServers() throws Exception {
+    CLUSTER.getClusterControl().waitForActive();
+    CLUSTER.getClusterControl().waitForRunningPassivesInStandby();
+  }
+
+  @Test
+  public void oversizedPuts() throws Exception {
+    CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder
+        = CacheManagerBuilder.newCacheManagerBuilder()
+        .with(ClusteringServiceConfigurationBuilder.cluster(CLUSTER.getConnectionURI().resolve("/crud-cm"))
+            .autoCreate()
+            .defaultServerResource("primary-server-resource"));
+    CountDownLatch syncLatch = new CountDownLatch(2);
+
+    CompletableFuture f1 = CompletableFuture.runAsync(() -> doPuts(clusteredCacheManagerBuilder, syncLatch));
+    CompletableFuture f2 = CompletableFuture.runAsync(() -> doPuts(clusteredCacheManagerBuilder, syncLatch));
+
+    syncLatch.await();
+    for (int i = 0; i < MAX_SWITCH_OVER; i++) {
+      CLUSTER.getClusterControl().terminateActive();
+      CLUSTER.getClusterControl().waitForActive();
+      CLUSTER.getClusterControl().startOneServer();
+      CLUSTER.getClusterControl().waitForRunningPassivesInStandby();
+      Thread.sleep(2000);
+    }
+
+    f1.get();
+    f2.get();
+  }
+
+  private void doPuts(CacheManagerBuilder<PersistentCacheManager> clusteredCacheManagerBuilder,
+                      CountDownLatch syncLatch) {
+    try (PersistentCacheManager cacheManager = clusteredCacheManagerBuilder.build(true)) {
+      CacheConfiguration<Long, String> config = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
+        ResourcePoolsBuilder.newResourcePoolsBuilder()
+          .with(ClusteredResourcePoolBuilder.clusteredDedicated("primary-server-resource", CACHE_SIZE_IN_MB, MemoryUnit.MB)))
+        .build();
+
+      syncLatch.countDown();
+      Cache<Long, String> cache = cacheManager.createCache("clustered-cache", config);
+      for (long i = 0; i < MAX_PUTS; i++) {
+        if (i % 1000 == 0) {
+          // a small pause
+          try {
+            Thread.sleep(10);
+          } catch (InterruptedException ignored) {
+          }
+        }
+        cache.put(i, LARGE_VALUE);
+      }
+    }
+  }
+
+  private static String buildLargeString() {
+    char[] filler = new char[PER_ELEMENT_SIZE];
+    Arrays.fill(filler, '0');
+    return new String(filler);
+  }
+}

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/PassiveReplicationMessage.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/internal/messages/PassiveReplicationMessage.java
@@ -49,10 +49,14 @@ public abstract class PassiveReplicationMessage extends EhcacheOperationMessage 
     }
 
     private Chain dropLastElement(Chain chain) {
-      List<Element> elements = StreamSupport.stream(chain.spliterator(), false)
-        .collect(Collectors.toList());
-      elements.remove(elements.size() -1); // remove last
-      return Util.getChain(elements);
+      if (!chain.isEmpty()) {
+        List<Element> elements = StreamSupport.stream(chain.spliterator(), false)
+          .collect(Collectors.toList());
+        elements.remove(elements.size() - 1); // remove last
+        return Util.getChain(elements);
+      } else {
+        return chain;
+      }
     }
 
     public long getClientId() {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
@@ -192,7 +192,9 @@ public class OffHeapChainMap<K> implements MapInternals {
           current.close();
         }
       } else {
-        heads.put(key, chainStorage.newChain(chain));
+        if (!chain.isEmpty()) {
+          heads.put(key, chainStorage.newChain(chain));
+        }
       }
     } finally {
       lock.unlock();

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierActiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierActiveEntity.java
@@ -650,6 +650,11 @@ public class ClusterTierActiveEntity implements ActiveServerEntity<EhcacheEntity
         final Chain chain;
         try {
           chain = store.get(key);
+          if (chain.isEmpty()) {
+            // evicted just continue with next
+            remainingKeys--;
+            continue;
+          }
           numKeyGets++;
         } catch (TimeoutException e) {
           throw new AssertionError("Server side store is not expected to throw timeout exception");


### PR DESCRIPTION
Empty chains may get replicated due to possibility of eviction between calls on the active.