### PR TITLE
Make sure that all projects are using the statistic version from parent

### DIFF
--- a/clustered/integration-test/build.gradle
+++ b/clustered/integration-test/build.gradle
@@ -29,8 +29,13 @@ dependencies {
   testCompileOnly "org.terracotta:lease-api:$terracottaPlatformVersion"
 
   testImplementation project(':management')
-  testImplementation "org.terracotta.management.dist:mnm-nms:$terracottaPlatformVersion"
-  testImplementation "org.terracotta.management.dist:mnm-nms-agent:$terracottaPlatformVersion"
+  testImplementation("org.terracotta.management.dist:mnm-nms:$terracottaPlatformVersion") {
+    exclude group: 'org.terracotta', module: 'statistics'
+  }
+  testImplementation("org.terracotta.management.dist:mnm-nms-agent:$terracottaPlatformVersion") {
+    exclude group: 'org.terracotta', module: 'statistics'
+  }
+  testImplementation "org.terracotta:statistics:$parent.statisticVersion"
   testImplementation "com.fasterxml.jackson.core:jackson-databind:2.8.0"
   testRuntimeOnly project(':clustered:clustered-dist')
   testRuntimeOnly project(':dist')

--- a/clustered/server/build.gradle
+++ b/clustered/server/build.gradle
@@ -27,7 +27,11 @@ dependencies {
   implementation ("org.terracotta.management:monitoring-service-api:$terracottaPlatformVersion") {
     transitive = false
   }
-  implementation "org.terracotta.management.dist:mnm-common:$terracottaPlatformVersion"
+  implementation ("org.terracotta.management.dist:mnm-common:$terracottaPlatformVersion") {
+    exclude group: 'org.terracotta', module: 'statistics'
+  }
+  implementation "org.terracotta:statistics:$parent.statisticVersion"
+
   providedImplementation "org.terracotta:entity-server-api:$terracottaApisVersion"
   providedImplementation "org.terracotta:standard-cluster-services:$terracottaApisVersion"
   providedImplementation "org.terracotta:runnel:$terracottaPlatformVersion"

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -23,12 +23,17 @@ dependencies {
   // optional: if we want to use the clustered management layer
   compileOnly project(':clustered:client')
   compileOnly "org.terracotta:entity-client-api:$terracottaApisVersion"
-  compileOnly "org.terracotta.management.dist:mnm-nms-agent:$terracottaPlatformVersion"
+  compileOnly("org.terracotta.management.dist:mnm-nms-agent:$terracottaPlatformVersion") {
+    exclude group: 'org.terracotta', module: 'statistics'
+  }
+  implementation "org.terracotta:statistics:$parent.statisticVersion"
 
   compileOnly project(':api')
   compileOnly project(':core')
   compileOnly project(':impl')
-  testImplementation "org.terracotta.management:management-registry:$terracottaPlatformVersion"
+  testImplementation("org.terracotta.management:management-registry:$terracottaPlatformVersion") {
+    exclude group: 'org.terracotta', module: 'statistics'
+  }
   testImplementation project(':xml')
   testImplementation project(':impl')
   testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"


### PR DESCRIPTION
Basically, when the terracotta-statistics version is changed in gradle.properties, the project should compile directly. Right now it fails on tons of dependency conflicts. This PR solves that by ignoring and adding an explicit dependency at the right place.