### PR TITLE
Disable store statistics when having only one tier configured

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -46,6 +46,7 @@ import org.ehcache.core.events.NullStoreEventDispatcher;
 import org.ehcache.core.spi.service.ExecutionService;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.events.StoreEventSource;
+import org.ehcache.impl.internal.store.heap.OnHeapStore;
 import org.ehcache.spi.resilience.StoreAccessException;
 import org.ehcache.core.spi.store.tiering.AuthoritativeTier;
 import org.ehcache.core.spi.time.TimeSource;

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -122,7 +122,7 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
 
 
   private ClusteredStore(Configuration<K, V> config, OperationsCodec<K, V> codec, ChainResolver<K, V> resolver, TimeSource timeSource) {
-    super(config.getKeyType(), config.getValueType());
+    super(config);
 
     this.chainCompactionLimit = Integer.getInteger(CHAIN_COMPACTION_THRESHOLD_PROP, DEFAULT_CHAIN_COMPACTION_THRESHOLD);
     this.codec = codec;

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -68,7 +68,7 @@ import org.ehcache.spi.service.ServiceDependencies;
 import org.ehcache.spi.service.ServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terracotta.statistics.MappedOperationStatistic;
+import org.terracotta.statistics.OperationStatistic;
 import org.terracotta.statistics.StatisticsManager;
 import org.terracotta.statistics.observer.OperationObserver;
 
@@ -129,15 +129,15 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
     this.resolver = resolver;
     this.timeSource = timeSource;
 
-    this.getObserver = createObserver("get", StoreOperationOutcomes.GetOutcome.class);
-    this.putObserver = createObserver("put", StoreOperationOutcomes.PutOutcome.class);
-    this.removeObserver = createObserver("remove", StoreOperationOutcomes.RemoveOutcome.class);
-    this.putIfAbsentObserver = createObserver("putIfAbsent", StoreOperationOutcomes.PutIfAbsentOutcome.class);
-    this.conditionalRemoveObserver = createObserver("conditionalRemove", StoreOperationOutcomes.ConditionalRemoveOutcome.class);
-    this.replaceObserver = createObserver("replace", StoreOperationOutcomes.ReplaceOutcome.class);
-    this.conditionalReplaceObserver = createObserver("conditionalReplace", StoreOperationOutcomes.ConditionalReplaceOutcome.class);
-    this.evictionObserver = createObserver("eviction", StoreOperationOutcomes.EvictionOutcome.class);
-    this.getAndFaultObserver = createObserver("getAndFault", AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.class);
+    this.getObserver = createObserver("get", StoreOperationOutcomes.GetOutcome.class, true);
+    this.putObserver = createObserver("put", StoreOperationOutcomes.PutOutcome.class, true);
+    this.removeObserver = createObserver("remove", StoreOperationOutcomes.RemoveOutcome.class, true);
+    this.putIfAbsentObserver = createObserver("putIfAbsent", StoreOperationOutcomes.PutIfAbsentOutcome.class, true);
+    this.conditionalRemoveObserver = createObserver("conditionalRemove", StoreOperationOutcomes.ConditionalRemoveOutcome.class, true);
+    this.replaceObserver = createObserver("replace", StoreOperationOutcomes.ReplaceOutcome.class, true);
+    this.conditionalReplaceObserver = createObserver("conditionalReplace", StoreOperationOutcomes.ConditionalReplaceOutcome.class, true);
+    this.getAndFaultObserver = createObserver("getAndFault", AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.class, true);
+    this.evictionObserver = createObserver("eviction", StoreOperationOutcomes.EvictionOutcome.class, false);
   }
 
   /**
@@ -556,7 +556,7 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
 
     private final Lock connectLock = new ReentrantLock();
     private final Map<Store<?, ?>, StoreConfig> createdStores = new ConcurrentWeakIdentityHashMap<>();
-    private final Map<ClusteredStore<?, ?>, MappedOperationStatistic<?, ?>[]> tierOperationStatistics = new ConcurrentWeakIdentityHashMap<>();
+    private final Map<ClusteredStore<?, ?>, OperationStatistic<?>[]> tierOperationStatistics = new ConcurrentWeakIdentityHashMap<>();
 
     @Override
     @SuppressWarnings("unchecked")
@@ -568,7 +568,7 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
     public <K, V> ClusteredStore<K, V> createStore(final Configuration<K, V> storeConfig, final ServiceConfiguration<?>... serviceConfigs) {
       ClusteredStore<K, V> store = createStoreInternal(storeConfig, serviceConfigs);
 
-      tierOperationStatistics.put(store, new MappedOperationStatistic<?, ?>[] {
+      tierOperationStatistics.put(store, new OperationStatistic<?>[] {
         createTranslatedStatistic(store, "get", TierOperationOutcomes.GET_TRANSLATION, "get"),
         createTranslatedStatistic(store, "eviction", TierOperationOutcomes.EVICTION_TRANSLATION, "eviction")
       });
@@ -789,7 +789,7 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
     public <K, V> AuthoritativeTier<K, V> createAuthoritativeTier(Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       ClusteredStore<K, V> authoritativeTier = createStoreInternal(storeConfig, serviceConfigs);
 
-      tierOperationStatistics.put(authoritativeTier, new MappedOperationStatistic<?, ?>[] {
+      tierOperationStatistics.put(authoritativeTier, new OperationStatistic<?>[] {
         createTranslatedStatistic(authoritativeTier, "get", TierOperationOutcomes.GET_AND_FAULT_TRANSLATION, "getAndFault"),
         createTranslatedStatistic(authoritativeTier, "eviction", TierOperationOutcomes.EVICTION_TRANSLATION, "eviction")
       });

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -37,9 +37,7 @@ import org.ehcache.clustered.client.service.ClusteringService;
 import org.ehcache.clustered.client.service.ClusteringService.ClusteredCacheIdentifier;
 import org.ehcache.clustered.common.Consistency;
 import org.ehcache.clustered.common.internal.store.Chain;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
-import org.ehcache.config.SizedResourcePool;
 import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.core.CacheConfigurationChangeListener;
 import org.ehcache.core.Ehcache;
@@ -50,7 +48,6 @@ import org.ehcache.core.spi.service.ExecutionService;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.core.spi.store.events.StoreEventSource;
 import org.ehcache.impl.internal.store.basic.BaseStore;
-import org.ehcache.impl.internal.store.heap.OnHeapStore;
 import org.ehcache.spi.resilience.StoreAccessException;
 import org.ehcache.core.spi.store.tiering.AuthoritativeTier;
 import org.ehcache.core.spi.time.TimeSource;
@@ -94,7 +91,6 @@ import java.util.function.Supplier;
 
 import static org.ehcache.core.exceptions.StorePassThroughException.handleException;
 import static org.ehcache.core.spi.service.ServiceUtils.findSingletonAmongst;
-import static org.terracotta.statistics.StatisticBuilder.operation;
 
 /**
  * Supports a {@link Store} in a clustered environment.

--- a/core/src/main/java/org/ehcache/core/EhcacheManager.java
+++ b/core/src/main/java/org/ehcache/core/EhcacheManager.java
@@ -28,6 +28,7 @@ import org.ehcache.config.ResourceType;
 import org.ehcache.core.config.BaseCacheConfiguration;
 import org.ehcache.core.config.DefaultConfiguration;
 import org.ehcache.core.config.store.StoreEventSourceConfiguration;
+import org.ehcache.core.config.store.StoreStatisticsConfiguration;
 import org.ehcache.core.events.CacheEventDispatcher;
 import org.ehcache.core.events.CacheEventDispatcherFactory;
 import org.ehcache.core.events.CacheEventListenerConfiguration;
@@ -77,7 +78,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.ehcache.core.internal.service.ServiceLocator.dependencySet;
-import static org.ehcache.core.spi.service.ServiceUtils.findSingletonAmongst;
+import static org.ehcache.core.spi.service.ServiceUtils.findOptionalAmongst;
 
 /**
  * Implementation class for the {@link org.ehcache.CacheManager} and {@link PersistentCacheManager}
@@ -492,18 +493,20 @@ public class EhcacheManager implements PersistentCacheManager, InternalCacheMana
       }
     }
 
-    int dispatcherConcurrency;
-    StoreEventSourceConfiguration eventSourceConfiguration = findSingletonAmongst(StoreEventSourceConfiguration.class, config
-        .getServiceConfigurations()
-        .toArray());
-    if (eventSourceConfiguration != null) {
-      dispatcherConcurrency = eventSourceConfiguration.getDispatcherConcurrency();
-    } else {
-      dispatcherConcurrency = StoreEventSourceConfiguration.DEFAULT_DISPATCHER_CONCURRENCY;
-    }
+    Collection<ServiceConfiguration<?>> serviceConfigurations = config.getServiceConfigurations();
 
-    Store.Configuration<K, V> storeConfiguration = new StoreConfigurationImpl<>(config, dispatcherConcurrency, keySerializer, valueSerializer);
-    final Store<K, V> store = storeProvider.createStore(storeConfiguration, serviceConfigArray);
+    int dispatcherConcurrency = findOptionalAmongst(StoreEventSourceConfiguration.class, serviceConfigurations)
+      .map(StoreEventSourceConfiguration::getDispatcherConcurrency)
+      .orElse(StoreEventSourceConfiguration.DEFAULT_DISPATCHER_CONCURRENCY);
+
+    boolean operationStatisticsEnabled = findOptionalAmongst(StoreStatisticsConfiguration.class, serviceConfigurations)
+      .map(StoreStatisticsConfiguration::isOperationStatisticsEnabled)
+      // By default, we enable statistics only in a tiered environment
+      .orElseGet(() -> config.getResourcePools().getResourceTypeSet().size() > 1);
+
+    Store.Configuration<K, V> storeConfiguration = new StoreConfigurationImpl<>(config, dispatcherConcurrency,
+      operationStatisticsEnabled, keySerializer, valueSerializer);
+    Store<K, V> store = storeProvider.createStore(storeConfiguration, serviceConfigArray);
 
     lifeCycledList.add(new LifeCycled() {
       @Override

--- a/core/src/main/java/org/ehcache/core/config/store/StoreStatisticsConfiguration.java
+++ b/core/src/main/java/org/ehcache/core/config/store/StoreStatisticsConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.core.config.store;
+
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.spi.service.ServiceConfiguration;
+
+/**
+ * Configure if statistics are unable on stores. By default they are enabled in a tiered
+ * configuration to accurately track the usage of each tier. If a store is
+ * standing alone, then they will be disabled by default since they are a mirror
+ * of the cache statistics.
+ * <p>
+ * Note that statistics about the store size, mapping and so on are not affected
+ * by this configuration. Only operation statistics (e.g. get/put counts) are disabled.
+ */
+public class StoreStatisticsConfiguration implements ServiceConfiguration<Store.Provider> {
+
+  private final boolean operationStatisticsEnabled;
+
+  public StoreStatisticsConfiguration(boolean operationStatisticsEnabled) {
+    this.operationStatisticsEnabled = operationStatisticsEnabled;
+  }
+
+  public boolean isOperationStatisticsEnabled() {
+    return operationStatisticsEnabled;
+  }
+
+  @Override
+  public Class<Store.Provider> getServiceType() {
+    return Store.Provider.class;
+  }
+}

