### PR TITLE
Handling OSME in passive: remove the key and catch.

### DIFF
--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainMap.java
@@ -214,6 +214,10 @@ public class OffHeapChainMap<K> implements MapInternals {
     }
   }
 
+  void remove(K key) {
+    heads.removeNoReturn(key);
+  }
+
   public void clear() {
     heads.writeLock().lock();
     try {

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/offheap/OffHeapServerStore.java
@@ -119,9 +119,14 @@ public class OffHeapServerStore implements ServerStore, MapInternals {
 
   public void put(long key, Chain chain) {
     try {
-      segmentFor(key).put(key, chain);
-    } catch (OversizeMappingException e) {
-      handleOversizeMappingException(key, (long k) -> segmentFor(k).put(k, chain));
+      try {
+        segmentFor(key).put(key, chain);
+      } catch (OversizeMappingException e) {
+        handleOversizeMappingException(key, (long k) -> segmentFor(k).put(k, chain));
+      }
+    } catch (Throwable t) {
+      segmentFor(key).remove(key);
+      throw t;
     }
   }
 

--- a/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierPassiveEntity.java
+++ b/clustered/server/src/main/java/org/ehcache/clustered/server/store/ClusterTierPassiveEntity.java
@@ -52,6 +52,7 @@ import org.terracotta.entity.PassiveServerEntity;
 import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.entity.StateDumpCollector;
+import org.terracotta.offheapstore.exceptions.OversizeMappingException;
 
 import java.util.concurrent.TimeoutException;
 
@@ -175,7 +176,7 @@ public class ClusterTierPassiveEntity implements PassiveServerEntity<EhcacheEnti
         } else {
           throw new AssertionError("Unsupported EhcacheOperationMessage: " + operationMessage.getMessageType());
         }
-      } catch (ClusterException e) {
+      } catch (ClusterException | OversizeMappingException e) {
         // The above operations are not critical enough to fail a passive, so just log the exception
         LOGGER.error("Unexpected exception raised during operation: " + message, e);
       }

--- a/clustered/server/src/test/java/org/ehcache/clustered/server/offheap/ChainMapTest.java
+++ b/clustered/server/src/test/java/org/ehcache/clustered/server/offheap/ChainMapTest.java
@@ -392,6 +392,37 @@ public class ChainMapTest {
 
   }
 
+  @Test
+  public void testRemoveMissingKey() {
+    OffHeapChainMap<String> map = new OffHeapChainMap<>(new UnlimitedPageSource(new OffHeapBufferSource()), StringPortability.INSTANCE, minPageSize, maxPageSize, steal);
+    map.remove("foo");
+    assertThat(map.get("foo").isEmpty(), is(true));
+  }
+
+  @Test
+  public void testRemoveSingleChain() {
+    OffHeapChainMap<String> map = new OffHeapChainMap<>(new UnlimitedPageSource(new OffHeapBufferSource()), StringPortability.INSTANCE, minPageSize, maxPageSize, steal);
+    map.append("foo", buffer(1));
+    map.append("bar", buffer(2));
+    assertThat(map.get("foo"), contains(element(1)));
+    assertThat(map.get("bar"), contains(element(2)));
+
+    map.remove("foo");
+    assertThat(map.get("foo").isEmpty(), is(true));
+    assertThat(map.get("bar"), contains(element(2)));
+  }
+
+  @Test
+  public void testRemoveDoubleChain() {
+    OffHeapChainMap<String> map = new OffHeapChainMap<>(new UnlimitedPageSource(new OffHeapBufferSource()), StringPortability.INSTANCE, minPageSize, maxPageSize, steal);
+    map.append("foo", buffer(1));
+    map.append("foo", buffer(2));
+    assertThat(map.get("foo"), contains(element(1), element(2)));
+
+    map.remove("foo");
+    assertThat(map.get("foo").isEmpty(), is(true));
+  }
+
   private static ByteBuffer buffer(int i) {
     ByteBuffer buffer = ByteBuffer.allocate(i);
     while (buffer.hasRemaining()) {


### PR DESCRIPTION
Currently can only reproduce OSME in passive while putting, so the key is removed in a nested catch clause in OffHeapServerStore#put, and the exception is rethrown to be caught and logged in ClusterTierPassiveEntity#invokePassiveInternal. Not sure whether the same should be done in other methods potentially throwing OSME, e.g. in OffHeapServerStore#replaceAtHead - can't reproduce it there since the failure results in a successful eviction.