### PR TITLE
Use final releases of tc modules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,10 @@ slf4jVersion = 1.7.25
 sizeofVersion = 0.3.0
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.5.0-pre12
-terracottaApisVersion = 1.5.0-pre4
-terracottaCoreVersion = 5.5.0-pre11
-terracottaPassthroughTestingVersion = 1.5.0-pre4
+terracottaPlatformVersion = 5.5.0
+terracottaApisVersion = 1.5.0
+terracottaCoreVersion = 5.5.0
+terracottaPassthroughTestingVersion = 1.5.0
 
 # Test lib versions
 junitVersion = 4.12


### PR DESCRIPTION
In the context of https://github.com/ehcache/ehcache3/issues/2468 , use final versions of terracotta modules , on top of internal25, aka commit 173d990d859b0b3ac98255d826662a510d8eae0f