### PR TITLE
[DO NOT MERGE] Offheap Iterator Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ subprojects {
   checkstyle {
     configFile = file("$rootDir/config/checkstyle.xml")
     configProperties = ['projectDir':projectDir, 'rootDir':rootDir]
-    toolVersion = '5.7'
+    toolVersion = '5.9'
   }
 
   findbugs {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ import scripts.*
 
 ext {
   baseVersion = '3.0.0-SNAPSHOT'
-  offheapVersion = '2.2.1'
+  offheapVersion = '2.4.2'
   managementVersion = '2.2.0'
   statisticVersion = '1.1.0'
   jcacheVersion = '1.0.0'
@@ -47,8 +47,8 @@ subprojects {
 
   archivesBaseName = "ehcache-${project.name}"
 
-  sourceCompatibility = 1.6
-  targetCompatibility = 1.6
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
 
   repositories {
     mavenCentral()

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCache.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCache.java
@@ -58,7 +58,7 @@ public class EhcachePersistentConcurrentOffHeapClockCache<K, V> extends Abstract
 
   @Override
   public V compute(K key, final BiFunction<K, V, V> mappingFunction, final boolean pin) {
-    MetadataTuple<V> result = computeWithMetadata(key, new org.terracotta.offheapstore.jdk8.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
+    MetadataTuple<V> result = computeWithMetadata(key, new java.util.function.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
       @Override
       public MetadataTuple<V> apply(K k, MetadataTuple<V> current) {
         V oldValue = current == null ? null : current.value();
@@ -78,7 +78,7 @@ public class EhcachePersistentConcurrentOffHeapClockCache<K, V> extends Abstract
 
   @Override
   public V computeIfPresent(K key, final BiFunction<K, V, V> mappingFunction) {
-    MetadataTuple<V> result = computeIfPresentWithMetadata(key, new org.terracotta.offheapstore.jdk8.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
+    MetadataTuple<V> result = computeIfPresentWithMetadata(key, new java.util.function.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
       @Override
       public MetadataTuple<V> apply(K k, MetadataTuple<V> current) {
         V oldValue = current.value();
@@ -105,7 +105,7 @@ public class EhcachePersistentConcurrentOffHeapClockCache<K, V> extends Abstract
   @Override
   public boolean computeIfPinned(final K key, final BiFunction<K,V,V> remappingFunction, final Function<V,Boolean> unpinFunction) {
     final AtomicBoolean unpin = new AtomicBoolean();
-    computeIfPresentWithMetadata(key, new org.terracotta.offheapstore.jdk8.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
+    computeIfPresentWithMetadata(key, new java.util.function.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
       @Override
       public MetadataTuple<V> apply(K k, MetadataTuple<V> current) {
         if ((current.metadata() & Metadata.PINNED) != 0) {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStore.java
@@ -74,8 +74,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.lang.Long.max;
 import static org.ehcache.core.spi.ServiceLocator.findSingletonAmongst;
 import static org.ehcache.core.spi.ServiceLocator.findSingletonAmongst;
+import static org.terracotta.offheapstore.util.MemoryUnit.BYTES;
 
 /**
  *
@@ -171,7 +173,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
         DiskWriteThreadPool writeWorkers = new DiskWriteThreadPool(executionService, threadPoolAlias, writerConcurrency);
 
         Factory<FileBackedStorageEngine<K, OffHeapValueHolder<V>>> storageEngineFactory = FileBackedStorageEngine.createFactory(source,
-                keyPortability, elementPortability, writeWorkers, false);
+            max((size / 16) / 10, 1024), BYTES, keyPortability, elementPortability, writeWorkers, false);
 
         EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>> factory = new EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>>(
             source,
@@ -212,7 +214,7 @@ public class OffHeapDiskStore<K, V> extends AbstractOffHeapStore<K, V> implement
     DiskWriteThreadPool writeWorkers = new DiskWriteThreadPool(executionService, threadPoolAlias, writerConcurrency);
 
     Factory<FileBackedStorageEngine<K, OffHeapValueHolder<V>>> storageEngineFactory = FileBackedStorageEngine.createFactory(source,
-        keyPortability, elementPortability, writeWorkers, true);
+        max((size / 16) / 10, 1024), BYTES, keyPortability, elementPortability, writeWorkers, true);
 
     EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>> factory = new EhcachePersistentSegmentFactory<K, OffHeapValueHolder<V>>(
         source,

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -406,6 +406,7 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
           }
           return null;
         } else {
+          mappedValue.forceDeserialization();
           returnValue.set(mappedValue);
           return newUpdatedValueHolder(mappedKey, value, mappedValue, now, eventSink);
         }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStore.java
@@ -37,6 +37,7 @@ import org.ehcache.expiry.Expiry;
 import org.ehcache.function.BiFunction;
 import org.ehcache.function.Function;
 import org.ehcache.function.NullaryFunction;
+import org.ehcache.impl.internal.store.offheap.portability.OffHeapValueHolderPortability;
 import org.ehcache.core.spi.time.TimeSource;
 import org.ehcache.impl.internal.store.offheap.factories.EhcacheSegmentFactory;
 import org.ehcache.core.spi.cache.Store;
@@ -47,6 +48,7 @@ import org.ehcache.core.spi.cache.tiering.LowerCachingTier;
 import org.ehcache.core.statistics.AuthoritativeTierOperationOutcomes;
 import org.ehcache.core.statistics.LowerCachingTierOperationsOutcome;
 import org.ehcache.core.statistics.StoreOperationOutcomes;
+import org.ehcache.spi.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.offheapstore.Segment;
@@ -1227,6 +1229,10 @@ public abstract class AbstractOffHeapStore<K, V> implements AuthoritativeTier<K,
 
   protected static <K, V> EvictionVeto<K, OffHeapValueHolder<V>> wrap(EvictionVeto<? super K, ? super V> delegate) {
     return new OffHeapEvictionVetoWrapper<K, V>(delegate);
+  }
+
+  protected OffHeapValueHolderPortability<V> createValuePortability(Serializer<V> serializer) {
+    return new OffHeapValueHolderPortability<>(serializer);
   }
 
   private static class OffHeapEvictionVetoWrapper<K, V> implements EvictionVeto<K, OffHeapValueHolder<V>> {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/EhcacheConcurrentOffHeapClockCache.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/EhcacheConcurrentOffHeapClockCache.java
@@ -53,7 +53,7 @@ public class EhcacheConcurrentOffHeapClockCache<K, V> extends AbstractConcurrent
 
   @Override
   public V compute(K key, final BiFunction<K, V, V> mappingFunction, final boolean pin) {
-    MetadataTuple<V> result = computeWithMetadata(key, new org.terracotta.offheapstore.jdk8.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
+    MetadataTuple<V> result = computeWithMetadata(key, new java.util.function.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
       @Override
       public MetadataTuple<V> apply(K k, MetadataTuple<V> current) {
         V oldValue = current == null ? null : current.value();
@@ -73,7 +73,7 @@ public class EhcacheConcurrentOffHeapClockCache<K, V> extends AbstractConcurrent
 
   @Override
   public V computeIfPresent(K key, final BiFunction<K, V, V> mappingFunction) {
-    MetadataTuple<V> result = computeIfPresentWithMetadata(key, new org.terracotta.offheapstore.jdk8.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
+    MetadataTuple<V> result = computeIfPresentWithMetadata(key, new java.util.function.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
       @Override
       public MetadataTuple<V> apply(K k, MetadataTuple<V> current) {
         V oldValue = current.value();
@@ -100,7 +100,7 @@ public class EhcacheConcurrentOffHeapClockCache<K, V> extends AbstractConcurrent
   @Override
   public boolean computeIfPinned(final K key, final BiFunction<K,V,V> remappingFunction, final Function<V,Boolean> unpinFunction) {
     final AtomicBoolean unpin = new AtomicBoolean();
-    computeIfPresentWithMetadata(key, new org.terracotta.offheapstore.jdk8.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
+    computeIfPresentWithMetadata(key, new java.util.function.BiFunction<K, MetadataTuple<V>, MetadataTuple<V>>() {
       @Override
       public MetadataTuple<V> apply(K k, MetadataTuple<V> current) {
         if ((current.metadata() & Metadata.PINNED) != 0) {

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapStore.java
@@ -91,9 +91,9 @@ public class OffHeapStore<K, V> extends AbstractOffHeapStore<K, V> {
     HeuristicConfiguration config = new HeuristicConfiguration(size);
     PageSource source = new UpfrontAllocatingPageSource(getBufferSource(), config.getMaximumSize(), config.getMaximumChunkSize(), config.getMinimumChunkSize());
     Portability<K> keyPortability = new SerializerPortability<K>(keySerializer);
-    Portability<OffHeapValueHolder<V>> elementPortability = new OffHeapValueHolderPortability<V>(valueSerializer);
+    Portability<OffHeapValueHolder<V>> valuePortability = createValuePortability(valueSerializer);
     Factory<OffHeapBufferStorageEngine<K, OffHeapValueHolder<V>>> storageEngineFactory = OffHeapBufferStorageEngine.createFactory(PointerSize.INT, source, config
-        .getSegmentDataPageSize(), keyPortability, elementPortability, false, true);
+        .getSegmentDataPageSize(), keyPortability, valuePortability, false, true);
 
     Factory<? extends PinnableSegment<K, OffHeapValueHolder<V>>> segmentFactory = new EhcacheSegmentFactory<K, OffHeapValueHolder<V>>(
                                                                                                          source,

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapValueHolder.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/OffHeapValueHolder.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 * OffHeapValueHolder
 */
 @FindbugsSuppressWarnings("SE_NO_SERIALVERSIONID")
-public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> implements BinaryValueHolder {
+public class OffHeapValueHolder<V> extends AbstractValueHolder<V> implements BinaryValueHolder {
 
   public static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
@@ -124,16 +124,20 @@ public final class OffHeapValueHolder<V> extends AbstractValueHolder<V> implemen
 
   void forceDeserialization() {
     if (value == null && mode != Mode.VALUE) {
-      try {
-        value = valueSerializer.read(binaryValue.duplicate());
-      } catch (ClassNotFoundException e) {
-        throw new SerializerException(e);
-      } finally {
-        if (mode == Mode.BINARY) {
-          binaryValue = null;
-          valueSerializer = null;
-          mode = Mode.VALUE;
-        }
+      value = deserialize();
+    }
+  }
+
+  V deserialize() {
+    try {
+      return valueSerializer.read(binaryValue.duplicate());
+    } catch (ClassNotFoundException e) {
+      throw new SerializerException(e);
+    } finally {
+      if (mode == Mode.BINARY) {
+        binaryValue = null;
+        valueSerializer = null;
+        mode = Mode.VALUE;
       }
     }
   }

--- a/impl/src/main/java/org/ehcache/impl/internal/store/offheap/portability/OffHeapValueHolderPortability.java
+++ b/impl/src/main/java/org/ehcache/impl/internal/store/offheap/portability/OffHeapValueHolderPortability.java
@@ -73,7 +73,10 @@ public class OffHeapValueHolderPortability<V> implements WriteBackPortability<Of
     long lastAccessTime = byteBuffer.getLong();
     long expireTime = byteBuffer.getLong();
     long hits = byteBuffer.getLong();
-    OffHeapValueHolder<V> valueHolder = new OffHeapValueHolder<V>(id, byteBuffer.slice(), serializer, creationTime, expireTime, lastAccessTime, hits, writeContext);
-    return valueHolder;
+    return createLazyOffHeapValueHolder(id, byteBuffer.slice(), serializer, creationTime, expireTime, lastAccessTime, hits, writeContext);
+  }
+
+  protected OffHeapValueHolder<V> createLazyOffHeapValueHolder(long id, ByteBuffer byteBuffer, Serializer<V> serializer, long creationTime, long expireTime, long lastAccessTime, long hits, WriteContext writeContext) {
+    return new OffHeapValueHolder<V>(id, byteBuffer.slice(), serializer, creationTime, expireTime, lastAccessTime, hits, writeContext);
   }
 }

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCacheTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/EhcachePersistentConcurrentOffHeapClockCacheTest.java
@@ -40,6 +40,7 @@ import static org.ehcache.impl.internal.store.disk.OffHeapDiskStore.persistent;
 import static org.ehcache.impl.internal.spi.TestServiceProvider.providerContaining;
 import org.ehcache.impl.internal.store.disk.factories.EhcachePersistentSegmentFactory;
 import static org.mockito.Mockito.mock;
+import static org.terracotta.offheapstore.util.MemoryUnit.BYTES;
 
 public class EhcachePersistentConcurrentOffHeapClockCacheTest extends AbstractEhcacheOffHeapBackingMapTest {
 
@@ -66,7 +67,7 @@ public class EhcachePersistentConcurrentOffHeapClockCacheTest extends AbstractEh
       Serializer<String> valueSerializer = serializationProvider.createValueSerializer(String.class, EhcachePersistentConcurrentOffHeapClockCacheTest.class.getClassLoader());
       PersistentPortability<String> keyPortability = persistent(new SerializerPortability<String>(keySerializer));
       PersistentPortability<String> elementPortability = persistent(new SerializerPortability<String>(valueSerializer));
-      Factory<FileBackedStorageEngine<String, String>> storageEngineFactory = FileBackedStorageEngine.createFactory(pageSource, keyPortability, elementPortability);
+      Factory<FileBackedStorageEngine<String, String>> storageEngineFactory = FileBackedStorageEngine.createFactory(pageSource, configuration.getMaximumSize() / 10, BYTES, keyPortability, elementPortability);
       EhcachePersistentSegmentFactory<String, String> segmentFactory = new EhcachePersistentSegmentFactory<String, String>(pageSource, storageEngineFactory, 0, evictionPredicate, evictionListener, true);
       return new EhcachePersistentConcurrentOffHeapClockCache<String, String>(evictionPredicate, segmentFactory, 1);
     } catch (UnsupportedTypeException e) {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/OffHeapDiskStoreTest.java
@@ -23,6 +23,8 @@ import org.ehcache.config.units.MemoryUnit;
 import org.ehcache.exceptions.CacheAccessException;
 import org.ehcache.exceptions.CachePersistenceException;
 import org.ehcache.expiry.Expiry;
+import org.ehcache.impl.internal.store.offheap.portability.AssertingOffHeapValueHolderPortability;
+import org.ehcache.impl.internal.store.offheap.portability.OffHeapValueHolderPortability;
 import org.ehcache.impl.internal.events.TestStoreEventDispatcher;
 import org.ehcache.impl.internal.executor.OnDemandExecutionService;
 import org.ehcache.impl.internal.persistence.TestLocalPersistenceService;
@@ -88,7 +90,12 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
               new OnDemandExecutionService(), null, 1,
               storeConfiguration, timeSource,
               new TestStoreEventDispatcher<String, String>(),
-              MemoryUnit.MB.toBytes(1));
+              MemoryUnit.MB.toBytes(1)) {
+        @Override
+        protected OffHeapValueHolderPortability<String> createValuePortability(Serializer<String> serializer) {
+          return new AssertingOffHeapValueHolderPortability<>(serializer);
+        }
+      };
       OffHeapDiskStore.Provider.init(offHeapStore);
       return offHeapStore;
     } catch (UnsupportedTypeException e) {
@@ -111,7 +118,12 @@ public class OffHeapDiskStoreTest extends AbstractOffHeapStoreTest {
               new OnDemandExecutionService(), null, 1,
               storeConfiguration, timeSource,
               new TestStoreEventDispatcher<String, byte[]>(),
-              MemoryUnit.MB.toBytes(1));
+              MemoryUnit.MB.toBytes(1)) {
+        @Override
+        protected OffHeapValueHolderPortability<byte[]> createValuePortability(Serializer<byte[]> serializer) {
+          return new AssertingOffHeapValueHolderPortability<>(serializer);
+        }
+      };
       OffHeapDiskStore.Provider.init(offHeapStore);
       return offHeapStore;
     } catch (UnsupportedTypeException e) {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/disk/factories/EhcachePersistentSegmentTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/disk/factories/EhcachePersistentSegmentTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.terracotta.offheapstore.util.MemoryUnit.BYTES;
 
 public class EhcachePersistentSegmentTest {
 
@@ -71,7 +72,7 @@ public class EhcachePersistentSegmentTest {
       Serializer<String> valueSerializer = serializationProvider.createValueSerializer(String.class, EhcachePersistentSegmentTest.class.getClassLoader());
       PersistentPortability<String> keyPortability = persistent(new SerializerPortability<String>(keySerializer));
       PersistentPortability<String> elementPortability = persistent(new SerializerPortability<String>(valueSerializer));
-      Factory<FileBackedStorageEngine<String, String>> storageEngineFactory = FileBackedStorageEngine.createFactory(pageSource, keyPortability, elementPortability);
+      Factory<FileBackedStorageEngine<String, String>> storageEngineFactory = FileBackedStorageEngine.createFactory(pageSource, configuration.getMaximumSize() / 10, BYTES, keyPortability, elementPortability);
       return new EhcachePersistentSegmentFactory.EhcachePersistentSegment<String, String>(pageSource, storageEngineFactory.newInstance(), 1, true, evictionPredicate, evictionListener);
     } catch (UnsupportedTypeException e) {
       throw new AssertionError(e);

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStoreTest.java
@@ -119,6 +119,7 @@ public abstract class AbstractOffHeapStoreTest {
       offHeapStore.setInvalidationListener(new CachingTier.InvalidationListener<String, String>() {
         @Override
         public void onInvalidation(String key, Store.ValueHolder<String> valueHolder) {
+          valueHolder.value();
           invalidated.set(valueHolder);
         }
       });
@@ -200,6 +201,7 @@ public abstract class AbstractOffHeapStoreTest {
       offHeapStore.setInvalidationListener(new CachingTier.InvalidationListener<String, String>() {
         @Override
         public void onInvalidation(String key, Store.ValueHolder<String> valueHolder) {
+          valueHolder.value();
           invalidated.set(valueHolder);
         }
       });
@@ -256,6 +258,7 @@ public abstract class AbstractOffHeapStoreTest {
       offHeapStore.setInvalidationListener(new CachingTier.InvalidationListener<String, String>() {
         @Override
         public void onInvalidation(String key, Store.ValueHolder<String> valueHolder) {
+          valueHolder.value();
           invalidated.set(valueHolder);
         }
       });

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AssertingOffHeapValueHolder.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AssertingOffHeapValueHolder.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.offheap;
+
+import org.ehcache.spi.serialization.Serializer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+import org.objectweb.asm.commons.Method;
+import org.terracotta.offheapstore.storage.portability.WriteContext;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Predicate;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.objectweb.asm.Opcodes.ASM5;
+import static org.objectweb.asm.Type.getObjectType;
+import static org.objectweb.asm.Type.getType;
+import static org.objectweb.asm.commons.Method.getMethod;
+
+public class AssertingOffHeapValueHolder<V> extends OffHeapValueHolder<V> {
+
+  /**
+   * This is a set of 'patterns' that capture a subset of the lock scopes that the `OffHeapValueHolder` can be
+   * called from.  You might end up looking at these patterns for one of three reasons:
+   *
+   * 1. (Most Likely) You introduced new code or new testing that access a pre-existing lock scope that is not listed
+   *    here.  Find the lock scope in the stack trace of the thrown exception and add an appropriate stanza here.
+   * 2. (Less Likely) You introduced a new call path that leaks a still serialized, attached value holder that someone
+   *    else tried to access later (outside lock scope).  In this case you must locate the source of the value holder
+   *    and either force deserialization or detach the value under the pre-existing lock scope.
+   * 3. (Least Likely) You introduced a new method to OffHeapStore that needs locking properly.
+   */
+  private static final Collection<Predicate<StackTraceElement>> LOCK_SCOPES = asList(
+    className("org.terracotta.offheapstore.AbstractLockedOffHeapHashMap").methodName("shrink"),
+    className("org.terracotta.offheapstore.AbstractLockedOffHeapHashMap").methodName("computeWithMetadata"),
+    className("org.terracotta.offheapstore.AbstractLockedOffHeapHashMap").methodName("computeIfPresentWithMetadata"),
+    className("org.ehcache.impl.internal.store.offheap.factories.EhcacheSegmentFactory$EhcacheSegment").methodName("computeIfPresentAndPin"),
+    className("org.ehcache.impl.internal.store.disk.factories.EhcachePersistentSegmentFactory$EhcachePersistentSegment").methodName("computeIfPresentAndPin"),
+    className("org.ehcache.impl.internal.store.offheap.factories.EhcacheSegmentFactory$EhcacheSegment$EntrySet").methodName("iterator"),
+    className("org.ehcache.impl.internal.store.disk.factories.EhcachePersistentSegmentFactory$EhcachePersistentSegment$EntrySet").methodName("iterator"),
+    className("org.terracotta.offheapstore.AbstractLockedOffHeapHashMap$LockedEntryIterator").methodName("next")
+  );
+
+  private static void assertStackTraceContainsLockScope() {
+    assertThat(stream(Thread.currentThread().getStackTrace()).filter(ste -> LOCK_SCOPES.stream().anyMatch(p -> p.test(ste))).anyMatch(ste -> isLockedInFrame(ste)), is(true));
+  }
+
+  private static StePredicateBuilderOne className(String className) {
+    return new StePredicateBuilderOne() {
+      @Override
+      public Predicate<StackTraceElement> methodName(String methodName) {
+        StePredicateBuilderOne outer = this;
+        return ste -> outer.test(ste) && methodName.equals(ste.getMethodName());
+      }
+
+      @Override
+      public boolean test(StackTraceElement ste) {
+        return className.equals(ste.getClassName());
+      }
+    };
+  }
+
+  interface StePredicateBuilderOne extends Predicate<StackTraceElement> {
+
+    Predicate<StackTraceElement> methodName(String computeIfPresentWithMetadata);
+  }
+
+  public AssertingOffHeapValueHolder(long id, ByteBuffer binaryValue, Serializer<V> serializer, long creationTime, long expireTime, long lastAccessTime, long hits, WriteContext writeContext) {
+    super(id, binaryValue, serializer, creationTime, expireTime, lastAccessTime, hits, writeContext);
+  }
+
+  @Override
+  void writeBack() {
+    assertStackTraceContainsLockScope();
+    super.writeBack();
+  }
+
+  @Override
+  V deserialize() {
+    assertStackTraceContainsLockScope();
+    return super.deserialize();
+  }
+
+  @Override
+  void prepareForDelayedDeserialization() {
+    assertStackTraceContainsLockScope();
+    super.prepareForDelayedDeserialization();
+  }
+
+  private static final Type LOCK_CLASS;
+  private static final Method LOCK_METHOD;
+  private static final Method UNLOCK_METHOD;
+
+  static {
+    try {
+      LOCK_CLASS = getType(Lock.class);
+      LOCK_METHOD = getMethod(Lock.class.getMethod("lock"));
+      UNLOCK_METHOD = getMethod(Lock.class.getMethod("unlock"));
+    } catch (NoSuchMethodException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static boolean isLockedInFrame(StackTraceElement ste) {
+    try {
+      ClassReader reader = new ClassReader(ste.getClassName());
+
+      NavigableMap<Integer, Integer> lockLevels = new TreeMap<>();
+
+      reader.accept(new ClassVisitor(ASM5) {
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+          if (ste.getMethodName().equals(name)) {
+            return new InstructionAdapter(ASM5, new MethodVisitor(ASM5) {}) {
+
+              private final Map<Label, Integer> levels = new HashMap<>();
+
+              private int lockLevel;
+
+              @Override
+              public void invokeinterface(String owner, String name, String descriptor) {
+                if (LOCK_CLASS.equals(getObjectType(owner))) {
+                  if (LOCK_METHOD.equals(new Method(name, descriptor))) {
+                    lockLevel++;
+                  } else if (UNLOCK_METHOD.equals(new Method(name, descriptor))) {
+                    lockLevel--;
+                  }
+                }
+              }
+
+              @Override
+              public void visitJumpInsn(int opcode, Label label) {
+                levels.merge(label, lockLevel, Integer::max);
+              }
+
+              @Override
+              public void visitLabel(Label label) {
+                lockLevel = levels.merge(label, lockLevel, Integer::max);
+              }
+
+              @Override
+              public void visitLineNumber(int line, Label start) {
+                lockLevels.merge(line, levels.get(start), Integer::max);
+              }
+            };
+          } else {
+            return null;
+          }
+        }
+      }, 0);
+
+      Map.Entry<Integer, Integer> entry = lockLevels.floorEntry(ste.getLineNumber());
+
+      return entry.getValue() > 0;
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AssertingOffHeapValueHolderTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/AssertingOffHeapValueHolderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.offheap;
+
+import org.ehcache.spi.serialization.Serializer;
+import org.junit.Test;
+import org.terracotta.offheapstore.storage.portability.WriteContext;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public class AssertingOffHeapValueHolderTest {
+
+  @Test @SuppressWarnings("unchecked")
+  public void testLockingAssertionsOnPrepareForDelayedDeserialization() {
+    OffHeapValueHolder<String> valueHolder = new AssertingOffHeapValueHolder<>(1L, ByteBuffer.allocate(1), mock(Serializer.class), 10L, 20L, 15L, 0L, mock(WriteContext.class));
+    try {
+      valueHolder.prepareForDelayedDeserialization();
+      fail("Expected AssertionError");
+    } catch (AssertionError e) {
+      //expected
+    }
+  }
+
+  @Test @SuppressWarnings("unchecked")
+  public void testLockingAssertionsOnForceDeserialize() {
+    OffHeapValueHolder<String> valueHolder = new AssertingOffHeapValueHolder<>(1L, ByteBuffer.allocate(1), mock(Serializer.class), 10L, 20L, 15L, 0L, mock(WriteContext.class));
+    try {
+      valueHolder.forceDeserialization();
+      fail("Expected AssertionError");
+    } catch (AssertionError e) {
+      //expected
+    }
+  }
+
+  @Test @SuppressWarnings("unchecked")
+  public void testLockingAssertionsOnWriteBack() {
+    OffHeapValueHolder<String> valueHolder = new AssertingOffHeapValueHolder<>(1L, ByteBuffer.allocate(1), mock(Serializer.class), 10L, 20L, 15L, 0L, mock(WriteContext.class));
+    try {
+      valueHolder.writeBack();
+      fail("Expected AssertionError");
+    } catch (AssertionError e) {
+      //expected
+    }
+  }
+}

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreTest.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/OffHeapStoreTest.java
@@ -23,6 +23,8 @@ import org.ehcache.expiry.Expiry;
 import org.ehcache.impl.internal.events.TestStoreEventDispatcher;
 import org.ehcache.impl.internal.spi.serialization.DefaultSerializationProvider;
 import org.ehcache.core.spi.time.TimeSource;
+import org.ehcache.impl.internal.store.offheap.portability.AssertingOffHeapValueHolderPortability;
+import org.ehcache.impl.internal.store.offheap.portability.OffHeapValueHolderPortability;
 import org.ehcache.spi.serialization.SerializationProvider;
 import org.ehcache.spi.serialization.Serializer;
 import org.ehcache.spi.serialization.UnsupportedTypeException;
@@ -41,7 +43,12 @@ public class OffHeapStoreTest extends AbstractOffHeapStoreTest {
       Serializer<String> valueSerializer = serializationProvider.createValueSerializer(String.class, classLoader);
       StoreConfigurationImpl<String, String> storeConfiguration = new StoreConfigurationImpl<String, String>(String.class, String.class,
           null, classLoader, expiry, null, 0, keySerializer, valueSerializer);
-      OffHeapStore<String, String> offHeapStore = new OffHeapStore<String, String>(storeConfiguration, timeSource, new TestStoreEventDispatcher<String, String>(), MemoryUnit.MB.toBytes(1));
+      OffHeapStore<String, String> offHeapStore = new OffHeapStore<String, String>(storeConfiguration, timeSource, new TestStoreEventDispatcher<String, String>(), MemoryUnit.MB.toBytes(1)) {
+        @Override
+        protected OffHeapValueHolderPortability<String> createValuePortability(Serializer<String> serializer) {
+          return new AssertingOffHeapValueHolderPortability<>(serializer);
+        }
+      };
       OffHeapStore.Provider.init(offHeapStore);
       return offHeapStore;
     } catch (UnsupportedTypeException e) {
@@ -59,7 +66,12 @@ public class OffHeapStoreTest extends AbstractOffHeapStoreTest {
       Serializer<byte[]> valueSerializer = serializationProvider.createValueSerializer(byte[].class, classLoader);
       StoreConfigurationImpl<String, byte[]> storeConfiguration = new StoreConfigurationImpl<String, byte[]>(String.class, byte[].class,
           evictionVeto, getClass().getClassLoader(), expiry, null, 0, keySerializer, valueSerializer);
-      OffHeapStore<String, byte[]> offHeapStore = new OffHeapStore<String, byte[]>(storeConfiguration, timeSource, new TestStoreEventDispatcher<String, byte[]>(),MemoryUnit.MB.toBytes(1));
+      OffHeapStore<String, byte[]> offHeapStore = new OffHeapStore<String, byte[]>(storeConfiguration, timeSource, new TestStoreEventDispatcher<String, byte[]>(),MemoryUnit.MB.toBytes(1)) {
+        @Override
+        protected OffHeapValueHolderPortability<byte[]> createValuePortability(Serializer<byte[]> serializer) {
+          return new AssertingOffHeapValueHolderPortability<>(serializer);
+        }
+      };
       OffHeapStore.Provider.init(offHeapStore);
       return offHeapStore;
     } catch (UnsupportedTypeException e) {

--- a/impl/src/test/java/org/ehcache/impl/internal/store/offheap/portability/AssertingOffHeapValueHolderPortability.java
+++ b/impl/src/test/java/org/ehcache/impl/internal/store/offheap/portability/AssertingOffHeapValueHolderPortability.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.impl.internal.store.offheap.portability;
+
+import org.ehcache.impl.internal.store.offheap.AssertingOffHeapValueHolder;
+import org.ehcache.impl.internal.store.offheap.OffHeapValueHolder;
+import org.ehcache.spi.serialization.Serializer;
+import org.terracotta.offheapstore.storage.portability.WriteContext;
+
+import java.nio.ByteBuffer;
+
+public class AssertingOffHeapValueHolderPortability<V> extends OffHeapValueHolderPortability<V> {
+
+  public AssertingOffHeapValueHolderPortability(Serializer<V> serializer) {
+    super(serializer);
+  }
+
+  @Override
+  protected OffHeapValueHolder<V> createLazyOffHeapValueHolder(long id, ByteBuffer byteBuffer, Serializer<V> serializer, long creationTime, long expireTime, long lastAccessTime, long hits, WriteContext writeContext) {
+    return new AssertingOffHeapValueHolder<>(id, byteBuffer, serializer, creationTime, expireTime, lastAccessTime, hits, writeContext);
+  }
+}


### PR DESCRIPTION
This is the 'proper' fix for the offheap iterator issues around buffer deserialization and detachment.  ~~Right now I've somewhat cleaned the actual 'test' code I used to identify all the unlocked paths. As I see it we have a number of options regarding the test coverage here:~~

~~1. Commit the bug fixes with no test coverage (get rid of the second commit)~~
~~2. Commit the bug fixes with the test code commented out.~~
~~3. Commit the bug fixes and test code as they are in this PR.~~
4. Add additional testing seams to the offheap code to allow injection of a subclass of the `LazyOffheapValueHolder` in enough of the tests to provide coverage.

Edit: So I did the *right* thing and added proper testing coverage.