### PR TITLE
TDB-4221 Enhance log message for ClusteredStatisticsCountTest.countTest

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/AbstractClusteringManagementTest.java
@@ -321,6 +321,7 @@ public abstract class AbstractClusteringManagementTest extends ClusteredTests {
   public static void waitForAllNotifications(String... notificationTypes) throws InterruptedException {
     List<String> waitingFor = new ArrayList<>(Arrays.asList(notificationTypes));
     List<ContextualNotification> missingOnes = new ArrayList<>();
+    List<ContextualNotification> existingOnes = new ArrayList<>();
 
     // please keep these sout because it is really hard to troubleshoot blocking tests in the beforeClass method in the case we do not receive all notifs.
 //    System.out.println("waitForAllNotifications: " + waitingFor);
@@ -331,6 +332,7 @@ public abstract class AbstractClusteringManagementTest extends ClusteredTests {
           if (message.getType().equals("NOTIFICATION")) {
             for (ContextualNotification notification : message.unwrap(ContextualNotification.class)) {
               if (waitingFor.remove(notification.getType())) {
+                existingOnes.add(notification);
 //                System.out.println("Remove " + notification.getType());
 //                System.out.println("Still waiting for: " + waitingFor);
               } else {
@@ -348,7 +350,7 @@ public abstract class AbstractClusteringManagementTest extends ClusteredTests {
     t.join(30_000); // should be way enough to receive all messages
     t.interrupt(); // we interrupt the thread that is waiting on the message queue
 
-    assertTrue("Still waiting for: " + waitingFor, waitingFor.isEmpty());
-    assertTrue("Unexpected notification: " + missingOnes, missingOnes.isEmpty());
+    assertTrue("Still waiting for: " + waitingFor + ", only got: " + existingOnes, waitingFor.isEmpty());
+    assertTrue("Unexpected notification: " + missingOnes + ", only got: " + existingOnes, missingOnes.isEmpty());
   }
 }


### PR DESCRIPTION
The test failure in TDB-4221 may be transient, but we are enhancing the log message, so that next time it would be easier to debug.