--- a/core/src/main/java/org/ehcache/core/internal/store/StoreConfigurationImpl.java
+++ b/core/src/main/java/org/ehcache/core/internal/store/StoreConfigurationImpl.java
@@ -38,6 +38,7 @@ public class StoreConfigurationImpl<K, V> implements Store.Configuration<K, V> {
   private final Serializer<K> keySerializer;
   private final Serializer<V> valueSerializer;
   private final int dispatcherConcurrency;
+  private final boolean operationStatisticsEnabled;
 
   /**
    * Creates a new {@code StoreConfigurationImpl} based on the provided parameters.
@@ -51,7 +52,23 @@ public class StoreConfigurationImpl<K, V> implements Store.Configuration<K, V> {
                                 Serializer<K> keySerializer, Serializer<V> valueSerializer) {
     this(cacheConfig.getKeyType(), cacheConfig.getValueType(), cacheConfig.getEvictionAdvisor(),
         cacheConfig.getClassLoader(), cacheConfig.getExpiryPolicy(), cacheConfig.getResourcePools(),
-        dispatcherConcurrency, keySerializer, valueSerializer);
+        dispatcherConcurrency, true, keySerializer, valueSerializer);
+  }
+
+  /**
+   * Creates a new {@code StoreConfigurationImpl} based on the provided parameters.
+   *
+   * @param cacheConfig the cache configuration
+   * @param dispatcherConcurrency the level of concurrency for ordered events
+   * @param operationStatisticsEnabled if operation statistics should be enabled
+   * @param keySerializer the key serializer
+   * @param valueSerializer the value serializer
+   */
+  public StoreConfigurationImpl(CacheConfiguration<K, V> cacheConfig, int dispatcherConcurrency, boolean operationStatisticsEnabled,
+                                Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+    this(cacheConfig.getKeyType(), cacheConfig.getValueType(), cacheConfig.getEvictionAdvisor(),
+      cacheConfig.getClassLoader(), cacheConfig.getExpiryPolicy(), cacheConfig.getResourcePools(),
+      dispatcherConcurrency, operationStatisticsEnabled, keySerializer, valueSerializer);
   }
 
   /**
@@ -72,6 +89,29 @@ public class StoreConfigurationImpl<K, V> implements Store.Configuration<K, V> {
                                 ClassLoader classLoader, ExpiryPolicy<? super K, ? super V> expiry,
                                 ResourcePools resourcePools, int dispatcherConcurrency,
                                 Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+    this(keyType, valueType, evictionAdvisor, classLoader, expiry, resourcePools, dispatcherConcurrency,
+      true, keySerializer, valueSerializer);
+  }
+
+  /**
+   * Creates a new {@code StoreConfigurationImpl} based on the provided parameters.
+   *
+   * @param keyType the key type
+   * @param valueType the value type
+   * @param evictionAdvisor the eviction advisor
+   * @param classLoader the class loader
+   * @param expiry the expiry policy
+   * @param resourcePools the resource pools
+   * @param dispatcherConcurrency the level of concurrency for ordered events
+   * @param operationStatisticsEnabled if operation statistics should be enabled
+   * @param keySerializer the key serializer
+   * @param valueSerializer the value serializer
+   */
+  public StoreConfigurationImpl(Class<K> keyType, Class<V> valueType,
+                                EvictionAdvisor<? super K, ? super V> evictionAdvisor,
+                                ClassLoader classLoader, ExpiryPolicy<? super K, ? super V> expiry,
+                                ResourcePools resourcePools, int dispatcherConcurrency, boolean operationStatisticsEnabled,
+                                Serializer<K> keySerializer, Serializer<V> valueSerializer) {
     this.keyType = keyType;
     this.valueType = valueType;
     this.evictionAdvisor = evictionAdvisor;
@@ -81,6 +121,7 @@ public class StoreConfigurationImpl<K, V> implements Store.Configuration<K, V> {
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;
     this.dispatcherConcurrency = dispatcherConcurrency;
+    this.operationStatisticsEnabled = operationStatisticsEnabled;
   }
 
   /**
@@ -153,5 +194,13 @@ public class StoreConfigurationImpl<K, V> implements Store.Configuration<K, V> {
   @Override
   public int getDispatcherConcurrency() {
     return dispatcherConcurrency;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isOperationStatisticsEnabled() {
+    return operationStatisticsEnabled;
   }
 }

--- a/core/src/main/java/org/ehcache/core/spi/service/ServiceUtils.java
+++ b/core/src/main/java/org/ehcache/core/spi/service/ServiceUtils.java
@@ -18,6 +18,7 @@ package org.ehcache.core.spi.service;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,11 +73,24 @@ public final class ServiceUtils {
    * @throws IllegalArgumentException if more than one matching instance
    */
   public static <T> T findSingletonAmongst(Class<T> clazz, Collection<?> instances) {
+    return findOptionalAmongst(clazz, instances)
+      .orElse(null);
+  }
+
+  /**
+   * Find the only expected instance of {@code clazz} among the {@code instances}.
+   *
+   * @param clazz searched class
+   * @param instances instances looked at
+   * @param <T> type of the searched instance
+   * @return the optionally found compatible instance
+   * @throws IllegalArgumentException if more than one matching instance
+   */
+  public static <T> Optional<T> findOptionalAmongst(Class<T> clazz, Collection<?> instances) {
     return findStreamAmongst(clazz, instances)
       .reduce((i1, i2) -> {
         throw new IllegalArgumentException("More than one " + clazz.getName() + " found");
-      })
-      .orElse(null);
+      });
   }
 
   /**
@@ -90,5 +104,18 @@ public final class ServiceUtils {
    */
   public static <T> T findSingletonAmongst(Class<T> clazz, Object ... instances) {
     return findSingletonAmongst(clazz, Arrays.asList(instances));
+  }
+
+  /**
+   * Find the only expected instance of {@code clazz} among the {@code instances}.
+   *
+   * @param clazz searched class
+   * @param instances instances looked at
+   * @param <T> type of the searched instance
+   * @return the optionally found compatible instance
+   * @throws IllegalArgumentException if more than one matching instance
+   */
+  public static <T> Optional<T> findOptionalAmongst(Class<T> clazz, Object ... instances) {
+    return findOptionalAmongst(clazz, Arrays.asList(instances));
   }
 }

--- a/core/src/main/java/org/ehcache/core/spi/store/Store.java
+++ b/core/src/main/java/org/ehcache/core/spi/store/Store.java
@@ -629,6 +629,14 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
      * The concurrency level of the dispatcher that processes events
      */
     int getDispatcherConcurrency();
+
+    /**
+     * If operation statistics (e.g. get/put count) should be enabled. It is
+     * a default method to keep the original behavior which was enabled all the time.
+     */
+    default boolean isOperationStatisticsEnabled() {
+      return true;
+    }
   }
 
   /**

--- a/core/src/test/java/org/ehcache/core/spi/service/ServiceUtilsTest.java
+++ b/core/src/test/java/org/ehcache/core/spi/service/ServiceUtilsTest.java
@@ -76,4 +76,25 @@ public class ServiceUtilsTest {
     assertThatThrownBy(() ->ServiceUtils.findSingletonAmongst(String.class, Arrays.asList("t1", "t2")))
       .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void findOptionalAmongstColl_notFound() {
+    assertThat(ServiceUtils.findOptionalAmongst(String.class, Collections.emptySet())).isEmpty();
+  }
+
+  @Test
+  public void findOptionalAmongstColl_found() {
+    assertThat(ServiceUtils.findOptionalAmongst(String.class, Arrays.asList( 2, "t1"))).contains("t1");
+  }
+
+  @Test
+  public void findOptionalAmongstArray_notFound() {
+    assertThat(ServiceUtils.findOptionalAmongst(String.class)).isEmpty();
+  }
+
+  @Test
+  public void findOptionalAmongstArray_found() {
+    assertThat(ServiceUtils.findOptionalAmongst(String.class, 2, "t1")).contains("t1");
+  }
+
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultTierStatistics.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/DefaultTierStatistics.java
@@ -29,6 +29,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.ehcache.impl.internal.statistics.StatsUtils.findStatisticOnDescendants;
 import static org.terracotta.statistics.ValueStatistics.counter;
@@ -85,16 +86,35 @@ class DefaultTierStatistics implements TierStatistics {
 
   private Map<String, ValueStatistic<?>> createKnownStatistics(String tierName) {
     Map<String, ValueStatistic<?>> knownStatistics = new HashMap<>(7);
-    knownStatistics.put(tierName + ":HitCount", counter(this::getHits));
-    knownStatistics.put(tierName + ":MissCount", counter(this::getMisses));
-    knownStatistics.put(tierName + ":PutCount", counter(this::getPuts));
-    knownStatistics.put(tierName + ":RemovalCount", counter(this::getRemovals));
+    addIfPresent(knownStatistics, tierName + ":HitCount", get, this::getHits);
+    addIfPresent(knownStatistics, tierName + ":MissCount", get, this::getMisses);
+    addIfPresent(knownStatistics, tierName + ":PutCount", put, this::getPuts);
+    addIfPresent(knownStatistics, tierName + ":RemovalCount", remove, this::getRemovals);
+
+    // These two a special because they are used by the cache so they should always be there
     knownStatistics.put(tierName + ":EvictionCount", counter(this::getEvictions));
     knownStatistics.put(tierName + ":ExpirationCount", counter(this::getExpirations));
+
     mapping.ifPresent(longValueStatistic -> knownStatistics.put(tierName + ":MappingCount", gauge(this::getMappings)));
     allocatedMemory.ifPresent(longValueStatistic -> knownStatistics.put(tierName + ":AllocatedByteSize", gauge(this::getAllocatedByteSize)));
     occupiedMemory.ifPresent(longValueStatistic -> knownStatistics.put(tierName + ":OccupiedByteSize", gauge(this::getOccupiedByteSize)));
     return knownStatistics;
+  }
+
+  /**
+   * Add the statistic as a known statistic only if the reference statistic is available. We consider that the reference statistic can only be
+   * an instance of {@code ZeroOperationStatistic} when statistics are disabled.
+   *
+   * @param knownStatistics map of known statistics
+   * @param name the name of the statistic to add
+   * @param reference the reference statistic that should be available for the statistic to be added
+   * @param valueSupplier the supplier that will provide the current value for the statistic
+   * @param <T> type of the supplied value
+   */
+  private static <T extends Number> void addIfPresent(Map<String, ValueStatistic<?>> knownStatistics, String name, OperationStatistic<?> reference, Supplier<T> valueSupplier) {
+    if(!(reference instanceof ZeroOperationStatistic)) {
+      knownStatistics.put(name, counter(valueSupplier));
+    }
   }
 
   @Override

--- a/impl/src/main/java/org/ehcache/impl/internal/statistics/StatsUtils.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/statistics/StatsUtils.java
@@ -30,19 +30,17 @@ import org.terracotta.context.query.Matchers;
 import org.terracotta.context.query.Query;
 import org.terracotta.statistics.OperationStatistic;
 
-import static org.terracotta.context.query.Matchers.attributes;
-import static org.terracotta.context.query.Matchers.context;
-import static org.terracotta.context.query.Matchers.hasAttribute;
+import static org.terracotta.context.query.Matchers.*;
 import static org.terracotta.context.query.QueryBuilder.queryBuilder;
 
 /**
  * Class allowing to query cache and tier statistics
  */
