### PR TITLE
Ability to autoconfigure Ehcache

### DIFF
--- a/api/src/main/java/org/ehcache/spi/service/ServiceCreationConfigurationProvider.java
+++ b/api/src/main/java/org/ehcache/spi/service/ServiceCreationConfigurationProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.spi.service;
+
+import java.util.function.Supplier;
+
+/**
+ * Implementations can be discovered in the classpath and be called to load additional
+ * configuration for services, in case they have not already been added programmatically
+ * or through XML configuration.
+ */
+public interface ServiceCreationConfigurationProvider<T extends Service> extends Supplier<ServiceCreationConfiguration<T>> {
+
+  /**
+   * Indicates which service will consume the configuration at creation.
+   *
+   * @return the service type
+   */
+  Class<T> getServiceType();
+
+}

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
@@ -140,10 +140,6 @@ public abstract class AbstractClusteringManagementTest extends ClusteredTests {
         .defaultServerResource("primary-server-resource")
         .resourcePool("resource-pool-a", 10, MemoryUnit.MB, "secondary-server-resource") // <2>
         .resourcePool("resource-pool-b", 8, MemoryUnit.MB)) // will take from primary-server-resource
-      // management config
-      .using(new DefaultManagementRegistryConfiguration()
-        .addTags("webapp-1", "server-node-1")
-        .setCacheManagerAlias("my-super-cache-manager"))
       // cache config
       .withCache("dedicated-cache-1", newCacheConfigurationBuilder(
         String.class, String.class,

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ManagementActivator.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ManagementActivator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2018 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
+ * Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG.
+ */
+package org.ehcache.clustered.management;
+
+import org.ehcache.management.ManagementRegistryService;
+import org.ehcache.management.registry.DefaultManagementRegistryConfiguration;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.ehcache.spi.service.ServiceCreationConfigurationProvider;
+
+/**
+ * Activates management automatically if no config has been previously set manually or through XML.
+ *
+ * @author Mathieu Carbou
+ */
+public class ManagementActivator implements ServiceCreationConfigurationProvider<ManagementRegistryService> {
+  @Override
+  public Class<ManagementRegistryService> getServiceType() {
+    return ManagementRegistryService.class;
+  }
+
+  @Override
+  public ServiceCreationConfiguration<ManagementRegistryService> get() {
+    return new DefaultManagementRegistryConfiguration()
+      .addTags("webapp-1", "server-node-1")
+      .setCacheManagerAlias("my-super-cache-manager");
+  }
+
+}

--- a/clustered/integration-test/src/test/resources/META-INF/services/org.ehcache.spi.service.ServiceCreationConfigurationProvider
+++ b/clustered/integration-test/src/test/resources/META-INF/services/org.ehcache.spi.service.ServiceCreationConfigurationProvider
@@ -1,0 +1,1 @@
+org.ehcache.clustered.management.ManagementActivator

--- a/clustered/integration-test/src/test/resources/simpleConfiguration.txt
+++ b/clustered/integration-test/src/test/resources/simpleConfiguration.txt
@@ -21,3 +21,5 @@ caches:
 services:
     - org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration:
         rootDirectory: build/tmp/EhcacheManagerToStringTest
+    -org.ehcache.management.registry.DefaultManagementRegistryConfiguration
+


### PR DESCRIPTION
We have the requirement to be able to automatically configure a management registry in some case.

So this PR is to add the ability to provide within the classpath a configuration provider that would be discovered and add configs if they are not already there through programmatic or xml config.

This PR is not complete:
- I'll send an email for more details and use case
- If this solution is good, we have to decide where to put the provider interface and depending on this what we document