### PR TITLE
Use an expiration strategy depending on expiration policy

### DIFF
--- a/core/src/main/java/org/ehcache/core/spi/store/AbstractValueHolder.java
+++ b/core/src/main/java/org/ehcache/core/spi/store/AbstractValueHolder.java
@@ -63,7 +63,7 @@ public abstract class AbstractValueHolder<V> implements Store.ValueHolder<V> {
   public void setExpirationTime(long expirationTime, TimeUnit unit) {
     if (expirationTime == NO_EXPIRE) {
       updateExpirationTime(NO_EXPIRE);
-    } else if (expirationTime <= 0) {
+    } else if (expirationTime < 0) {
       throw new IllegalArgumentException("invalid expiration time: " + expirationTime);
     } else {
       updateExpirationTime(nativeTimeUnit().convert(expirationTime, unit));

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -290,7 +290,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         return null;
       }
 
-      strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, mapping, timeSource.getTimeMillis());
+      strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(key, mapping, timeSource.getTimeMillis());
 
       getObserver.end(StoreOperationOutcomes.GetOutcome.HIT);
       return mapping;
@@ -456,7 +456,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           entryActuallyAdded.set(holder != null);
         } else {
           returnValue.set(mappedValue);
-          holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          holder = strategy.setAccessAndExpiryWhenCallerlUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             delta -= mappedValue.size();
           }
@@ -508,7 +508,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           return null;
         } else {
           outcome.set(RemoveStatus.KEY_PRESENT);
-          OnHeapValueHolder<V> holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          OnHeapValueHolder<V> holder = strategy.setAccessAndExpiryWhenCallerlUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             updateUsageInBytesIfRequired(- mappedValue.size());
           }
@@ -612,7 +612,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           return holder;
         } else {
           outcome.set(ReplaceStatus.MISS_PRESENT);
-          OnHeapValueHolder<V> holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          OnHeapValueHolder<V> holder = strategy.setAccessAndExpiryWhenCallerlUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             updateUsageInBytesIfRequired(- mappedValue.size());
           }
@@ -708,7 +708,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           }
         }
         else {
-          strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, cachedValue, now);
+          strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(key, cachedValue, now);
         }
       }
 
@@ -1168,7 +1168,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           }
           holder = null;
         } else if (Objects.equals(existingValue, computedValue) && !replaceEqual.get() && mappedValue != null) {
-          holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          holder = strategy.setAccessAndExpiryWhenCallerlUnderLock(key, mappedValue, now, eventSink);
           outcome.set(StoreOperationOutcomes.ComputeOutcome.HIT);
           if (holder == null) {
             valueHeld.set(mappedValue);
@@ -1253,7 +1253,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         } else {
           previousValue.set(mappedValue);
           outcome.set(StoreOperationOutcomes.ComputeIfAbsentOutcome.HIT);
-          holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          holder = strategy.setAccessAndExpiryWhenCallerlUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             delta -= mappedValue.size();
           }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -149,6 +149,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
   private final Copier<V> valueCopier;
 
   private final SizeOfEngine sizeOfEngine;
+  private final OnHeapStrategy<K, V> strategy;
 
   private volatile long capacity;
   private final EvictionAdvisor<? super K, ? super V> evictionAdvisor;
@@ -236,6 +237,8 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
       this.map = new KeyCopyBackend<>(byteSized, keyCopier, castBackend(backingMapSupplier));
     }
 
+    strategy = OnHeapStrategy.strategy(this, expiry, timeSource);
+
     getObserver = createObserver("get", StoreOperationOutcomes.GetOutcome.class, true);
     putObserver = createObserver("put", StoreOperationOutcomes.PutOutcome.class, true);
     removeObserver = createObserver("remove", StoreOperationOutcomes.RemoveOutcome.class, true);
@@ -287,7 +290,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         return null;
       }
 
-      setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, mapping, timeSource.getTimeMillis());
+      strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, mapping, timeSource.getTimeMillis());
 
       getObserver.end(StoreOperationOutcomes.GetOutcome.HIT);
       return mapping;