-final class StatsUtils {
+public final class StatsUtils {
 
   private StatsUtils() {}
 
-  static Matcher<Map<String, Object>> hasTag(final String tag) {
+  public static Matcher<Map<String, Object>> hasTag(final String tag) {
     return hasAttribute("tags", new Matcher<Set<String>>() {
       @Override
       protected boolean matchesSafely(Set<String> object) {
@@ -51,7 +49,7 @@ final class StatsUtils {
     });
   }
 
-  static Matcher<Map<String, Object>> hasProperty(final String key, final String value) {
+  public static Matcher<Map<String, Object>> hasProperty(final String key, final String value) {
     return hasAttribute("properties", new Matcher<Map<String, Object>>() {
       @Override
       protected boolean matchesSafely(Map<String, Object> properties) {
@@ -72,7 +70,7 @@ final class StatsUtils {
    * @return the wanted statistic or null if no such statistic is found
    * @throws RuntimeException when more than one matching statistic is found
    */
-  static <T> Optional<T> findStatisticOnDescendants(Object context, String discriminator, String tag, String statName) {
+  public static <T> Optional<T> findStatisticOnDescendants(Object context, String discriminator, String tag, String statName) {
 
     @SuppressWarnings("unchecked")
     Set<TreeNode> statResult = queryBuilder()
@@ -107,7 +105,7 @@ final class StatsUtils {
    * @return the wanted statistic or null if no such statistic is found
    * @throws RuntimeException when more than one matching statistic is found
    */
-  static <T> Optional<T> findStatisticOnDescendants(Object context, String tag, String statName) {
+  public static <T> Optional<T> findStatisticOnDescendants(Object context, String tag, String statName) {
 
     @SuppressWarnings("unchecked")
     Set<TreeNode> statResult = queryBuilder()
@@ -141,7 +139,7 @@ final class StatsUtils {
    * @return the operation statistic searched for
    * @throws RuntimeException if 0 or more than 1 result is found
    */
-  static <T extends Enum<T>> OperationStatistic<T> findOperationStatisticOnChildren(Object context, Class<T> type, String statName) {
+  public static <T extends Enum<T>> OperationStatistic<T> findOperationStatisticOnChildren(Object context, Class<T> type, String statName) {
     @SuppressWarnings("unchecked")
     Query query = queryBuilder()
       .children()
@@ -173,7 +171,7 @@ final class StatsUtils {
    * @return an array of tier names
    * @throws RuntimeException if not tiers are found or if tiers have multiple tags
    */
-  static String[] findTiers(Cache<?, ?> cache) {
+  public static String[] findTiers(Cache<?, ?> cache) {
     // Here I'm randomly taking the eviction observer because it exists on all tiers
     @SuppressWarnings("unchecked")
     Query statQuery = queryBuilder()
@@ -209,7 +207,7 @@ final class StatsUtils {
    * @param tiers all tiers
    * @return the lowest tier
    */
-  static String findLowestTier(String[] tiers) {
+  public static String findLowestTier(String[] tiers) {
     //if only 1 store then you don't need to find the lowest tier
     if (tiers.length == 1) {
       return tiers[0];
@@ -230,5 +228,28 @@ final class StatsUtils {
     }
 
     return lowestTier;
+  }
+
+  public static <T extends Enum<T>> boolean hasOperationStat(Object rootNode, Class<T> statisticType, String statName) {
+    Query q = queryBuilder().descendants()
+      .filter(context(identifier(subclassOf(OperationStatistic.class))))
+      .filter(context(attributes(Matchers.allOf(
+        hasAttribute("name", statName),
+        hasAttribute("this", new Matcher<OperationStatistic>() {
+          @Override
+          protected boolean matchesSafely(OperationStatistic object) {
+            return object.type().equals(statisticType);
+          }
+        })
+      ))))
+      .build();
+
+    Set<TreeNode> result = q.execute(Collections.singleton(ContextManager.nodeFor(rootNode)));
+
+    if (result.size() > 1) {
+      throw new RuntimeException("a zero or a single stat was expected; found " + result.size());
+    }
+
+    return !result.isEmpty();
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.basic;
+
+import org.ehcache.core.spi.store.Store;
+import org.terracotta.statistics.MappedOperationStatistic;
+import org.terracotta.statistics.StatisticType;
+import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.observer.OperationObserver;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.terracotta.statistics.StatisticBuilder.operation;
+
+/**
+ * Base class to most stores. It provides functionality common to stores in general. A given store implementation is not required to extend
+ * it but the implementor might find it easier to do so.
+ */
+public abstract class BaseStore<K, V> implements Store<K, V> {
+
+  protected <T extends Enum<T>> OperationObserver<T> createObserver(String name, Class<T> outcome) {
+    return operation(outcome).named(name).of(this).tag(getStatisticsTag()).build();
+  }
+
+  protected <T extends Serializable> void registerStatistics(String name, Set<String> tags, StatisticType type, Supplier<T> valueSupplier) {
+    StatisticsManager.createPassThroughStatistic(this, name, tags, type, valueSupplier);
+  }
+
+  protected abstract String getStatisticsTag();
+
+  protected static abstract class BaseStoreProvider implements Store.Provider {
+
+    protected  <K, V, S extends Enum<S>, T extends Enum<T>> MappedOperationStatistic<S, T> createTranslatedStatistics(BaseStore<K, V> store, String statisticName, int tierHeight, Map<T, Set<S>> translation, String targetName) {
+      MappedOperationStatistic<S, T> stat = new MappedOperationStatistic<>(store, translation, statisticName, tierHeight, targetName, store.getStatisticsTag());
+      StatisticsManager.associate(stat).withParent(store);
+      return stat;
+    }
+  }
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.store.basic;
 
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.spi.store.Store;
 import org.ehcache.impl.internal.util.CheckerUtil;
@@ -58,7 +57,7 @@ public abstract class BaseStore<K, V> implements Store<K, V> {
     return operation(outcome).named(name).of(this).tag(getStatisticsTag()).build();
   }
 
-  protected <T extends Serializable> void registerStatistic(String name, Set<String> tags, StatisticType type, Supplier<T> valueSupplier) {
+  protected <T extends Serializable> void registerStatistic(String name, StatisticType type, Set<String> tags, Supplier<T> valueSupplier) {
     StatisticsManager.createPassThroughStatistic(this, name, tags, type, valueSupplier);
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
@@ -37,12 +37,14 @@ import static org.terracotta.statistics.StatisticBuilder.operation;
  */
 public abstract class BaseStore<K, V> implements Store<K, V> {
 
+  /* Type of the keys stored in this store */
   protected final Class<K> keyType;
+  /* Type of the values stored in this store */
   protected final Class<V> valueType;
 
-  public BaseStore(Class<K> keyType, Class<V> valueType) {
-    this.keyType = keyType;
-    this.valueType = valueType;
+  public BaseStore(Configuration<K, V> config) {
+    this.keyType = config.getKeyType();
+    this.valueType = config.getValueType();
   }
 
   protected void checkKey(K keyObject) {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
@@ -19,6 +19,7 @@ package org.ehcache.impl.internal.store.basic;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.spi.store.Store;
+import org.ehcache.impl.internal.util.CheckerUtil;
 import org.terracotta.statistics.MappedOperationStatistic;
 import org.terracotta.statistics.StatisticType;
 import org.terracotta.statistics.StatisticsManager;
@@ -36,6 +37,22 @@ import static org.terracotta.statistics.StatisticBuilder.operation;
  * it but the implementor might find it easier to do so.
  */
 public abstract class BaseStore<K, V> implements Store<K, V> {
+
+  protected final Class<K> keyType;
+  protected final Class<V> valueType;
+
+  public BaseStore(Class<K> keyType, Class<V> valueType) {
+    this.keyType = keyType;
+    this.valueType = valueType;
+  }
+
+  protected void checkKey(K keyObject) {
+    CheckerUtil.checkKey(keyType, keyObject);
+  }
+
+  protected void checkValue(V valueObject) {
+    CheckerUtil.checkValue(valueType, valueObject);
+  }
 
   protected <T extends Enum<T>> OperationObserver<T> createObserver(String name, Class<T> outcome) {
     return operation(outcome).named(name).of(this).tag(getStatisticsTag()).build();

--- a/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/basic/BaseStore.java
@@ -16,6 +16,8 @@
 
 package org.ehcache.impl.internal.store.basic;
 
+import org.ehcache.config.ResourcePool;
+import org.ehcache.config.ResourceType;
 import org.ehcache.core.spi.store.Store;
 import org.terracotta.statistics.MappedOperationStatistic;
 import org.terracotta.statistics.StatisticType;
@@ -39,18 +41,22 @@ public abstract class BaseStore<K, V> implements Store<K, V> {
     return operation(outcome).named(name).of(this).tag(getStatisticsTag()).build();
   }
 
-  protected <T extends Serializable> void registerStatistics(String name, Set<String> tags, StatisticType type, Supplier<T> valueSupplier) {
+  protected <T extends Serializable> void registerStatistic(String name, Set<String> tags, StatisticType type, Supplier<T> valueSupplier) {
     StatisticsManager.createPassThroughStatistic(this, name, tags, type, valueSupplier);
   }
 
   protected abstract String getStatisticsTag();
 
+
   protected static abstract class BaseStoreProvider implements Store.Provider {
 
-    protected  <K, V, S extends Enum<S>, T extends Enum<T>> MappedOperationStatistic<S, T> createTranslatedStatistics(BaseStore<K, V> store, String statisticName, int tierHeight, Map<T, Set<S>> translation, String targetName) {
+    protected  <K, V, S extends Enum<S>, T extends Enum<T>> MappedOperationStatistic<S, T> createTranslatedStatistic(BaseStore<K, V> store, String statisticName, Map<T, Set<S>> translation, String targetName) {
+      int tierHeight = getResourceType().getTierHeight();
       MappedOperationStatistic<S, T> stat = new MappedOperationStatistic<>(store, translation, statisticName, tierHeight, targetName, store.getStatisticsTag());
       StatisticsManager.associate(stat).withParent(store);
       return stat;
     }
+
+    protected abstract ResourceType<?> getResourceType();
   }
 }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -16,7 +16,6 @@
 
 package org.ehcache.impl.internal.store.disk;
 
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.SizedResourcePool;
 import org.ehcache.core.CacheConfigurationChangeListener;
 import org.ehcache.Status;
@@ -60,7 +59,7 @@ import org.terracotta.offheapstore.disk.persistent.PersistentPortability;
 import org.terracotta.offheapstore.disk.storage.FileBackedStorageEngine;
 import org.terracotta.offheapstore.storage.portability.Portability;
 import org.terracotta.offheapstore.util.Factory;
-import org.terracotta.statistics.MappedOperationStatistic;
+import org.terracotta.statistics.OperationStatistic;
 import org.terracotta.statistics.StatisticsManager;
 
 import java.io.File;
@@ -295,7 +294,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
   @ServiceDependencies({TimeSourceService.class, SerializationProvider.class, ExecutionService.class, DiskResourceService.class})
   public static class Provider extends BaseStoreProvider implements AuthoritativeTier.Provider {
 
-    private final Map<OffHeapDiskStore<?, ?>, MappedOperationStatistic<?, ?>[]> tierOperationStatistics = new ConcurrentWeakIdentityHashMap<>();
+    private final Map<OffHeapDiskStore<?, ?>, OperationStatistic<?>[]> tierOperationStatistics = new ConcurrentWeakIdentityHashMap<>();
     private final Map<Store<?, ?>, PersistenceSpaceIdentifier> createdStores = new ConcurrentWeakIdentityHashMap<>();
     private final String defaultThreadPool;
     private volatile ServiceProvider<Service> serviceProvider;
@@ -328,7 +327,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
     public <K, V> OffHeapDiskStore<K, V> createStore(Configuration<K, V> storeConfig, ServiceConfiguration<?>... serviceConfigs) {
       OffHeapDiskStore<K, V> store = createStoreInternal(storeConfig, new ThreadLocalStoreEventDispatcher<>(storeConfig.getDispatcherConcurrency()), serviceConfigs);
 
-      tierOperationStatistics.put(store, new MappedOperationStatistic<?, ?>[] {
+      tierOperationStatistics.put(store, new OperationStatistic<?>[] {
         createTranslatedStatistic(store, "get", TierOperationOutcomes.GET_TRANSLATION, "get"),
         createTranslatedStatistic(store, "eviction", TierOperationOutcomes.EVICTION_TRANSLATION, "eviction")
       });
@@ -464,7 +463,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
       OffHeapDiskStore<K, V> authoritativeTier = createStoreInternal(storeConfig, new ThreadLocalStoreEventDispatcher<>(storeConfig
         .getDispatcherConcurrency()), serviceConfigs);
 
-      tierOperationStatistics.put(authoritativeTier, new MappedOperationStatistic<?, ?>[] {
+      tierOperationStatistics.put(authoritativeTier, new OperationStatistic<?>[] {
         createTranslatedStatistic(authoritativeTier, "get", TierOperationOutcomes.GET_AND_FAULT_TRANSLATION, "getAndFault"),
         createTranslatedStatistic(authoritativeTier, "eviction", TierOperationOutcomes.EVICTION_TRANSLATION, "eviction")
       });

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -91,8 +91,6 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapDiskStore.class);
 
-  private static final String STATISTICS_TAG = "Disk";
-
   private static final String KEY_TYPE_PROPERTY_NAME = "keyType";
   private static final String VALUE_TYPE_PROPERTY_NAME = "valueType";
 
@@ -116,7 +114,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
   public OffHeapDiskStore(FileBasedPersistenceContext fileBasedPersistenceContext,
                           ExecutionService executionService, String threadPoolAlias, int writerConcurrency, int diskSegments,
                           final Configuration<K, V> config, TimeSource timeSource, StoreEventDispatcher<K, V> eventDispatcher, long sizeInBytes) {
-    super(STATISTICS_TAG, config, timeSource, eventDispatcher);
+    super(config, timeSource, eventDispatcher);
     this.fileBasedPersistenceContext = fileBasedPersistenceContext;
     this.executionService = executionService;
     this.threadPoolAlias = threadPoolAlias;
@@ -139,6 +137,11 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
     if (!status.compareAndSet(Status.UNINITIALIZED, Status.AVAILABLE)) {
       throw new AssertionError();
     }
+  }
+
+  @Override
+  protected String getStatisticsTag() {
+    return "Disk";
   }
 
   @Override
@@ -328,7 +331,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
     }
 
     private <K, V, S extends Enum<S>, T extends Enum<T>> MappedOperationStatistic<S, T> createTranslatedStatistic(OffHeapDiskStore<K, V> store, String statisticName, Map<T, Set<S>> translation, String targetName) {
-      MappedOperationStatistic<S, T> stat = new MappedOperationStatistic<>(store, translation, statisticName, ResourceType.Core.DISK.getTierHeight(), targetName, STATISTICS_TAG);
+      MappedOperationStatistic<S, T> stat = new MappedOperationStatistic<>(store, translation, statisticName, ResourceType.Core.DISK.getTierHeight(), targetName, store.getStatisticsTag());
       StatisticsManager.associate(stat).withParent(store);
       return stat;
     }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -148,8 +148,6 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
   static final int SAMPLE_SIZE = 8;
   private final Backend<K, V> map;
 
-  private final Class<K> keyType;
-  private final Class<V> valueType;
   private final Copier<V> valueCopier;
 
   private final SizeOfEngine sizeOfEngine;
@@ -210,6 +208,8 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
 
   public OnHeapStore(Configuration<K, V> config, TimeSource timeSource, Copier<K> keyCopier, Copier<V> valueCopier,
                      SizeOfEngine sizeOfEngine, StoreEventDispatcher<K, V> eventDispatcher, Supplier<EvictingConcurrentMap<?, ?>> backingMapSupplier) {
+    super(config.getKeyType(), config.getValueType());
+
     Objects.requireNonNull(keyCopier, "keyCopier must not be null");
 
     this.valueCopier = Objects.requireNonNull(valueCopier, "valueCopier must not be null");
@@ -229,8 +229,6 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
     } else {
       this.evictionAdvisor = config.getEvictionAdvisor();
     }
-    this.keyType = config.getKeyType();
-    this.valueType = config.getValueType();
     this.expiry = config.getExpiry();
     this.storeEventDispatcher = eventDispatcher;
 
@@ -1539,14 +1537,6 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         return false;
       }
     }
-  }
-
-  private void checkKey(K keyObject) {
-    CheckerUtil.checkKey(keyType, keyObject);
-  }
-
-  private void checkValue(V valueObject) {
-    CheckerUtil.checkValue(valueType, valueObject);
   }
 
   private void fireOnExpirationEvent(K mappedKey, ValueHolder<V> mappedValue, StoreEventSink<K, V> eventSink) {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -18,7 +18,6 @@ package org.ehcache.impl.internal.store.heap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.ehcache.Cache;
-import org.ehcache.config.ResourcePool;
 import org.ehcache.config.SizedResourcePool;
 import org.ehcache.core.CacheConfigurationChangeEvent;
 import org.ehcache.core.CacheConfigurationChangeListener;
@@ -32,7 +31,6 @@ import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.core.events.StoreEventSink;
 import org.ehcache.impl.internal.concurrent.EvictingConcurrentMap;
 import org.ehcache.impl.internal.store.basic.BaseStore;
-import org.ehcache.impl.internal.util.CheckerUtil;
 import org.ehcache.spi.resilience.StoreAccessException;
 import org.ehcache.core.spi.store.heap.LimitExceededException;
 import org.ehcache.expiry.ExpiryPolicy;
@@ -100,7 +98,6 @@ import java.util.function.Supplier;
 import static org.ehcache.config.Eviction.noAdvice;
 import static org.ehcache.core.config.ExpiryUtils.isExpiryDurationInfinite;
 import static org.ehcache.core.exceptions.StorePassThroughException.handleException;
-import static org.terracotta.statistics.StatisticBuilder.operation;
 import static org.terracotta.statistics.StatisticType.COUNTER;
 import static org.terracotta.statistics.StatisticType.GAUGE;
 
@@ -260,10 +257,9 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
     silentInvalidateAllWithHashObserver = createObserver("silentInvalidateAllWithHash", HigherCachingTierOperationOutcomes.SilentInvalidateAllWithHashOutcome.class);
 
     Set<String> tags = new HashSet<>(Arrays.asList(getStatisticsTag(), "tier"));
-    StatisticsManager.createPassThroughStatistic(this, "mappings", tags, COUNTER, () -> map.mappingCount());
-
-    if(byteSized) {
-      StatisticsManager.createPassThroughStatistic(this, "occupiedMemory", tags, GAUGE, () -> map.byteSize());
+    registerStatistic("mappings", COUNTER, tags, () -> map.mappingCount());
+    if (byteSized) {
+      registerStatistic("occupiedMemory", GAUGE, tags, () -> map.byteSize());
     }
   }
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -205,7 +205,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
 
   public OnHeapStore(Configuration<K, V> config, TimeSource timeSource, Copier<K> keyCopier, Copier<V> valueCopier,
                      SizeOfEngine sizeOfEngine, StoreEventDispatcher<K, V> eventDispatcher, Supplier<EvictingConcurrentMap<?, ?>> backingMapSupplier) {
-    super(config.getKeyType(), config.getValueType());
+    super(config);
 
     Objects.requireNonNull(keyCopier, "keyCopier must not be null");
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -72,8 +72,6 @@ public abstract class AbstractOffHeapStore<K, V> extends BaseStore<K, V> impleme
     // Do nothing
   };
 
-  private final Class<K> keyType;
-  private final Class<V> valueType;
   private final TimeSource timeSource;
   private final StoreEventDispatcher<K, V> eventDispatcher;
 
@@ -108,8 +106,8 @@ public abstract class AbstractOffHeapStore<K, V> extends BaseStore<K, V> impleme
   private volatile CachingTier.InvalidationListener<K, V> invalidationListener = (CachingTier.InvalidationListener<K, V>) NULL_INVALIDATION_LISTENER;
 
   public AbstractOffHeapStore(Configuration<K, V> config, TimeSource timeSource, StoreEventDispatcher<K, V> eventDispatcher) {
-    keyType = config.getKeyType();
-    valueType = config.getValueType();
+    super(config.getKeyType(), config.getValueType());
+
     expiry = config.getExpiry();
 
     this.timeSource = timeSource;
@@ -1066,14 +1064,6 @@ public abstract class AbstractOffHeapStore<K, V> extends BaseStore<K, V> impleme
     if (valve != null) {
       valve.invalidateAll();
     }
-  }
-
-  private void checkKey(K keyObject) {
-    CheckerUtil.checkKey(keyType, keyObject);
-  }
-
-  private void checkValue(V valueObject) {
-    CheckerUtil.checkValue(valueType, valueObject);
   }
 
   private void onExpirationInCachingTier(ValueHolder<V> mappedValue, K key) {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -36,7 +36,6 @@ import org.ehcache.core.config.ExpiryUtils;
 import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.core.events.StoreEventSink;
 import org.ehcache.impl.internal.store.basic.BaseStore;
-import org.ehcache.impl.internal.util.CheckerUtil;
 import org.ehcache.spi.resilience.StoreAccessException;
 import org.ehcache.core.spi.time.TimeSource;
 import org.ehcache.expiry.ExpiryPolicy;
@@ -54,13 +53,11 @@ import org.ehcache.impl.store.HashUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.offheapstore.exceptions.OversizeMappingException;
-import org.terracotta.statistics.StatisticsManager;
 import org.terracotta.statistics.StatisticType;
 import org.terracotta.statistics.observer.OperationObserver;
 
 import static org.ehcache.core.config.ExpiryUtils.isExpiryDurationInfinite;
 import static org.ehcache.core.exceptions.StorePassThroughException.handleException;
-import static org.terracotta.statistics.StatisticBuilder.operation;
 import static org.terracotta.statistics.StatisticsManager.tags;
 import static org.terracotta.statistics.StatisticType.GAUGE;
 
@@ -152,7 +149,7 @@ public abstract class AbstractOffHeapStore<K, V> extends BaseStore<K, V> impleme
   }
 
   private <T extends Serializable> void registerStatistic(String name, StatisticType type, Set<String> tags, Function<EhcacheOffHeapBackingMap<K, OffHeapValueHolder<V>>, T> fn) {
-    StatisticsManager.createPassThroughStatistic(this, name, tags, type, () -> {
+    registerStatistic(name, type, tags, () -> {
       EhcacheOffHeapBackingMap<K, OffHeapValueHolder<V>> map = backingMap();
       // Returning null means not available.
       // Do not return -1 because a stat can be negative and it's hard to tell the difference

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -110,27 +110,27 @@ public abstract class AbstractOffHeapStore<K, V> extends BaseStore<K, V> impleme
     this.timeSource = timeSource;
     this.eventDispatcher = eventDispatcher;
 
-    this.getObserver = createObserver("get", StoreOperationOutcomes.GetOutcome.class);
-    this.putObserver = createObserver("put", StoreOperationOutcomes.PutOutcome.class);
-    this.putIfAbsentObserver = createObserver("putIfAbsent", StoreOperationOutcomes.PutIfAbsentOutcome.class);
-    this.removeObserver = createObserver("remove", StoreOperationOutcomes.RemoveOutcome.class);
-    this.conditionalRemoveObserver = createObserver("conditionalRemove", StoreOperationOutcomes.ConditionalRemoveOutcome.class);
-    this.replaceObserver = createObserver("replace", StoreOperationOutcomes.ReplaceOutcome.class);
-    this.conditionalReplaceObserver = createObserver("conditionalReplace", StoreOperationOutcomes.ConditionalReplaceOutcome.class);
-    this.computeObserver = createObserver("compute", StoreOperationOutcomes.ComputeOutcome.class);
-    this.computeIfAbsentObserver = createObserver("computeIfAbsent", StoreOperationOutcomes.ComputeIfAbsentOutcome.class);
-    this.evictionObserver = createObserver("eviction", StoreOperationOutcomes.EvictionOutcome.class);
-    this.expirationObserver = createObserver("expiration", StoreOperationOutcomes.ExpirationOutcome.class);
+    this.getObserver = createObserver("get", StoreOperationOutcomes.GetOutcome.class, true);
+    this.putObserver = createObserver("put", StoreOperationOutcomes.PutOutcome.class, true);
+    this.putIfAbsentObserver = createObserver("putIfAbsent", StoreOperationOutcomes.PutIfAbsentOutcome.class, true);
+    this.removeObserver = createObserver("remove", StoreOperationOutcomes.RemoveOutcome.class, true);
+    this.conditionalRemoveObserver = createObserver("conditionalRemove", StoreOperationOutcomes.ConditionalRemoveOutcome.class, true);
+    this.replaceObserver = createObserver("replace", StoreOperationOutcomes.ReplaceOutcome.class, true);
+    this.conditionalReplaceObserver = createObserver("conditionalReplace", StoreOperationOutcomes.ConditionalReplaceOutcome.class, true);
+    this.computeObserver = createObserver("compute", StoreOperationOutcomes.ComputeOutcome.class, true);
+    this.computeIfAbsentObserver = createObserver("computeIfAbsent", StoreOperationOutcomes.ComputeIfAbsentOutcome.class, true);
+    this.evictionObserver = createObserver("eviction", StoreOperationOutcomes.EvictionOutcome.class, false);
+    this.expirationObserver = createObserver("expiration", StoreOperationOutcomes.ExpirationOutcome.class, false);
 
-    this.getAndFaultObserver = createObserver("getAndFault", AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.class);
-    this.computeIfAbsentAndFaultObserver = createObserver("computeIfAbsentAndFault", AuthoritativeTierOperationOutcomes.ComputeIfAbsentAndFaultOutcome.class);
-    this.flushObserver = createObserver("flush", AuthoritativeTierOperationOutcomes.FlushOutcome.class);
+    this.getAndFaultObserver = createObserver("getAndFault", AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.class, true);
+    this.computeIfAbsentAndFaultObserver = createObserver("computeIfAbsentAndFault", AuthoritativeTierOperationOutcomes.ComputeIfAbsentAndFaultOutcome.class, true);
+    this.flushObserver = createObserver("flush", AuthoritativeTierOperationOutcomes.FlushOutcome.class, true);
 
-    this.invalidateObserver = createObserver("invalidate", LowerCachingTierOperationsOutcome.InvalidateOutcome.class);
-    this.invalidateAllObserver = createObserver("invalidateAll", LowerCachingTierOperationsOutcome.InvalidateAllOutcome.class);
-    this.invalidateAllWithHashObserver = createObserver("invalidateAllWithHash", LowerCachingTierOperationsOutcome.InvalidateAllWithHashOutcome.class);
-    this.getAndRemoveObserver= createObserver("getAndRemove", LowerCachingTierOperationsOutcome.GetAndRemoveOutcome.class);
-    this.installMappingObserver= createObserver("installMapping", LowerCachingTierOperationsOutcome.InstallMappingOutcome.class);
+    this.invalidateObserver = createObserver("invalidate", LowerCachingTierOperationsOutcome.InvalidateOutcome.class, true);
+    this.invalidateAllObserver = createObserver("invalidateAll", LowerCachingTierOperationsOutcome.InvalidateAllOutcome.class, true);
+    this.invalidateAllWithHashObserver = createObserver("invalidateAllWithHash", LowerCachingTierOperationsOutcome.InvalidateAllWithHashOutcome.class, true);
+    this.getAndRemoveObserver= createObserver("getAndRemove", LowerCachingTierOperationsOutcome.GetAndRemoveOutcome.class, true);
+    this.installMappingObserver= createObserver("installMapping", LowerCachingTierOperationsOutcome.InstallMappingOutcome.class, true);
 
     Set<String> tags = tags(getStatisticsTag(), "tier");
     registerStatistic("allocatedMemory", GAUGE, tags, EhcacheOffHeapBackingMap::allocatedMemory);

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -103,7 +103,7 @@ public abstract class AbstractOffHeapStore<K, V> extends BaseStore<K, V> impleme
   private volatile CachingTier.InvalidationListener<K, V> invalidationListener = (CachingTier.InvalidationListener<K, V>) NULL_INVALIDATION_LISTENER;
 
   public AbstractOffHeapStore(Configuration<K, V> config, TimeSource timeSource, StoreEventDispatcher<K, V> eventDispatcher) {
-    super(config.getKeyType(), config.getValueType());
+    super(config);
 
     expiry = config.getExpiry();
 

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
@@ -70,8 +70,6 @@ import static org.ehcache.impl.internal.store.offheap.OffHeapStoreUtils.getBuffe
  */
 public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
 
-  private static final String STATISTICS_TAG = "OffHeap";
-
   private final SwitchableEvictionAdvisor<K, OffHeapValueHolder<V>> evictionAdvisor;
   private final Serializer<K> keySerializer;
   private final Serializer<V> valueSerializer;
@@ -80,7 +78,7 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
   private volatile EhcacheConcurrentOffHeapClockCache<K, OffHeapValueHolder<V>> map;
 
   public OffHeapStore(final Configuration<K, V> config, TimeSource timeSource, StoreEventDispatcher<K, V> eventDispatcher, long sizeInBytes) {
-    super(STATISTICS_TAG, config, timeSource, eventDispatcher);
+    super(config, timeSource, eventDispatcher);
     EvictionAdvisor<? super K, ? super V> evictionAdvisor = config.getEvictionAdvisor();
     if (evictionAdvisor != null) {
       this.evictionAdvisor = wrap(evictionAdvisor);
@@ -90,6 +88,11 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
     this.keySerializer = config.getKeySerializer();
     this.valueSerializer = config.getValueSerializer();
     this.sizeInBytes = sizeInBytes;
+  }
+
+  @Override
+  protected String getStatisticsTag() {
+    return "OffHeap";
   }
 
   @Override
@@ -157,7 +160,7 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
     }
 
     private <K, V, S extends Enum<S>, T extends Enum<T>> MappedOperationStatistic<S, T> createTranslatedStatistic(OffHeapStore<K, V> store, String statisticName, Map<T, Set<S>> translation, String targetName) {
-      MappedOperationStatistic<S, T> stat = new MappedOperationStatistic<>(store, translation, statisticName, ResourceType.Core.OFFHEAP.getTierHeight(), targetName, STATISTICS_TAG);
+      MappedOperationStatistic<S, T> stat = new MappedOperationStatistic<>(store, translation, statisticName, ResourceType.Core.OFFHEAP.getTierHeight(), targetName, store.getStatisticsTag());
       StatisticsManager.associate(stat).withParent(store);
       return stat;
     }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
@@ -22,6 +22,7 @@ import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.config.ResourceType;
 import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.core.events.StoreEventDispatcher;
+import org.ehcache.impl.internal.store.disk.OffHeapDiskStore;
 import org.ehcache.spi.resilience.StoreAccessException;
 import org.ehcache.core.events.NullStoreEventDispatcher;
 import org.ehcache.impl.internal.events.ThreadLocalStoreEventDispatcher;

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultCacheStatisticsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultCacheStatisticsTest.java
@@ -64,9 +64,72 @@ public class DefaultCacheStatisticsTest {
    * @return if store statistics are enabled or disabled
    */
   @Parameterized.Parameters
-  public static Object[] data() {
+  public static final Object[] data() {
     return new Object[] { Boolean.FALSE, Boolean.TRUE };
   }
+
+  private static final String[][] KNOWN_STATISTICS = {
+    {
+      // Disabled
+      "Cache:EvictionCount",
+      "Cache:ExpirationCount",
+      "Cache:GetHitLatency#100",
+      "Cache:GetHitLatency#50",
+      "Cache:GetHitLatency#95",
+      "Cache:GetHitLatency#99",
+      "Cache:GetMissLatency#100",
+      "Cache:GetMissLatency#50",
+      "Cache:GetMissLatency#95",
+      "Cache:GetMissLatency#99",
+      "Cache:HitCount",
+      "Cache:MissCount",
+      "Cache:PutCount",
+      "Cache:PutLatency#100",
+      "Cache:PutLatency#50",
+      "Cache:PutLatency#95",
+      "Cache:PutLatency#99",
+      "Cache:RemovalCount",
+      "Cache:RemoveLatency#100",
+      "Cache:RemoveLatency#50",
+      "Cache:RemoveLatency#95",
+      "Cache:RemoveLatency#99",
+      "OnHeap:EvictionCount",
+      "OnHeap:ExpirationCount",
+      "OnHeap:MappingCount"
+    },
+    {
+      // Enabled
+      "Cache:EvictionCount",
+      "Cache:ExpirationCount",
+      "Cache:GetHitLatency#100",
+      "Cache:GetHitLatency#50",
+      "Cache:GetHitLatency#95",
+      "Cache:GetHitLatency#99",
+      "Cache:GetMissLatency#100",
+      "Cache:GetMissLatency#50",
+      "Cache:GetMissLatency#95",
+      "Cache:GetMissLatency#99",
+      "Cache:HitCount",
+      "Cache:MissCount",
+      "Cache:PutCount",
+      "Cache:PutLatency#100",
+      "Cache:PutLatency#50",
+      "Cache:PutLatency#95",
+      "Cache:PutLatency#99",
+      "Cache:RemovalCount",
+      "Cache:RemoveLatency#100",
+      "Cache:RemoveLatency#50",
+      "Cache:RemoveLatency#95",
+      "Cache:RemoveLatency#99",
+      "OnHeap:EvictionCount",
+      "OnHeap:ExpirationCount",
+      "OnHeap:HitCount",
+      "OnHeap:MappingCount",
+      "OnHeap:MissCount",
+      "OnHeap:PutCount",
+      "OnHeap:RemovalCount"
+    }
+  };
 
   private static final int TIME_TO_EXPIRATION = 100;
   private static final int HISTOGRAM_WINDOW_MILLIS = 400;
@@ -141,36 +204,7 @@ public class DefaultCacheStatisticsTest {
 
   @Test
   public void getKnownStatistics() {
-    assertThat(cacheStatistics.getKnownStatistics()).containsOnlyKeys(
-      "Cache:EvictionCount",
-      "Cache:ExpirationCount",
-      "Cache:GetHitLatency#100",
-      "Cache:GetHitLatency#50",
-      "Cache:GetHitLatency#95",
-      "Cache:GetHitLatency#99",
-      "Cache:GetMissLatency#100",
-      "Cache:GetMissLatency#50",
-      "Cache:GetMissLatency#95",
-      "Cache:GetMissLatency#99",
-      "Cache:HitCount",
-      "Cache:MissCount",
-      "Cache:PutCount",
-      "Cache:PutLatency#100",
-      "Cache:PutLatency#50",
-      "Cache:PutLatency#95",
-      "Cache:PutLatency#99",
-      "Cache:RemovalCount",
-      "Cache:RemoveLatency#100",
-      "Cache:RemoveLatency#50",
-      "Cache:RemoveLatency#95",
-      "Cache:RemoveLatency#99",
-      "OnHeap:EvictionCount",
-      "OnHeap:ExpirationCount",
-      "OnHeap:HitCount",
-      "OnHeap:MappingCount",
-      "OnHeap:MissCount",
-      "OnHeap:PutCount",
-      "OnHeap:RemovalCount");
+    assertThat(cacheStatistics.getKnownStatistics()).containsOnlyKeys(KNOWN_STATISTICS[enableStoreStatistics ? 1 : 0]);
   }
 
   @Test

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultTierStatisticsDisabledTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultTierStatisticsDisabledTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.impl.internal.statistics;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.units.EntryUnit;
+import org.ehcache.impl.internal.TimeSourceConfiguration;
+import org.ehcache.internal.TestTimeSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
+
+/**
+ * Test the behavior of statistics when they are disabled (the default with one tier) on a store.
+ */
+public class DefaultTierStatisticsDisabledTest {
+
+  private static final int TIME_TO_EXPIRATION = 100;
+
+  private DefaultTierStatistics onHeap;
+  private CacheManager cacheManager;
+  private Cache<Long, String> cache;
+  private TestTimeSource timeSource = new TestTimeSource(System.currentTimeMillis());
+
+  @Before
+  public void before() {
+    CacheConfiguration<Long, String> cacheConfiguration =
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
+        newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
+        .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMillis(TIME_TO_EXPIRATION)))
+        .build();
+
+    cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+      .withCache("aCache", cacheConfiguration)
+      .using(new TimeSourceConfiguration(timeSource))
+      .build(true);
+
+    cache = cacheManager.getCache("aCache", Long.class, String.class);
+
+    onHeap = new DefaultTierStatistics(cache, "OnHeap");
+  }
+
+  @After
+  public void after() {
+    if(cacheManager != null) {
+      cacheManager.close();
+    }
+  }
+
+  @Test
+  public void getKnownStatistics() {
+    // Passthrough are there. Special ones needed for the cache statistics are there
+    assertThat(onHeap.getKnownStatistics()).containsOnlyKeys("OnHeap:EvictionCount", "OnHeap:ExpirationCount", "OnHeap:MappingCount");
+  }
+
+  @Test
+  public void getHits() {
+    cache.put(1L, "a");
+    cache.get(1L);
+    assertThat(onHeap.getHits()).isEqualTo(0L);
+    assertNoStat("OnHeap:HitCount");
+  }
+
+  @Test
+  public void getMisses() {
+    cache.get(1L);
+    assertThat(onHeap.getMisses()).isEqualTo(0L);
+    assertNoStat("OnHeap:MissCount");
+  }
+
+  @Test
+  public void getPuts() {
+    cache.put(1L, "a");
+    assertThat(onHeap.getPuts()).isEqualTo(0L);
+    assertNoStat("OnHeap:PutCount");
+  }
+
+  @Test
+  public void getUpdates() {
+    cache.put(1L, "a");
+    cache.put(1L, "b");
+    assertThat(onHeap.getPuts()).isEqualTo(0L);
+    assertNoStat("OnHeap:PutCount");
+  }
+
+  @Test
+  public void getRemovals() {
+    cache.put(1L, "a");
+    cache.remove(1L);
+    assertThat(onHeap.getRemovals()).isEqualTo(0L);
+    assertNoStat("OnHeap:RemovalCount");
+  }
+
+  @Test
+  public void getEvictions() {
+    for (long i = 0; i < 11; i++) {
+      cache.put(i, "a");
+    }
+    assertThat(onHeap.getEvictions()).isEqualTo(1L);
+    assertStat("OnHeap:EvictionCount").isEqualTo(1L);
+  }
+
+  @Test
+  public void getExpirations() {
+    cache.put(1L, "a");
+    timeSource.advanceTime(TIME_TO_EXPIRATION);
+    cache.get(1L);
+    assertThat(onHeap.getExpirations()).isEqualTo(1L);
+    assertStat("OnHeap:ExpirationCount").isEqualTo(1L);
+  }
+
+  @Test
+  public void getMappings() {
+    cache.put(1L, "a");
+    assertThat(onHeap.getMappings()).isEqualTo(1L);
+    assertStat("OnHeap:MappingCount").isEqualTo(1L);
+  }
+
+  @Test
+  public void getAllocatedByteSize() {
+    cache.put(1L, "a");
+    assertThat(onHeap.getAllocatedByteSize()).isEqualTo(-1L);
+  }
+
+  @Test
+  public void getOccupiedByteSize() {
+    cache.put(1L, "a");
+    assertThat(onHeap.getOccupiedByteSize()).isEqualTo(-1L);
+  }
+
+  private AbstractObjectAssert<?, Number> assertStat(String key) {
+    return assertThat((Number) onHeap.getKnownStatistics().get(key).value());
+  }
+
+  private void assertNoStat(String key) {
+    assertThat(onHeap.getKnownStatistics()).doesNotContainKey(key);
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultTierStatisticsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/DefaultTierStatisticsTest.java
@@ -24,6 +24,7 @@ import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.config.units.EntryUnit;
+import org.ehcache.core.config.store.StoreStatisticsConfiguration;
 import org.ehcache.impl.internal.TimeSourceConfiguration;
 import org.ehcache.internal.TestTimeSource;
 import org.junit.After;
@@ -50,6 +51,7 @@ public class DefaultTierStatisticsTest {
       CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
         newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES))
         .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMillis(TIME_TO_EXPIRATION)))
+        .add(new StoreStatisticsConfiguration(true)) // explicitly enable statistics
         .build();
 
     cacheManager = CacheManagerBuilder.newCacheManagerBuilder()

--- a/impl/src/test/java/org/ehcache/impl/internal/statistics/StatsUtilsTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/statistics/StatsUtilsTest.java
@@ -21,7 +21,9 @@ import org.ehcache.CacheManager;
 import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.core.config.store.StoreStatisticsConfiguration;
 import org.ehcache.core.statistics.CacheOperationOutcomes;
+import org.ehcache.core.statistics.StoreOperationOutcomes;
 import org.ehcache.core.statistics.TierOperationOutcomes;
 import org.junit.After;
 import org.junit.Before;
@@ -43,12 +45,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.heap;
-import static org.ehcache.impl.internal.statistics.StatsUtils.findLowestTier;
-import static org.ehcache.impl.internal.statistics.StatsUtils.findOperationStatisticOnChildren;
-import static org.ehcache.impl.internal.statistics.StatsUtils.findStatisticOnDescendants;
-import static org.ehcache.impl.internal.statistics.StatsUtils.findTiers;
-import static org.ehcache.impl.internal.statistics.StatsUtils.hasProperty;
-import static org.ehcache.impl.internal.statistics.StatsUtils.hasTag;
+import static org.ehcache.impl.internal.statistics.StatsUtils.*;
 import static org.terracotta.context.query.Matchers.attributes;
 import static org.terracotta.context.query.Matchers.context;
 import static org.terracotta.context.query.Matchers.hasAttribute;
@@ -67,7 +64,9 @@ public class StatsUtilsTest {
   @Before
   public void before() {
     CacheConfiguration<Long, String> cacheConfiguration =
-      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10)).build();
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
+        .add(new StoreStatisticsConfiguration(true)) // explicitly enable statistics
+        .build();
 
     cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
       .withCache("aCache", cacheConfiguration)
@@ -209,5 +208,15 @@ public class StatsUtilsTest {
   public void testFindLowerTier_none() {
     expectedException.expect(RuntimeException.class);
     findLowestTier(new String[0]);
+  }
+
+  @Test
+  public void testHasOperationStatistic_found() {
+    assertThat(hasOperationStat(cache, StoreOperationOutcomes.GetOutcome.class, "get")).isTrue();
+  }
+
+  @Test
+  public void testHasOperationStatistic_notFound() {
+    assertThat(hasOperationStat(cache, StoreOperationOutcomes.GetOutcome.class, "xxx")).isFalse();
   }
 }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
@@ -22,6 +22,7 @@ import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.EvictionAdvisor;
 import org.ehcache.config.ResourcePool;
 import org.ehcache.config.ResourceType;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.core.internal.store.StoreConfigurationImpl;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.MemoryUnit;
@@ -248,7 +249,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
       Serializer<String> keySerializer = serializationProvider.createKeySerializer(String.class, classLoader);
       Serializer<String> valueSerializer = serializationProvider.createValueSerializer(String.class, classLoader);
       StoreConfigurationImpl<String, String> storeConfiguration = new StoreConfigurationImpl<>(String.class, String.class,
-        null, classLoader, expiry, null, 0, keySerializer, valueSerializer);
+        null, classLoader, expiry, null, 0, true, keySerializer, valueSerializer);
       OffHeapDiskStore<String, String> offHeapStore = new OffHeapDiskStore<>(
         getPersistenceContext(),
         new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
@@ -271,7 +272,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
       Serializer<String> keySerializer = serializationProvider.createKeySerializer(String.class, classLoader);
       Serializer<byte[]> valueSerializer = serializationProvider.createValueSerializer(byte[].class, classLoader);
       StoreConfigurationImpl<String, byte[]> storeConfiguration = new StoreConfigurationImpl<>(String.class, byte[].class,
-        evictionAdvisor, getClass().getClassLoader(), expiry, null, 0, keySerializer, valueSerializer);
+        evictionAdvisor, getClass().getClassLoader(), expiry, null, 0, true, keySerializer, valueSerializer);
       OffHeapDiskStore<String, byte[]> offHeapStore = new OffHeapDiskStore<>(
         getPersistenceContext(),
         new OnDemandExecutionService(), null, DEFAULT_WRITER_CONCURRENCY, DEFAULT_DISK_SEGMENTS,
@@ -298,7 +299,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
   public void testStoreInitFailsWithoutLocalPersistenceService() throws Exception {
     OffHeapDiskStore.Provider provider = new OffHeapDiskStore.Provider();
     try {
-      ServiceLocator serviceLocator = dependencySet().with(provider).build();
+      dependencySet().with(provider).build();
       fail("IllegalStateException expected");
     } catch (IllegalStateException e) {
       assertThat(e.getMessage(), containsString("Failed to find provider with satisfied dependency set for interface" +
@@ -333,7 +334,7 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
   private void assertRank(final Store.Provider provider, final int expectedRank, final ResourceType<?>... resources) {
     assertThat(provider.rank(
       new HashSet<>(Arrays.asList(resources)),
-        Collections.<ServiceConfiguration<?>>emptyList()),
+        Collections.emptyList()),
         is(expectedRank));
   }
 
@@ -354,7 +355,8 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
     try (CacheManager manager = newCacheManagerBuilder()
       .with(persistence(temporaryFolder.newFolder("disk-stores").getAbsolutePath()))
       .build(true)) {
-      final Cache<Long, CacheValue> cache = manager.createCache("test", newCacheConfigurationBuilder(Long.class, CacheValue.class,
+
+      CacheConfigurationBuilder<Long, CacheValue> cacheConfigurationBuilder = newCacheConfigurationBuilder(Long.class, CacheValue.class,
         heap(1000).offheap(10, MB).disk(20, MB))
         .withLoaderWriter(new CacheLoaderWriter<Long, CacheValue>() {
           @Override
@@ -382,7 +384,9 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
           @Override
           public void deleteAll(Iterable<? extends Long> keys) {
           }
-        }));
+        });
+
+      Cache<Long, CacheValue> cache = manager.createCache("test", cacheConfigurationBuilder);
 
       for (long i = 0; i < 100000; i++) {
         cache.put(i, new CacheValue((int) i));

--- a/integration-test/src/test/java/org/ehcache/integration/StoreStatisticsTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/StoreStatisticsTest.java
@@ -21,6 +21,7 @@ import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.core.config.store.StoreStatisticsConfiguration;
 import org.ehcache.core.statistics.AuthoritativeTierOperationOutcomes;
 import org.ehcache.core.statistics.CachingTierOperationOutcomes;
 import org.ehcache.core.statistics.LowerCachingTierOperationsOutcome;
@@ -38,7 +39,6 @@ import org.terracotta.statistics.OperationStatistic;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -66,47 +66,63 @@ public class StoreStatisticsTest {
 
   @Test
   public void test1TierStoreStatsAvailableInContextManager() throws Exception {
-    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("threeTieredCache",
             CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(1))
-        ).build(true);
+              .add(new StoreStatisticsConfiguration(true)) // explicitly enable statistics
+        ).build(true)) {
 
-    Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
+      Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
 
-    assertNull(cache.get(0L));
+      assertNull(cache.get(0L));
 
-    long onHeapMisses = StoreStatisticsTest.<StoreOperationOutcomes.GetOutcome>findStat(cache, "get", "OnHeap").count(StoreOperationOutcomes.GetOutcome.MISS);
-    assertThat(onHeapMisses, equalTo(1L));
+      long onHeapMisses = StoreStatisticsTest.<StoreOperationOutcomes.GetOutcome>findStat(cache, "get", "OnHeap").count(StoreOperationOutcomes.GetOutcome.MISS);
+      assertThat(onHeapMisses, equalTo(1L));
+    }
+  }
 
-    cacheManager.close();
+  @Test
+  public void test1TierStoreStatsAvailableInContextManager_disabledByDefault() throws Exception {
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+      .withCache("threeTieredCache",
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(1))
+      ).build(true)) {
+
+      Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
+
+      assertNull(cache.get(0L));
+
+      assertNull("Statistics are disabled so nothing is expected here", StoreStatisticsTest.<StoreOperationOutcomes.GetOutcome>findStat(cache, "get", "OnHeap"));
+    }
   }
 
   @Test
   public void test2TiersStoreStatsAvailableInContextManager() throws Exception {
-    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("threeTieredCache",
             CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
                 newResourcePoolsBuilder()
                     .heap(1, MemoryUnit.MB)
                     .offheap(2, MemoryUnit.MB)
                 )
-        ).build(true);
+        ).build(true)) {
 
-    Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
+      Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
 
-    assertNull(cache.get(0L));
+      assertNull(cache.get(0L));
 
-    long onHeapMisses = StoreStatisticsTest.<CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome>findStat(cache, "getOrComputeIfAbsent", "OnHeap").count(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.MISS);
-    assertThat(onHeapMisses, equalTo(1L));
-    long offheapMisses = StoreStatisticsTest.<AuthoritativeTierOperationOutcomes.GetAndFaultOutcome>findStat(cache, "getAndFault", "OffHeap").count(AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.MISS);
-    assertThat(offheapMisses, equalTo(1L));
-
-    cacheManager.close();
+      long onHeapMisses = StoreStatisticsTest.<CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome>findStat(cache, "getOrComputeIfAbsent", "OnHeap")
+        .count(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.MISS);
+      assertThat(onHeapMisses, equalTo(1L));
+      long offheapMisses = StoreStatisticsTest.<AuthoritativeTierOperationOutcomes.GetAndFaultOutcome>findStat(cache, "getAndFault", "OffHeap")
+        .count(AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.MISS);
+      assertThat(offheapMisses, equalTo(1L));
+    }
   }
 
   @Test
   public void test3TiersStoreStatsAvailableInContextManager() throws Exception {
-    PersistentCacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+    try(PersistentCacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .with(new CacheManagerPersistenceConfiguration(new File(getStoragePath(), "StoreStatisticsTest")))
         .withCache("threeTieredCache",
             CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
@@ -115,20 +131,21 @@ public class StoreStatisticsTest {
                     .offheap(2, MemoryUnit.MB)
                     .disk(5, MemoryUnit.MB)
                 )
-        ).build(true);
+        ).build(true)) {
 
-    Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
+      Cache<Long, String> cache = cacheManager.getCache("threeTieredCache", Long.class, String.class);
 
-    assertNull(cache.get(0L));
+      assertNull(cache.get(0L));
 
-    long onHeapMisses = StoreStatisticsTest.<CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome>findStat(cache, "getOrComputeIfAbsent", "OnHeap").count(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.MISS);
-    assertThat(onHeapMisses, equalTo(1L));
-    long offHeapMisses = StoreStatisticsTest.<LowerCachingTierOperationsOutcome.GetAndRemoveOutcome>findStat(cache, "getAndRemove", "OffHeap").count(LowerCachingTierOperationsOutcome.GetAndRemoveOutcome.MISS);
-    assertThat(offHeapMisses, equalTo(1L));
-    long diskMisses = StoreStatisticsTest.<AuthoritativeTierOperationOutcomes.GetAndFaultOutcome>findStat(cache, "getAndFault", "Disk").count(AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.MISS);
-    assertThat(diskMisses, equalTo(1L));
-
-    cacheManager.close();
+      long onHeapMisses = StoreStatisticsTest.<CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome>findStat(cache, "getOrComputeIfAbsent", "OnHeap")
+        .count(CachingTierOperationOutcomes.GetOrComputeIfAbsentOutcome.MISS);
+      assertThat(onHeapMisses, equalTo(1L));
+      long offHeapMisses = StoreStatisticsTest.<LowerCachingTierOperationsOutcome.GetAndRemoveOutcome>findStat(cache, "getAndRemove", "OffHeap")
+        .count(LowerCachingTierOperationsOutcome.GetAndRemoveOutcome.MISS);
+      assertThat(offHeapMisses, equalTo(1L));
+      long diskMisses = StoreStatisticsTest.<AuthoritativeTierOperationOutcomes.GetAndFaultOutcome>findStat(cache, "getAndFault", "Disk").count(AuthoritativeTierOperationOutcomes.GetAndFaultOutcome.MISS);
+      assertThat(diskMisses, equalTo(1L));
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -147,12 +164,16 @@ public class StoreStatisticsTest {
                   }
                 }))))).build().execute(operationStatisticNodes);
 
-    if (result.size() != 1) {
-      throw new RuntimeException("query for unique stat '" + statName + "' with tag '" + tag + "' failed; found " + result.size() + " instance(s)");
+    switch (result.size()) {
+      case 0:
+        return null;
+      case 1: {
+        TreeNode node = result.iterator().next();
+        return (OperationStatistic<T>) node.getContext().attributes().get("this");
+      }
+      default:
+       throw new RuntimeException("query for unique stat '" + statName + "' with tag '" + tag + "' failed; found " + result.size() + " instance(s)");
     }
-
-    TreeNode node = result.iterator().next();
-    return (OperationStatistic<T>) node.getContext().attributes().get("this");
   }
 
   private String getStoragePath() throws IOException {

--- a/integration-test/src/test/java/org/ehcache/integration/statistics/TierCalculationTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/statistics/TierCalculationTest.java
@@ -29,6 +29,7 @@ import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.core.config.store.StoreStatisticsConfiguration;
 import org.ehcache.core.spi.service.StatisticsService;
 import org.ehcache.impl.config.persistence.DefaultPersistenceConfiguration;
 import org.ehcache.impl.internal.TimeSourceConfiguration;
@@ -65,6 +66,7 @@ public class TierCalculationTest extends AbstractTierCalculationTest {
       CacheConfigurationBuilder
         .newCacheConfigurationBuilder(Integer.class, String.class, resources)
         .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMillis(TIME_TO_EXPIRATION)))
+        .add(new StoreStatisticsConfiguration(true)) // explicitly enable statistics
         .build();
 
     StatisticsService statisticsService = new DefaultStatisticsService();

--- a/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
+++ b/management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 
@@ -54,6 +55,7 @@ import static org.ehcache.config.builders.ResourcePoolsBuilder.heap;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.ehcache.config.units.MemoryUnit.MB;
 
+@SuppressWarnings("try")
 public class DefaultManagementRegistryServiceTest {
 
   private static final Collection<Descriptor> ONHEAP_DESCRIPTORS = new ArrayList<>();
@@ -73,17 +75,14 @@ public class DefaultManagementRegistryServiceTest {
 
   @Test
   public void testCanGetContext() {
-    CacheManager cacheManager1 = null;
-    try {
-      CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
-        .build();
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
+      .build();
 
-      ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
-
-      cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
           .withCache("aCache", cacheConfiguration)
           .using(managementRegistry)
-          .build(true);
+          .build(true)) {
 
       ContextContainer contextContainer = managementRegistry.getContextContainer();
       assertThat(contextContainer.getName()).isEqualTo("cacheManagerName");
@@ -94,105 +93,91 @@ public class DefaultManagementRegistryServiceTest {
       assertThat(subcontext.getName()).isEqualTo("cacheName");
       assertThat(subcontext.getValue()).isEqualTo("aCache");
     }
-    finally {
-      if(cacheManager1 != null) cacheManager1.close();
-    }
   }
 
   @Test
   public void descriptorOnHeapTest() {
-    CacheManager cacheManager1 = null;
-    try {
-      CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
-          .add(new StoreStatisticsConfiguration(true))
-          .build();
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
+        .add(new StoreStatisticsConfiguration(true))
+        .build();
 
-      ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
+    ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-      cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
           .withCache("aCache", cacheConfiguration)
           .using(managementRegistry)
-          .build(true);
+          .build(true)) {
 
-      assertThat(managementRegistry.getCapabilities()).hasSize(4);
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getName()).isEqualTo("ActionsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(1).getName()).isEqualTo("SettingsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(2).getName()).isEqualTo("StatisticCollectorCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getName()).isEqualTo("StatisticsCapability");
+      List<Capability> capabilities = new ArrayList<>(managementRegistry.getCapabilities());
+      assertThat(capabilities).hasSize(4);
+      assertThat(capabilities.get(0).getName()).isEqualTo("ActionsCapability");
+      assertThat(capabilities.get(1).getName()).isEqualTo("SettingsCapability");
+      assertThat(capabilities.get(2).getName()).isEqualTo("StatisticCollectorCapability");
+      assertThat(capabilities.get(3).getName()).isEqualTo("StatisticsCapability");
 
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getDescriptors()).hasSize(4);
+      assertThat(capabilities.get(0).getDescriptors()).hasSize(4);
 
-      Collection<? extends Descriptor> descriptors = new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getDescriptors();
+      Collection<? extends Descriptor> descriptors = capabilities.get(3).getDescriptors();
       Collection<Descriptor> allDescriptors = new ArrayList<>();
       allDescriptors.addAll(ONHEAP_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
       assertThat(descriptors).containsOnlyElementsOf(allDescriptors);
     }
-    finally {
-      if(cacheManager1 != null) cacheManager1.close();
-    }
-
   }
 
   @Test
   public void descriptorOnHeapTest_withoutStats() {
-    CacheManager cacheManager1 = null;
-    try {
-      CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
-        .build();
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
+      .build();
 
-      ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
+    ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-      cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("aCache", cacheConfiguration)
         .using(managementRegistry)
-        .build(true);
+        .build(true)) {
 
+      List<Capability> capabilities = new ArrayList<>(managementRegistry.getCapabilities());
       assertThat(managementRegistry.getCapabilities()).hasSize(4);
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getName()).isEqualTo("ActionsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(1).getName()).isEqualTo("SettingsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(2).getName()).isEqualTo("StatisticCollectorCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getName()).isEqualTo("StatisticsCapability");
+      assertThat(capabilities.get(0).getName()).isEqualTo("ActionsCapability");
+      assertThat(capabilities.get(1).getName()).isEqualTo("SettingsCapability");
+      assertThat(capabilities.get(2).getName()).isEqualTo("StatisticCollectorCapability");
+      assertThat(capabilities.get(3).getName()).isEqualTo("StatisticsCapability");
 
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getDescriptors()).hasSize(4);
+      assertThat(capabilities.get(0).getDescriptors()).hasSize(4);
 
-      Collection<? extends Descriptor> descriptors = new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getDescriptors();
+      Collection<? extends Descriptor> descriptors = capabilities.get(3).getDescriptors();
       Collection<Descriptor> allDescriptors = new ArrayList<>();
       allDescriptors.addAll(ONHEAP_NO_STATS_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
       assertThat(descriptors).containsOnlyElementsOf(allDescriptors);
     }
-    finally {
-      if(cacheManager1 != null) cacheManager1.close();
-    }
-
   }
 
   @Test
   public void descriptorOffHeapTest() {
-    CacheManager cacheManager1 = null;
-    try {
-      CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, newResourcePoolsBuilder().heap(5, MB).offheap(10, MB))
-          .build();
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, newResourcePoolsBuilder().heap(5, MB).offheap(10, MB))
+        .build();
 
-      ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
+    ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-      cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
           .withCache("aCache", cacheConfiguration)
           .using(managementRegistry)
-          .build(true);
+          .build(true)) {
 
-      assertThat(managementRegistry.getCapabilities()).hasSize(4);
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getName()).isEqualTo("ActionsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(1).getName()).isEqualTo("SettingsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(2).getName()).isEqualTo("StatisticCollectorCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getName()).isEqualTo("StatisticsCapability");
+      List<Capability> capabilities = new ArrayList<>(managementRegistry.getCapabilities());
+      assertThat(capabilities).hasSize(4);
+      assertThat(capabilities.get(0).getName()).isEqualTo("ActionsCapability");
+      assertThat(capabilities.get(1).getName()).isEqualTo("SettingsCapability");
+      assertThat(capabilities.get(2).getName()).isEqualTo("StatisticCollectorCapability");
+      assertThat(capabilities.get(3).getName()).isEqualTo("StatisticsCapability");
 
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getDescriptors()).hasSize(4);
+      assertThat(capabilities.get(0).getDescriptors()).hasSize(4);
 
-      Collection<? extends Descriptor> descriptors = new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getDescriptors();
+      Collection<? extends Descriptor> descriptors = capabilities.get(3).getDescriptors();
       Collection<Descriptor> allDescriptors = new ArrayList<>();
       allDescriptors.addAll(ONHEAP_DESCRIPTORS);
       allDescriptors.addAll(OFFHEAP_DESCRIPTORS);
@@ -201,19 +186,13 @@ public class DefaultManagementRegistryServiceTest {
 
       assertThat(descriptors).containsOnlyElementsOf(allDescriptors);
     }
-    finally {
-      if(cacheManager1 != null) cacheManager1.close();
-    }
-
   }
 
   @Test
   public void descriptorDiskStoreTest() throws Exception {
-    PersistentCacheManager persistentCacheManager = null;
-    try {
-      ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
+    ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-      persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+    try(PersistentCacheManager persistentCacheManager = CacheManagerBuilder.newCacheManagerBuilder()
           .with(CacheManagerBuilder.persistence(getStoragePath() + File.separator + "myData"))
           .withCache("persistent-cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class,
               ResourcePoolsBuilder.newResourcePoolsBuilder()
@@ -221,27 +200,25 @@ public class DefaultManagementRegistryServiceTest {
                   .disk(10, MemoryUnit.MB, true))
               )
           .using(managementRegistry)
-          .build(true);
+          .build(true)) {
 
-      assertThat(managementRegistry.getCapabilities()).hasSize(4);
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getName()).isEqualTo("ActionsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(1).getName()).isEqualTo("SettingsCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(2).getName()).isEqualTo("StatisticCollectorCapability");
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getName()).isEqualTo("StatisticsCapability");
+      List<Capability> capabilities = new ArrayList<>(managementRegistry.getCapabilities());
+      assertThat(capabilities).hasSize(4);
+      assertThat(capabilities.get(0).getName()).isEqualTo("ActionsCapability");
+      assertThat(capabilities.get(1).getName()).isEqualTo("SettingsCapability");
+      assertThat(capabilities.get(2).getName()).isEqualTo("StatisticCollectorCapability");
+      assertThat(capabilities.get(3).getName()).isEqualTo("StatisticsCapability");
 
 
-      assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getDescriptors()).hasSize(4);
+      assertThat(capabilities.get(0).getDescriptors()).hasSize(4);
 
-      Collection<? extends Descriptor> descriptors = new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getDescriptors();
+      Collection<? extends Descriptor> descriptors = capabilities.get(3).getDescriptors();
       Collection<Descriptor> allDescriptors = new ArrayList<>();
       allDescriptors.addAll(ONHEAP_DESCRIPTORS);
       allDescriptors.addAll(DISK_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
       assertThat(descriptors).containsOnlyElementsOf(allDescriptors);
-    }
-    finally {
-      if(persistentCacheManager != null) persistentCacheManager.close();
     }
   }
 
@@ -257,24 +234,24 @@ public class DefaultManagementRegistryServiceTest {
 
     ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-    CacheManager cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("aCache", cacheConfiguration)
         .using(managementRegistry)
-        .build(true);
+        .build(true)) {
 
-    assertThat(managementRegistry.getCapabilities()).hasSize(4);
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getName()).isEqualTo("ActionsCapability");
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(1).getName()).isEqualTo("SettingsCapability");
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(2).getName()).isEqualTo("StatisticCollectorCapability");
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getName()).isEqualTo("StatisticsCapability");
+      assertThat(managementRegistry.getCapabilities()).hasSize(4);
+      List<Capability> capabilities = new ArrayList<>(managementRegistry.getCapabilities());
+      assertThat(capabilities.get(0).getName()).isEqualTo("ActionsCapability");
+      assertThat(capabilities.get(1).getName()).isEqualTo("SettingsCapability");
+      assertThat(capabilities.get(2).getName()).isEqualTo("StatisticCollectorCapability");
+      assertThat(capabilities.get(3).getName()).isEqualTo("StatisticsCapability");
 
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getDescriptors()).hasSize(4);
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getDescriptors()).hasSize(ONHEAP_DESCRIPTORS.size() + CACHE_DESCRIPTORS.size());
+      assertThat(capabilities.get(0).getDescriptors()).hasSize(4);
+      assertThat(capabilities.get(3).getDescriptors()).hasSize(ONHEAP_DESCRIPTORS.size() + CACHE_DESCRIPTORS.size());
 
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(0).getCapabilityContext().getAttributes()).hasSize(2);
-    assertThat(new ArrayList<Capability>(managementRegistry.getCapabilities()).get(3).getCapabilityContext().getAttributes()).hasSize(2);
-
-    cacheManager1.close();
+      assertThat(capabilities.get(0).getCapabilityContext().getAttributes()).hasSize(2);
+      assertThat(capabilities.get(3).getCapabilityContext().getAttributes()).hasSize(2);
+    }
   }
 
   @Test
@@ -286,55 +263,54 @@ public class DefaultManagementRegistryServiceTest {
 
     ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-    CacheManager cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("aCache1", cacheConfiguration)
         .withCache("aCache2", cacheConfiguration)
         .using(managementRegistry)
-        .build(true);
+        .build(true)) {
 
-    Context context1 = Context.empty()
-      .with("cacheManagerName", "myCM")
-      .with("cacheName", "aCache1");
+      Context context1 = Context.empty()
+        .with("cacheManagerName", "myCM")
+        .with("cacheName", "aCache1");
 
-    Context context2 = Context.empty()
-      .with("cacheManagerName", "myCM")
-      .with("cacheName", "aCache2");
+      Context context2 = Context.empty()
+        .with("cacheManagerName", "myCM")
+        .with("cacheName", "aCache2");
 
-    Cache<Long, String> cache1 = cacheManager1.getCache("aCache1", Long.class, String.class);
-    Cache<Long, String> cache2 = cacheManager1.getCache("aCache2", Long.class, String.class);
+      Cache<Long, String> cache1 = cacheManager.getCache("aCache1", Long.class, String.class);
+      Cache<Long, String> cache2 = cacheManager.getCache("aCache2", Long.class, String.class);
 
-    cache1.put(1L, "one");
-    cache2.put(3L, "three");
+      cache1.put(1L, "one");
+      cache2.put(3L, "three");
 
-    cache1.get(1L);
-    cache1.get(2L);
-    cache2.get(3L);
-    cache2.get(4L);
+      cache1.get(1L);
+      cache1.get(2L);
+      cache2.get(3L);
+      cache2.get(4L);
 
-    Builder builder1 = managementRegistry.withCapability("StatisticsCapability")
+      Builder builder1 = managementRegistry.withCapability("StatisticsCapability")
         .queryStatistic(queryStatisticName)
         .on(context1);
 
-    ContextualStatistics counters = getResultSet(builder1, context1, null, queryStatisticName).getResult(context1);
-    Number counterHistory1 = counters.<Number>getLatestSampleValue(queryStatisticName).get();
+      ContextualStatistics counters = getResultSet(builder1, context1, null, queryStatisticName).getResult(context1);
+      Number counterHistory1 = counters.<Number>getLatestSampleValue(queryStatisticName).get();
 
-    assertThat(counters.size()).isEqualTo(1);
-    assertThat(counterHistory1.longValue()).isEqualTo(1L);
+      assertThat(counters.size()).isEqualTo(1);
+      assertThat(counterHistory1.longValue()).isEqualTo(1L);
 
-    Builder builder2 = managementRegistry.withCapability("StatisticsCapability")
+      Builder builder2 = managementRegistry.withCapability("StatisticsCapability")
         .queryStatistic(queryStatisticName)
         .on(context1)
         .on(context2);
-    ResultSet<ContextualStatistics> allCounters = getResultSet(builder2, context1, context2, queryStatisticName);
+      ResultSet<ContextualStatistics> allCounters = getResultSet(builder2, context1, context2, queryStatisticName);
 
-    assertThat(allCounters.size()).isEqualTo(2);
-    assertThat(allCounters.getResult(context1).size()).isEqualTo(1);
-    assertThat(allCounters.getResult(context2).size()).isEqualTo(1);
+      assertThat(allCounters.size()).isEqualTo(2);
+      assertThat(allCounters.getResult(context1).size()).isEqualTo(1);
+      assertThat(allCounters.getResult(context2).size()).isEqualTo(1);
 
-    assertThat(allCounters.getResult(context1).getLatestSampleValue(queryStatisticName).get()).isEqualTo(1L);
-    assertThat(allCounters.getResult(context2).getLatestSampleValue(queryStatisticName).get()).isEqualTo(1L);
-
-    cacheManager1.close();
+      assertThat(allCounters.getResult(context1).getLatestSampleValue(queryStatisticName).get()).isEqualTo(1L);
+      assertThat(allCounters.getResult(context2).getLatestSampleValue(queryStatisticName).get()).isEqualTo(1L);
+    }
   }
 
   private static ResultSet<ContextualStatistics> getResultSet(Builder builder, Context context1, Context context2, String statisticsName) {
@@ -372,59 +348,50 @@ public class DefaultManagementRegistryServiceTest {
 
   @Test
   public void testCall() throws ExecutionException {
-    CacheManager cacheManager1 = null;
-    try {
     CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
         .build();
 
     ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
-
-    cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
         .withCache("aCache1", cacheConfiguration)
         .withCache("aCache2", cacheConfiguration)
         .using(managementRegistry)
-        .build(true);
+        .build(true)) {
 
-    Context context = Context.empty()
-      .with("cacheManagerName", "myCM")
-      .with("cacheName", "aCache1");
+      Context context = Context.empty()
+        .with("cacheManagerName", "myCM")
+        .with("cacheName", "aCache1");
 
-    cacheManager1.getCache("aCache1", Long.class, String.class).put(1L, "1");
+      cacheManager.getCache("aCache1", Long.class, String.class).put(1L, "1");
 
-    assertThat(cacheManager1.getCache("aCache1", Long.class, String.class).get(1L)).isEqualTo("1");
+      assertThat(cacheManager.getCache("aCache1", Long.class, String.class).get(1L)).isEqualTo("1");
 
-    ContextualReturn<?> result = managementRegistry.withCapability("ActionsCapability")
+      ContextualReturn<?> result = managementRegistry.withCapability("ActionsCapability")
         .call("clear")
         .on(context)
         .build()
         .execute()
         .getSingleResult();
 
-    assertThat(result.hasExecuted()).isTrue();
-    assertThat(result.getValue()).isNull();
+      assertThat(result.hasExecuted()).isTrue();
+      assertThat(result.getValue()).isNull();
 
-    assertThat(cacheManager1.getCache("aCache1", Long.class, String.class).get(1L)).isNull();
+      assertThat(cacheManager.getCache("aCache1", Long.class, String.class).get(1L)).isNull();
     }
-    finally {
-      if(cacheManager1 != null) cacheManager1.close();
-    }
-
   }
 
   @Test
   public void testCallOnInexistignContext() throws ExecutionException {
-    CacheManager cacheManager1 = null;
-    try {
-      CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
-          .build();
+    CacheConfiguration<Long, String> cacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Long.class, String.class, heap(10))
+        .build();
 
-      ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
+    ManagementRegistryService managementRegistry = new DefaultManagementRegistryService(new DefaultManagementRegistryConfiguration().setCacheManagerAlias("myCM"));
 
-      cacheManager1 = CacheManagerBuilder.newCacheManagerBuilder()
+    try(CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
           .withCache("aCache1", cacheConfiguration)
           .withCache("aCache2", cacheConfiguration)
           .using(managementRegistry)
-          .build(true);
+          .build(true)) {
 
       Context inexisting = Context.empty()
           .with("cacheManagerName", "myCM2")
@@ -442,17 +409,13 @@ public class DefaultManagementRegistryServiceTest {
       expectedException.expect(NoSuchElementException.class);
       results.getSingleResult().getValue();
     }
-    finally {
-      if(cacheManager1 != null) cacheManager1.close();
-    }
-
   }
 
   @BeforeClass
   public static void loadStatsUtil() {
     ONHEAP_NO_STATS_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:EvictionCount" , "COUNTER"));
     ONHEAP_NO_STATS_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:ExpirationCount" , "COUNTER"));
-    ONHEAP_NO_STATS_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:MappingCount" , "COUNTER"));
+    ONHEAP_NO_STATS_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:MappingCount" , "GAUGE"));
 
     ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:EvictionCount" , "COUNTER"));
     ONHEAP_DESCRIPTORS.add(new StatisticDescriptor("OnHeap:ExpirationCount" , "COUNTER"));


### PR DESCRIPTION
Seems to give a 7% speed optimization