### PR TITLE
Move to a new xjc plugin

### DIFF
--- a/xml/build.gradle
+++ b/xml/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id 'org.unbroken-dome.xjc' version '1.1.3'
+  id 'org.openrepose.gradle.plugins.jaxb' version '2.5.0'
 }
 
 apply plugin: EhDeploy
@@ -23,7 +23,9 @@ apply plugin: EhDeploy
 dependencies {
   compile project(':api'), project(':core'), project(':impl')
   testCompile 'org.xmlunit:xmlunit-core:2.6.0', 'org.xmlunit:xmlunit-matchers:2.6.0'
-  xjcClasspath 'org.jvnet.jaxb2_commons:jaxb2-fluent-api:3.0'
+  jaxb 'org.glassfish.jaxb:jaxb-xjc:2.2.11'
+  jaxb 'org.glassfish.jaxb:jaxb-runtime:2.2.11'
+  xjc 'org.jvnet.jaxb2_commons:jaxb2-fluent-api:3.0'
 }
 
 test {
@@ -32,14 +34,45 @@ test {
   }
 }
 
-xjcGenerate {
-  source = fileTree('src/main/resources') { include '*.xsd' }
-  targetPackage = 'org.ehcache.xml.model'
-  extension = true
-  extraArgs = ['-Xfluent-api']
+def generatedDir = "${buildDir}/xjc/generated-sources"
+
+jaxb {
+  xsdDir = "src/main/resources"
+  bindingsDir = 'src/main/resources'
+  xjc {
+    destinationDir = generatedDir
+    generateEpisodeFiles = false
+    generatePackage = 'org.ehcache.xml.model'
+    extension = true
+    args = ['-Xfluent-api']
+  }
 }
 
-tasks.withType(JavaCompile) {
-  // We can't check for unchecked errors because of XJC that produces them
-  options.compilerArgs = ['-Werror', '-Xlint:deprecation']
+sourceSets {
+  generated {
+    java {
+      srcDirs += generatedDir
+    }
+  }
+  main {
+    compileClasspath += files([sourceSets.generated.java.outputDir])
+    runtimeClasspath += files([sourceSets.generated.java.outputDir])
+  }
+  test {
+    compileClasspath += files([sourceSets.generated.java.outputDir])
+    runtimeClasspath += files([sourceSets.generated.java.outputDir])
+  }
+  integrationTest {
+    compileClasspath += files([sourceSets.generated.java.outputDir])
+    runtimeClasspath += files([sourceSets.generated.java.outputDir])
+  }
+}
+
+compileGeneratedJava {
+  options.compilerArgs = ['-Xlint:unchecked,deprecation']
+  dependsOn xjc
+}
+
+compileJava {
+  dependsOn compileGeneratedJava
 }


### PR DESCRIPTION
This plugin plus playing with source sets allows to apply `-Werror` only on our code, not on generated code. However, it has the same issue as #2287. The generated code doesn't appear in the source jar and the final classes are not in the binary jar.