### PR TITLE
Fix #2447 : prevent race where clientinvalidatehash sees default timeouts instead of configured timeouts

### DIFF
--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusterTierClientEntityService.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusterTierClientEntityService.java
@@ -33,7 +33,7 @@ import org.terracotta.entity.MessageCodec;
 /**
  * ClusterTierClientEntityService
  */
-public class ClusterTierClientEntityService implements EntityClientService<ClusterTierClientEntity, ClusterTierEntityConfiguration, EhcacheEntityMessage, EhcacheEntityResponse, Void> {
+public class ClusterTierClientEntityService implements EntityClientService<ClusterTierClientEntity, ClusterTierEntityConfiguration, EhcacheEntityMessage, EhcacheEntityResponse, ClusterTierUserData> {
 
   private final EntityConfigurationCodec configCodec = new EntityConfigurationCodec(new CommonConfigCodec());
 
@@ -53,8 +53,9 @@ public class ClusterTierClientEntityService implements EntityClientService<Clust
   }
 
   @Override
-  public ClusterTierClientEntity create(EntityClientEndpoint<EhcacheEntityMessage, EhcacheEntityResponse> endpoint, Void userData) {
-    return new SimpleClusterTierClientEntity(endpoint);
+  public ClusterTierClientEntity create(EntityClientEndpoint<EhcacheEntityMessage, EhcacheEntityResponse> endpoint,
+                                        ClusterTierUserData userData) {
+    return new SimpleClusterTierClientEntity(endpoint, userData.getTimeouts(), userData.getStoreIdentifier());
   }
 
   @Override

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusterTierUserData.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/ClusterTierUserData.java
@@ -13,11 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ehcache.clustered.client.internal.store;
 
+import org.ehcache.clustered.client.config.Timeouts;
+
 /**
- * InternalClusterTierClientEntity : Marker interface for any extensions that is used internally
+ * ClusterTierUserData
+ *
+ * Additional information passed to client side cluster tier entity.
  */
-public interface InternalClusterTierClientEntity extends ClusterTierClientEntity {
+public class ClusterTierUserData {
+  private final Timeouts timeouts;
+  private final String storeIdentifier;
+
+  public ClusterTierUserData(Timeouts timeouts, String storeIdentifier) {
+    this.timeouts = timeouts;
+    this.storeIdentifier = storeIdentifier;
+  }
+
+  public Timeouts getTimeouts() {
+    return timeouts;
+  }
+
+  public String getStoreIdentifier() {
+    return storeIdentifier;
+  }
 }

--- a/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/SimpleClusterTierClientEntity.java
+++ b/clustered/client/src/main/java/org/ehcache/clustered/client/internal/store/SimpleClusterTierClientEntity.java
@@ -71,6 +71,9 @@ public class SimpleClusterTierClientEntity implements InternalClusterTierClientE
   private final Map<Class<? extends EhcacheEntityResponse>, List<ResponseListener<? extends EhcacheEntityResponse>>> responseListeners =
     new ConcurrentHashMap<>();
   private final List<DisconnectionListener> disconnectionListeners = new CopyOnWriteArrayList<>();
+  private final Timeouts timeouts;
+  private final String storeIdentifier;
+
   private volatile boolean initCompleted = false;
   private final Object initLock = new Object();
 
@@ -78,12 +81,13 @@ public class SimpleClusterTierClientEntity implements InternalClusterTierClientE
     // No op
   };
 
-  private Timeouts timeouts = TimeoutsBuilder.timeouts().build();
-  private String storeIdentifier;
   private volatile boolean connected = true;
 
-  public SimpleClusterTierClientEntity(EntityClientEndpoint<EhcacheEntityMessage, EhcacheEntityResponse> endpoint) {
+  public SimpleClusterTierClientEntity(EntityClientEndpoint<EhcacheEntityMessage, EhcacheEntityResponse> endpoint,
+                                       Timeouts timeouts, String storeIdentifier) {
     this.endpoint = endpoint;
+    this.timeouts = timeouts;
+    this.storeIdentifier = storeIdentifier;
     this.messageFactory = new LifeCycleMessageFactory();
     endpoint.setDelegate(new EndpointDelegate<EhcacheEntityResponse>() {
       @Override
@@ -107,11 +111,6 @@ public class SimpleClusterTierClientEntity implements InternalClusterTierClientE
         fireDisconnectionEvent();
       }
     });
-  }
-
-  @Override
-  public void setTimeouts(Timeouts timeouts) {
-    this.timeouts = timeouts;
   }
 
   void fireDisconnectionEvent() {
@@ -187,11 +186,6 @@ public class SimpleClusterTierClientEntity implements InternalClusterTierClientE
     } catch (ClusterException e) {
       throw new ClusterTierValidationException("Error validating cluster tier '" + storeIdentifier + "'", e);
     }
-  }
-
-  @Override
-  public void setStoreIdentifier(String storeIdentifier) {
-    this.storeIdentifier = storeIdentifier;
   }
 
   @Override

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/UnitTestConnectionService.java
@@ -285,7 +285,7 @@ public class UnitTestConnectionService implements ConnectionService {
   @SuppressWarnings("unused")
   public static final class PassthroughServerBuilder {
     private final List<EntityServerService<?, ?>> serverEntityServices = new ArrayList<>();
-    private final List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse, Void>> clientEntityServices =
+    private final List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse, ?>> clientEntityServices =
       new ArrayList<>();
     private final Map<ServiceProvider, ServiceProviderConfiguration> serviceProviders =
       new IdentityHashMap<>();
@@ -338,7 +338,7 @@ public class UnitTestConnectionService implements ConnectionService {
       return this;
     }
 
-    public PassthroughServerBuilder clientEntityService(EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse, Void> service) {
+    public PassthroughServerBuilder clientEntityService(EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse, ?> service) {
       this.clientEntityServices.add(service);
       return this;
     }
@@ -362,7 +362,7 @@ public class UnitTestConnectionService implements ConnectionService {
         newServer.registerServerEntityService(service);
       }
 
-      for (EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse, Void> service : clientEntityServices) {
+      for (EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse, ?> service : clientEntityServices) {
         newServer.registerClientEntityService(service);
       }
 

--- a/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/SimpleClusterTierClientEntityTest.java
+++ b/clustered/client/src/test/java/org/ehcache/clustered/client/internal/store/SimpleClusterTierClientEntityTest.java
@@ -15,6 +15,7 @@
  */
 package org.ehcache.clustered.client.internal.store;
 
+import org.ehcache.clustered.client.config.builders.TimeoutsBuilder;
 import org.ehcache.clustered.common.internal.ServerStoreConfiguration;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityMessage;
 import org.ehcache.clustered.common.internal.messages.EhcacheEntityResponse;
@@ -52,7 +53,8 @@ public class SimpleClusterTierClientEntityTest {
   @Test
   public void testFireWithInit() throws Exception {
     MockEndpointBuilder eb = new MockEndpointBuilder();
-    SimpleClusterTierClientEntity entity = new SimpleClusterTierClientEntity(eb.mockEndpoint);
+    SimpleClusterTierClientEntity entity = new SimpleClusterTierClientEntity(eb.mockEndpoint,
+      TimeoutsBuilder.timeouts().build(), "store1");
     AtomicBoolean responseRcvd = new AtomicBoolean(false);
     entity.addResponseListener(MockedEntityResponse.class, response -> responseRcvd.set(true));
     entity.validate(mock(ServerStoreConfiguration.class));
@@ -63,7 +65,8 @@ public class SimpleClusterTierClientEntityTest {
   @Test
   public void testFireWithDelayedInit() throws Exception {
     MockEndpointBuilder eb = new MockEndpointBuilder();
-    SimpleClusterTierClientEntity entity = new SimpleClusterTierClientEntity(eb.mockEndpoint);
+    SimpleClusterTierClientEntity entity = new SimpleClusterTierClientEntity(eb.mockEndpoint,
+      TimeoutsBuilder.timeouts().build(), "store1");
     AtomicBoolean responseRcvd = new AtomicBoolean(false);
     entity.addResponseListener(MockedEntityResponse.class, response -> responseRcvd.set(true));
     CountDownLatch beforeLatch = new CountDownLatch(1);


### PR DESCRIPTION
By making timeouts final, it is also ensured that any out of band request (such as clientinvalidatehash) coming from the server the moment the client connects will always see correct timeouts and store identifier.