@@ -303,7 +306,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         return null;
       }
 
-      if (mapping.isExpired(timeSource.getTimeMillis(), TimeUnit.MILLISECONDS)) {
+      if (strategy.isExpired(mapping)) {
         expireMappingUnderLock(key, mapping);
         return null;
       }
@@ -453,7 +456,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           entryActuallyAdded.set(holder != null);
         } else {
           returnValue.set(mappedValue);
-          holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             delta -= mappedValue.size();
           }
@@ -505,7 +508,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           return null;
         } else {
           outcome.set(RemoveStatus.KEY_PRESENT);
-          OnHeapValueHolder<V> holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          OnHeapValueHolder<V> holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             updateUsageInBytesIfRequired(- mappedValue.size());
           }
@@ -609,7 +612,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           return holder;
         } else {
           outcome.set(ReplaceStatus.MISS_PRESENT);
-          OnHeapValueHolder<V> holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          OnHeapValueHolder<V> holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             updateUsageInBytesIfRequired(- mappedValue.size());
           }
@@ -705,7 +708,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           }
         }
         else {
-          setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, cachedValue, now);
+          strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(key, cachedValue, now);
         }
       }
 
@@ -1165,7 +1168,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
           }
           holder = null;
         } else if (Objects.equals(existingValue, computedValue) && !replaceEqual.get() && mappedValue != null) {
-          holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
           outcome.set(StoreOperationOutcomes.ComputeOutcome.HIT);
           if (holder == null) {
             valueHeld.set(mappedValue);
@@ -1250,7 +1253,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         } else {
           previousValue.set(mappedValue);
           outcome.set(StoreOperationOutcomes.ComputeIfAbsentOutcome.HIT);
-          holder = setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
+          holder = strategy.setAccessTimeAndExpiryThenReturnMappingUnderLock(key, mappedValue, now, eventSink);
           if (holder == null) {
             delta -= mappedValue.size();
           }
@@ -1352,45 +1355,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
     return storeEventDispatcher;
   }
 
-  private void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
-    Duration duration;
-    try {
-      duration = expiry.getExpiryForAccess(key, valueHolder);
-      if (duration != null && duration.isNegative()) {
-        duration = Duration.ZERO;
-      }
-    } catch (RuntimeException re) {
-      LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
-      duration = Duration.ZERO;
-    }
-    valueHolder.accessed(now, duration);
-    if (Duration.ZERO.equals(duration)) {
-      // Expires mapping through computeIfPresent
-      expireMappingUnderLock(key, valueHolder);
-    }
-  }
-
-  private OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
-                                                                       StoreEventSink<K, V> eventSink) {
-    Duration duration = Duration.ZERO;
-    try {
-      duration = expiry.getExpiryForAccess(key, valueHolder);
-      if (duration != null && duration.isNegative()) {
-        duration = Duration.ZERO;
-      }
-    } catch (RuntimeException re) {
-      LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
-    }
-    valueHolder.accessed(now, duration);
-    if (Duration.ZERO.equals(duration)) {
-      // Fires event, must happen under lock
-      fireOnExpirationEvent(key, valueHolder, eventSink);
-      return null;
-    }
-    return valueHolder;
-  }
-
-  private void expireMappingUnderLock(K key, ValueHolder<V> value) {
+  void expireMappingUnderLock(K key, ValueHolder<V> value) {
 
     StoreEventSink<K, V> eventSink = storeEventDispatcher.eventSink();
     try {
@@ -1616,7 +1581,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
     }
   }
 
-  private void fireOnExpirationEvent(K mappedKey, ValueHolder<V> mappedValue, StoreEventSink<K, V> eventSink) {
+  void fireOnExpirationEvent(K mappedKey, ValueHolder<V> mappedValue, StoreEventSink<K, V> eventSink) {
     expirationObserver.begin();
     expirationObserver.end(StoreOperationOutcomes.ExpirationOutcome.SUCCESS);
     eventSink.expired(mappedKey, mappedValue);

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStrategy.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStrategy.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.heap;
+
+import org.ehcache.core.events.StoreEventSink;
+import org.ehcache.core.spi.time.TimeSource;
+import org.ehcache.expiry.ExpiryPolicy;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Henri Tremblay
+ */
+interface OnHeapStrategy<K, V> {
+
+  Logger LOG = LoggerFactory.getLogger(OnHeapStore.class);
+
+  static <K, V> OnHeapStrategy<K, V> strategy(OnHeapStore<K, V> store, ExpiryPolicy<? super K, ? super V> expiry, TimeSource timeSource) {
+    if(expiry == ExpiryPolicy.NO_EXPIRY) {
+      LOG.debug("No expiration strategy detected");
+      return new NoExpirationStrategy<>();
+    }
+    if(expiry.getClass().getName().equals("org.ehcache.config.builders.ExpiryPolicyBuilder$TimeToLiveExpiryPolicy")) {
+      LOG.debug("TTL expiration strategy detected");
+      return new TTLStrategy<>(timeSource);
+    }
+    LOG.debug("TTI or custom expiration strategy detected");
+    return new AllStrategy<>(store, expiry, timeSource);
+  }
+
+  boolean isExpired(OnHeapValueHolder<V> mapping);
+
+  void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now);
+
+  OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now, StoreEventSink<K, V> eventSink);
+
+  class AllStrategy<K, V> implements OnHeapStrategy<K, V> {
+    private final OnHeapStore<K, V> store;
+    private final ExpiryPolicy<? super K, ? super V> expiry;
+    private final TimeSource timeSource;
+
+    public AllStrategy(OnHeapStore<K, V> store, ExpiryPolicy<? super K, ? super V> expiry, TimeSource timeSource) {
+      this.store = store;
+      this.expiry = expiry;
+      this.timeSource = timeSource;
+    }
+
+    @Override
+    public boolean isExpired(OnHeapValueHolder<V> mapping) {
+      return mapping.isExpired(timeSource.getTimeMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
+      Duration duration = getAccessDuration(key, valueHolder);
+      if (Duration.ZERO.equals(duration)) {
+        // Expires mapping through computeIfPresent
+        store.expireMappingUnderLock(key, valueHolder);
+      } else {
+        valueHolder.accessed(now, duration);
+      }
+    }
+
+    private Duration getAccessDuration(K key, OnHeapValueHolder<V> valueHolder) {
+      Duration duration;
+      try {
+        duration = expiry.getExpiryForAccess(key, valueHolder);
+        if (duration != null && duration.isNegative()) {
+          duration = Duration.ZERO;
+        }
+      } catch (RuntimeException re) {
+        LOG.error("Expiry computation caused an exception - Expiry duration will be 0 ", re);
+        duration = Duration.ZERO;
+      }
+      return duration;
+    }
+
+    public OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
+                                                                                  StoreEventSink<K, V> eventSink) {
+      Duration duration = getAccessDuration(key, valueHolder);
+      if (Duration.ZERO.equals(duration)) {
+        // Fires event, must happen under lock
+        store.fireOnExpirationEvent(key, valueHolder, eventSink);
+        return null;
+      } else {
+        valueHolder.accessed(now, duration);
+      }
+      return valueHolder;
+    }
+
+  }
+
+  class NoExpirationStrategy<K, V> implements OnHeapStrategy<K, V> {
+
+    @Override
+    public boolean isExpired(OnHeapValueHolder<V> mapping) {
+      return false;
+    }
+
+    @Override
+    public void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
+      valueHolder.accessed(now, null);
+    }
+
+    public OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
+                                                                                 StoreEventSink<K, V> eventSink) {
+      valueHolder.accessed(now, null);
+      return valueHolder;
+    }
+  }
+
+  class TTLStrategy<K, V> implements OnHeapStrategy<K, V> {
+    private final TimeSource timeSource;
+
+    public TTLStrategy(TimeSource timeSource) {
+      this.timeSource = timeSource;
+    }
+
+    @Override
+    public boolean isExpired(OnHeapValueHolder<V> mapping) {
+      return mapping.isExpired(timeSource.getTimeMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
+      valueHolder.accessed(now, null);
+    }
+
+    public OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
+                                                                                 StoreEventSink<K, V> eventSink) {
+      valueHolder.accessed(now, null);
+      return valueHolder;
+    }
+  }
+
+}

