### PR TITLE
Fix #2426 : Abandon leadership if any is acquired before closing conn

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/ClusterTierManagerClientEntityFactory.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/ClusterTierManagerClientEntityFactory.java
@@ -79,13 +79,19 @@ public class ClusterTierManagerClientEntityFactory {
     }
   }
 
-  public void abandonLeadership(String entityIdentifier) {
+  /**
+   * Proactively abandon any maintenance holds (READ or WRITE) before closing connection.
+   *
+   * @param entityIdentifier the master entity identifier
+   * @return true of abandoned false otherwise
+   */
+  public boolean abandonMaintenanceHolds(String entityIdentifier) {
     Hold hold = maintenanceHolds.remove(entityIdentifier);
-    if (hold == null) {
-      throw new IllegalMonitorStateException("Leadership was never held");
-    } else {
+    if (hold != null) {
       hold.unlock();
+      return true;
     }
+    return false;
   }
 
   /**

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/ConnectionState.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/ConnectionState.java
@@ -208,7 +208,11 @@ class ConnectionState {
     }
   }
 
-  public void destroyState() {
+  public void destroyState(boolean healthyConnection) {
+    if (entityFactory != null && healthyConnection) {
+      // proactively abandon any acquired read or write locks on a healthy connection
+      entityFactory.abandonMaintenanceHolds(entityIdentifier);
+    }
     entityFactory = null;
 
     clusterTierEntities.clear();
@@ -301,7 +305,7 @@ class ConnectionState {
   private void handleConnectionClosedException() {
     while (true) {
       try {
-        destroyState();
+        destroyState(false);
         reconnect();
         retrieveEntity();
         connectionRecoveryListener.run();

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
@@ -135,7 +135,7 @@ class DefaultClusteringService implements ClusteringService, EntityService {
      * InFlightMessage.waitForAcks -- a method that can wait forever.)  Theoretically, the connection close will
      * take care of server-side cleanup in the event the server is connected.
      */
-    connectionState.destroyState();
+    connectionState.destroyState(true);
     inMaintenance = false;
     connectionState.closeConnection();
   }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/ClusterTierManagerClientEntityFactoryIntegrationTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/ClusterTierManagerClientEntityFactoryIntegrationTest.java
@@ -36,7 +36,9 @@ import org.terracotta.testing.rules.Cluster;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
 
@@ -154,12 +156,7 @@ public class ClusterTierManagerClientEntityFactoryIntegrationTest extends Cluste
   @Test
   public void testAbandonLeadershipWhenNotOwning() throws Exception {
     ClusterTierManagerClientEntityFactory factory = new ClusterTierManagerClientEntityFactory(CONNECTION);
-    try {
-      factory.abandonLeadership("testAbandonLeadershipWhenNotOwning");
-      fail("Expected IllegalMonitorStateException");
-    } catch (IllegalMonitorStateException e) {
-      //expected
-    }
+    assertFalse(factory.abandonMaintenanceHolds("testAbandonLeadershipWhenNotOwning"));
   }
 
   @Test
@@ -183,7 +180,7 @@ public class ClusterTierManagerClientEntityFactoryIntegrationTest extends Cluste
   public void testAcquireLeadershipAfterAbandoned() throws Exception {
     ClusterTierManagerClientEntityFactory factoryA = new ClusterTierManagerClientEntityFactory(CONNECTION);
     factoryA.acquireLeadership("testAcquireLeadershipAfterAbandoned");
-    factoryA.abandonLeadership("testAcquireLeadershipAfterAbandoned");
+    assertTrue(factoryA.abandonMaintenanceHolds("testAcquireLeadershipAfterAbandoned"));
 
     try (Connection clientB = CLUSTER.newConnection()) {
       ClusterTierManagerClientEntityFactory factoryB = new ClusterTierManagerClientEntityFactory(clientB);

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,7 +17,7 @@
 plugins {
   id 'org.asciidoctor.convert' version '1.5.3'
   id 'org.kordamp.gradle.livereload' version '0.2.1'
-  id 'com.github.jruby-gradle.base' version '1.4.0'
+  id 'com.github.jruby-gradle.base' version '1.5.0'
 }
 
 dependencies {


### PR DESCRIPTION
This PR addresses the issue where a VoltronReadWriteLockEntity for a given cluster tier manager entity may remain in the system even after the cluster tier manager entity has been destroyed.