--- a/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStrategy.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStrategy.java
@@ -60,26 +60,26 @@ interface OnHeapStrategy<K, V> {
   boolean isExpired(OnHeapValueHolder<V> mapping);
 
   /**
-   * Set the access time on the mapping and its expiry time if it is access sensitive (TTI). This action is thread-safe
-   * and doesn't require looking.
+   * Set the access time on the mapping and its expiry time if it is access sensitive (TTI). We  expect this action to
+   * be called when the caller isn't holding any lock.
    *
    * @param key key of the mapping. Used to remove it form the map if needed
    * @param valueHolder the mapping
    * @param now the current time
    */
-  void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now);
+  void setAccessAndExpiryTimeWhenCallerOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now);
 
   /**
-   * Set the access time on the mapping and its expiry time if it is access sensitive (TTI). This action is thread-safe
-   * but is requiring a global lock to perform the removal of the entry from the store.
+   * Set the access time on the mapping and its expiry time if it is access sensitive (TTI). We  expect this action to
+   * be called when the caller is currently holding a lock.
    *
    * @param key key of the mapping. Used to remove it form the map if needed
    * @param valueHolder the mapping
    * @param now the current time
-   * @param eventSink sink when the expiration request will be sent to do it under lock
+   * @param eventSink sink where the expiration request will be sent
    * @return the mapping or null if it was removed
    */
-  OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now, StoreEventSink<K, V> eventSink);
+  OnHeapValueHolder<V> setAccessAndExpiryWhenCallerlUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now, StoreEventSink<K, V> eventSink);
 
   /**
    * Get the new expiry duration as per {@link ExpiryPolicy#getExpiryForAccess(Object, Supplier)}.
@@ -123,7 +123,7 @@ interface OnHeapStrategy<K, V> {
     }
 
     @Override
-    public void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
+    public void setAccessAndExpiryTimeWhenCallerOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
       Duration duration = getAccessDuration(key, valueHolder);
       if (Duration.ZERO.equals(duration)) {
         // Expires mapping through computeIfPresent
@@ -161,8 +161,8 @@ interface OnHeapStrategy<K, V> {
       return duration;
     }
 
-    public OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
-                                                                                  StoreEventSink<K, V> eventSink) {
+    public OnHeapValueHolder<V> setAccessAndExpiryWhenCallerlUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
+                                                                       StoreEventSink<K, V> eventSink) {
       Duration duration = getAccessDuration(key, valueHolder);
       if (Duration.ZERO.equals(duration)) {
         // Fires event, must happen under lock
@@ -190,12 +190,12 @@ interface OnHeapStrategy<K, V> {
     }
 
     @Override
-    public void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
+    public void setAccessAndExpiryTimeWhenCallerOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
       valueHolder.accessed(now, null);
     }
 
-    public OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
-                                                                                 StoreEventSink<K, V> eventSink) {
+    public OnHeapValueHolder<V> setAccessAndExpiryWhenCallerlUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
+                                                                       StoreEventSink<K, V> eventSink) {
       valueHolder.accessed(now, null);
       return valueHolder;
     }
@@ -230,12 +230,12 @@ interface OnHeapStrategy<K, V> {
     }
 
     @Override
-    public void setAccessTimeAndExpiryThenReturnMappingOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
+    public void setAccessAndExpiryTimeWhenCallerOutsideLock(K key, OnHeapValueHolder<V> valueHolder, long now) {
       valueHolder.accessed(now, null);
     }
 
-    public OnHeapValueHolder<V> setAccessTimeAndExpiryThenReturnMappingUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
-                                                                                 StoreEventSink<K, V> eventSink) {
+    public OnHeapValueHolder<V> setAccessAndExpiryWhenCallerlUnderLock(K key, OnHeapValueHolder<V> valueHolder, long now,
+                                                                       StoreEventSink<K, V> eventSink) {
       valueHolder.accessed(now, null);
       return valueHolder;
     }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStrategyTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStrategyTest.java
@@ -109,7 +109,7 @@ public class OnHeapStrategyTest {
     TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
     when(policy.getExpiryForAccess(1, mapping)).thenReturn(null);
 
-    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+    strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(1, mapping, timeSource.getTimeMillis());
 
     assertThat(mapping.expiration).isNull();
     assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
@@ -124,7 +124,7 @@ public class OnHeapStrategyTest {
     TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
     when(policy.getExpiryForAccess(1, mapping)).thenReturn(Duration.ZERO);
 
-    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+    strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(1, mapping, timeSource.getTimeMillis());
 
     verify(store).expireMappingUnderLock(1, mapping);
   }
@@ -136,7 +136,7 @@ public class OnHeapStrategyTest {
     TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
     when(policy.getExpiryForAccess(1, mapping)).thenReturn(ExpiryPolicy.INFINITE);
 
-    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+    strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(1, mapping, timeSource.getTimeMillis());
 
     assertThat(mapping.expiration).isEqualTo(ExpiryPolicy.INFINITE);
     assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
@@ -151,7 +151,7 @@ public class OnHeapStrategyTest {
     TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
     when(policy.getExpiryForAccess(1, mapping)).thenReturn(Duration.ofMillis(20));
 
-    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+    strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(1, mapping, timeSource.getTimeMillis());
 
     assertThat(mapping.expiration).isEqualTo(Duration.ofMillis(20));
     assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
@@ -160,7 +160,7 @@ public class OnHeapStrategyTest {
 
     timeSource.advanceTime(30);
 
-    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+    strategy.setAccessAndExpiryTimeWhenCallerOutsideLock(1, mapping, timeSource.getTimeMillis());
 
     assertThat(mapping.expiration).isEqualTo(Duration.ofMillis(20));
     assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());

--- a/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStrategyTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStrategyTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.heap;
+
+import org.ehcache.expiry.ExpiryPolicy;
+import org.ehcache.impl.internal.store.heap.holders.OnHeapValueHolder;
+import org.ehcache.internal.TestTimeSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Henri Tremblay
+ */
+public class OnHeapStrategyTest {
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock
+  private OnHeapStore<Integer, String> store;
+
+  @Mock
+  private ExpiryPolicy<Integer, String> policy;
+
+  private OnHeapStrategy<Integer, String> strategy;
+
+  private static class TestOnHeapValueHolder extends OnHeapValueHolder<String> {
+
+    long now;
+    Duration expiration;
+
+    protected TestOnHeapValueHolder(long expirationTime) {
+      super(1, 0, expirationTime, true);
+    }
+
+    @Override
+    public String get() {
+      return "test";
+    }
+
+    @Override
+    public void accessed(long now, Duration expiration) {
+      this.now = now;
+      this.expiration = expiration;
+      super.accessed(now, expiration);
+    }
+  }
+
+  private TestTimeSource timeSource = new TestTimeSource();
+
+  @Test
+  public void isExpired_10seconds() {
+    strategy = OnHeapStrategy.strategy(store, policy, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    assertThat(strategy.isExpired(mapping)).isFalse();
+    timeSource.advanceTime(10);
+    assertThat(strategy.isExpired(mapping)).isTrue();
+  }
+
+  @Test
+  public void isExpired_TTL10seconds() {
+    strategy = OnHeapStrategy.strategy(store, policy, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    assertThat(strategy.isExpired(mapping)).isFalse();
+    timeSource.advanceTime(10);
+    assertThat(strategy.isExpired(mapping)).isTrue();
+  }
+
+  @Test
+  public void isExpired_neverExpires() {
+    strategy = OnHeapStrategy.strategy(store, ExpiryPolicy.NO_EXPIRY, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    assertThat(strategy.isExpired(mapping)).isFalse();
+    timeSource.advanceTime(10);
+    assertThat(strategy.isExpired(mapping)).isFalse();
+  }
+
+  @Test
+  public void setAccessTimeAndExpiryThenReturnMappingOutsideLock_nullExpiryForAccess() {
+    strategy = OnHeapStrategy.strategy(store, ExpiryPolicy.NO_EXPIRY, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    when(policy.getExpiryForAccess(1, mapping)).thenReturn(null);
+
+    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+
+    assertThat(mapping.expiration).isNull();
+    assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
+
+    verifyZeroInteractions(store);
+  }
+
+  @Test
+  public void setAccessTimeAndExpiryThenReturnMappingOutsideLock_zeroExpiryOnAccess() {
+    strategy = OnHeapStrategy.strategy(store, policy, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    when(policy.getExpiryForAccess(1, mapping)).thenReturn(Duration.ZERO);
+
+    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+
+    verify(store).expireMappingUnderLock(1, mapping);
+  }
+
+  @Test
+  public void setAccessTimeAndExpiryThenReturnMappingOutsideLock_infiniteExpiryOnAccess() {
+    strategy = OnHeapStrategy.strategy(store, policy, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    when(policy.getExpiryForAccess(1, mapping)).thenReturn(ExpiryPolicy.INFINITE);
+
+    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+
+    assertThat(mapping.expiration).isEqualTo(ExpiryPolicy.INFINITE);
+    assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
+
+    verifyZeroInteractions(store);
+  }
+
+  @Test
+  public void setAccessTimeAndExpiryThenReturnMappingOutsideLock_movingTime() {
+    strategy = OnHeapStrategy.strategy(store, policy, timeSource);
+
+    TestOnHeapValueHolder mapping = new TestOnHeapValueHolder(10);
+    when(policy.getExpiryForAccess(1, mapping)).thenReturn(Duration.ofMillis(20));
+
+    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+
+    assertThat(mapping.expiration).isEqualTo(Duration.ofMillis(20));
+    assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
+
+    verifyZeroInteractions(store);
+
+    timeSource.advanceTime(30);
+
+    strategy.setAccessTimeAndExpiryThenReturnMappingOutsideLock(1, mapping, timeSource.getTimeMillis());
+
+    assertThat(mapping.expiration).isEqualTo(Duration.ofMillis(20));
+    assertThat(mapping.now).isEqualTo(timeSource.getTimeMillis());
+
+    verifyZeroInteractions(store);
+  }
+}

--- a/integration-test/src/test/java/org/ehcache/integration/OnHeapEvictionStrategyTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/OnHeapEvictionStrategyTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.integration;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.expiry.ExpiryPolicy;
+import org.ehcache.impl.internal.TimeSourceConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Henri Tremblay
+ */
+public class OnHeapEvictionStrategyTest {
+
+  private final TestTimeSource timeSource = new TestTimeSource();
+  private final TimeSourceConfiguration timeSourceConfiguration = new TimeSourceConfiguration(timeSource);
+
+  private CacheManager cacheManager;
+
+  @Before
+  public void before() {
+    cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
+      .using(timeSourceConfiguration)
+      .build(true);
+  }
+
+  @After
+  public void after() {
+    cacheManager.close();
+  }
+
+  @Test
+  public void noExpiryGet() {
+    Cache<Integer, String> cache = createCache(ExpiryPolicyBuilder.noExpiration());
+
+    cache.put(1, "a");
+
+    timeSource.setTimeMillis(Long.MAX_VALUE);
+
+    assertThat(cache.get(1)).isEqualTo("a");
+  }
+
+  @Test
+  public void ttlExpiryGet() {
+    Cache<Integer, String> cache = createCache(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMillis(100)));
+
+    cache.put(1, "a");
+
+    assertThat(cache.get(1)).isEqualTo("a");
+
+    timeSource.setTimeMillis(100);
+
+    assertThat(cache.get(1)).isNull();
+  }
+
+  @Test
+  public void ttiExpiryGet() {
+    Cache<Integer, String> cache = createCache(ExpiryPolicyBuilder.timeToIdleExpiration(Duration.ofMillis(100)));
+
+    cache.put(1, "a");
+
+    assertThat(cache.get(1)).isEqualTo("a");
+
+    timeSource.setTimeMillis(100);
+
+    assertThat(cache.get(1)).isNull();
+  }
+
+  @Test
+  public void customExpiryGet() {
+    Cache<Integer, String> cache = createCache(
+      ExpiryPolicyBuilder.expiry()
+    .create(ExpiryPolicy.INFINITE)
+    .update(Duration.ofMillis(100))
+    .access(null)
+    .build());
+
+    cache.put(1, "a");
+
+    assertThat(cache.get(1)).isEqualTo("a");
+
+    cache.put(1, "b");
+
+    timeSource.setTimeMillis(100);
+
+    assertThat(cache.get(1)).isNull();
+  }
+
+  @Test
+  public void noExpiryPut() {
+    Cache<Integer, String> cache = createCache(ExpiryPolicyBuilder.noExpiration());
+
+    cache.put(1, "a");
+
+    timeSource.setTimeMillis(Long.MAX_VALUE);
+
+    assertThat(cache.putIfAbsent(1, "b")).isEqualTo("a");
+  }
+
+  @Test
+  public void ttlExpiryPut() {
+    Cache<Integer, String> cache = createCache(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofMillis(100)));
+
+    cache.put(1, "a");
+
+    assertThat(cache.putIfAbsent(1, "b")).isEqualTo("a");
+
+    timeSource.setTimeMillis(100);
+
+    assertThat(cache.putIfAbsent(1, "c")).isNull();
+  }
+
+  @Test
+  public void ttiExpiryPut() {
+    Cache<Integer, String> cache = createCache(ExpiryPolicyBuilder.timeToIdleExpiration(Duration.ofMillis(100)));
+
+    cache.put(1, "a");
+
+    assertThat(cache.putIfAbsent(1, "b")).isEqualTo("a");
+
+    timeSource.setTimeMillis(100);
+
+    assertThat(cache.putIfAbsent(1, "c")).isNull();
+  }
+
+  @Test
+  public void customExpiryPut() {
+    Cache<Integer, String> cache = createCache(
+      ExpiryPolicyBuilder.expiry()
+        .create(ExpiryPolicy.INFINITE)
+        .update(Duration.ofMillis(100))
+        .access(null)
+        .build());
+
+    cache.put(1, "a"); // create
+    cache.put(1, "b"); // update that will expire
+
+    timeSource.setTimeMillis(100);
+
+    assertThat(cache.putIfAbsent(1, "d")).isNull(); // expires since update
+  }
+
+  private Cache<Integer, String> createCache(ExpiryPolicy<? super Integer, ? super String> expiryPolicy) {
+    return cacheManager.createCache("cache",
+      CacheConfigurationBuilder.newCacheConfigurationBuilder(Integer.class, String.class,
+        ResourcePoolsBuilder.heap(10))
+        .withExpiry(expiryPolicy));
+  }
+}

--- a/integration-test/src/test/java/org/ehcache/integration/OnHeapEvictionStrategyTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/OnHeapEvictionStrategyTest.java
@@ -97,7 +97,7 @@ public class OnHeapEvictionStrategyTest {
       ExpiryPolicyBuilder.expiry()
     .create(ExpiryPolicy.INFINITE)
     .update(Duration.ofMillis(100))
-    .access(null)
+    .access((Duration) null)
     .build());
 
     cache.put(1, "a");
@@ -154,7 +154,7 @@ public class OnHeapEvictionStrategyTest {
       ExpiryPolicyBuilder.expiry()
         .create(ExpiryPolicy.INFINITE)
         .update(Duration.ofMillis(100))
-        .access(null)
+        .access((Duration) null)
         .build());
 
     cache.put(1, "a"); // create


### PR DESCRIPTION
This gives about 5% performance gain when no expiration is set and the SystemTimeSource is used. To get better, some further work is required on the `OnHeapValueHolder`.