### PR TITLE
Fixes #2345 : Allow Java Language style syntax for arrays, primitives and inner classes

### DIFF
--- a/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
@@ -26,14 +26,20 @@ import org.ehcache.spi.service.ServiceCreationConfiguration;
 import org.ehcache.xml.exceptions.XmlConfigurationException;
 import org.w3c.dom.Document;
 
+import java.lang.reflect.Array;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
+import static java.lang.Class.forName;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static org.ehcache.xml.ConfigurationParser.documentToText;
+import static org.ehcache.xml.XmlConfiguration.PrettyClassFormat.when;
 
 /**
  * Exposes {@link org.ehcache.config.Configuration} and {@link CacheConfigurationBuilder} expressed
@@ -335,10 +341,6 @@ public class XmlConfiguration implements Configuration {
     return newCacheConfigurationBuilderFromTemplate(name, keyType, valueType, resourcePoolsBuilder.build());
   }
 
-  public static Class<?> getClassForName(String name, ClassLoader classLoader) throws ClassNotFoundException {
-    return Class.forName(name, true, classLoader);
-  }
-
   @Override
   public Map<String, CacheConfiguration<?, ?>> getCacheConfigurations() {
     return configuration.getCacheConfigurations();
@@ -357,4 +359,75 @@ public class XmlConfiguration implements Configuration {
   public interface Template {
     <K, V> CacheConfigurationBuilder<K,V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resourcePools) throws ClassNotFoundException, InstantiationException, IllegalAccessException;
   }
+
+  public static Class<?> getClassForName(String name, ClassLoader classLoader) throws ClassNotFoundException {
+    return PRETTY_FORMATS.stream().filter(p -> p.applies().test(name)).findFirst().map(PrettyClassFormat::lookup).orElseThrow(AssertionError::new).lookup(name, classLoader);
+  }
+
+  private static final List<PrettyClassFormat> PRETTY_FORMATS = asList(
+    //Primitive Types
+    when("boolean"::equals).then((n, l) -> Boolean.TYPE),
+    when("byte"::equals).then((n, l) -> Byte.TYPE),
+    when("short"::equals).then((n, l) -> Short.TYPE),
+    when("int"::equals).then((n, l) -> Integer.TYPE),
+    when("long"::equals).then((n, l) -> Long.TYPE),
+    when("char"::equals).then((n, l) -> Character.TYPE),
+    when("float"::equals).then((n, l) -> Float.TYPE),
+    when("double"::equals).then((n, l) -> Double.TYPE),
+
+    //Java Language Array Syntax
+    when(n -> n.endsWith("[]")).then((n, l) -> {
+      String component = n.split("(\\[\\])+$", 2)[0];
+      int dimensions = (n.length() - component.length()) >> 1;
+      return Array.newInstance(getClassForName(component, l), new int[dimensions]).getClass();
+    }),
+
+    //Inner Classes
+    when(n -> n.contains(".")).then((n, l) -> {
+      try {
+        return forName(n, false, l);
+      } catch (ClassNotFoundException e) {
+        int innerSeperator = n.lastIndexOf(".");
+        if (innerSeperator == -1) {
+          throw e;
+        } else {
+          return forName(n.substring(0, innerSeperator) + "$" + n.substring(innerSeperator + 1), false, l);
+        }
+      }
+    }),
+
+    //Everything Else
+    when(n -> true).then((n, l) -> forName(n, false, l))
+  );
+
+  interface PrettyClassFormat {
+
+    static Builder when(Predicate<String> predicate) {
+      return lookup -> new PrettyClassFormat() {
+        @Override
+        public Predicate<String> applies() {
+          return predicate;
+        }
+
+        @Override
+        public Lookup lookup() {
+          return lookup;
+        }
+      };
+    }
+
+    Predicate<String> applies();
+
+    Lookup lookup();
+
+    interface Builder {
+      PrettyClassFormat then(Lookup lookup);
+    }
+  }
+
+  private interface Lookup {
+
+    Class<?> lookup(String name, ClassLoader loader) throws ClassNotFoundException;
+  }
+
 }

--- a/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
+++ b/xml/src/test/java/org/ehcache/xml/XmlConfigurationTest.java
@@ -47,6 +47,7 @@ import org.ehcache.xml.exceptions.XmlConfigurationException;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
 import org.junit.Rule;
 import org.junit.Test;
@@ -92,6 +93,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.heap;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.ehcache.core.spi.service.ServiceUtils.findSingletonAmongst;
+import static org.ehcache.core.util.ClassLoading.getDefaultClassLoader;
+import static org.ehcache.xml.XmlConfiguration.getClassForName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -772,6 +775,79 @@ public class XmlConfigurationTest {
     Configuration config = new XmlConfiguration(resource);
     XmlConfiguration xmlConfig = new XmlConfiguration(config);
     assertThat(xmlConfig.toString(), isSimilarTo(resource).ignoreComments().ignoreWhitespace().withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
+  }
+
+  @Test
+  public void testPrettyTypeNames() {
+    URL resource = XmlConfigurationTest.class.getResource("/configs/pretty-typed-caches.xml");
+    Configuration config = new XmlConfiguration(new XmlConfiguration(resource));
+
+    CacheConfiguration<?, ?> byteArray = config.getCacheConfigurations().get("byte-array");
+    assertThat(byteArray.getValueType(), equalTo(byte[].class));
+
+    CacheConfiguration<?, ?> stringArray = config.getCacheConfigurations().get("string-array");
+    assertThat(stringArray.getValueType(), equalTo(String[].class));
+
+    CacheConfiguration<?, ?> string2dArray = config.getCacheConfigurations().get("string-2d-array");
+    assertThat(string2dArray.getValueType(), equalTo(String[][].class));
+
+    CacheConfiguration<?, ?> mapEntry = config.getCacheConfigurations().get("map-entry");
+    assertThat(mapEntry.getValueType(), equalTo(Map.Entry.class));
+  }
+
+  @Test
+  public void testPrimitiveNameConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("boolean", getDefaultClassLoader()), IsEqual.equalTo(Boolean.TYPE));
+    assertThat(getClassForName("byte", getDefaultClassLoader()), IsEqual.equalTo(Byte.TYPE));
+    assertThat(getClassForName("short", getDefaultClassLoader()), IsEqual.equalTo(Short.TYPE));
+    assertThat(getClassForName("int", getDefaultClassLoader()), IsEqual.equalTo(Integer.TYPE));
+    assertThat(getClassForName("long", getDefaultClassLoader()), IsEqual.equalTo(Long.TYPE));
+    assertThat(getClassForName("char", getDefaultClassLoader()), IsEqual.equalTo(Character.TYPE));
+    assertThat(getClassForName("float", getDefaultClassLoader()), IsEqual.equalTo(Float.TYPE));
+    assertThat(getClassForName("double", getDefaultClassLoader()), IsEqual.equalTo(Double.TYPE));
+  }
+
+  @Test
+  public void testPrimitiveArrayClassNameConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("boolean[]", getDefaultClassLoader()), IsEqual.equalTo(boolean[].class));
+    assertThat(getClassForName("byte[]", getDefaultClassLoader()), IsEqual.equalTo(byte[].class));
+    assertThat(getClassForName("short[]", getDefaultClassLoader()), IsEqual.equalTo(short[].class));
+    assertThat(getClassForName("int[]", getDefaultClassLoader()), IsEqual.equalTo(int[].class));
+    assertThat(getClassForName("long[]", getDefaultClassLoader()), IsEqual.equalTo(long[].class));
+    assertThat(getClassForName("char[]", getDefaultClassLoader()), IsEqual.equalTo(char[].class));
+    assertThat(getClassForName("float[]", getDefaultClassLoader()), IsEqual.equalTo(float[].class));
+    assertThat(getClassForName("double[]", getDefaultClassLoader()), IsEqual.equalTo(double[].class));
+  }
+
+  @Test
+  public void testMultiDimensionPrimitiveArrayClassNameConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("byte[][][][]", getDefaultClassLoader()), IsEqual.equalTo(byte[][][][].class));
+    assertThat(getClassForName("short[][][][]", getDefaultClassLoader()), IsEqual.equalTo(short[][][][].class));
+    assertThat(getClassForName("int[][][][]", getDefaultClassLoader()), IsEqual.equalTo(int[][][][].class));
+    assertThat(getClassForName("long[][][][]", getDefaultClassLoader()), IsEqual.equalTo(long[][][][].class));
+    assertThat(getClassForName("char[][][][]", getDefaultClassLoader()), IsEqual.equalTo(char[][][][].class));
+    assertThat(getClassForName("float[][][][]", getDefaultClassLoader()), IsEqual.equalTo(float[][][][].class));
+    assertThat(getClassForName("double[][][][]", getDefaultClassLoader()), IsEqual.equalTo(double[][][][].class));
+  }
+
+  @Test
+  public void testArrayClassNameConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("java.lang.String[]", getDefaultClassLoader()), IsEqual.equalTo(String[].class));
+  }
+
+  @Test
+  public void testMultiDimensionArrayClassNameConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("java.lang.String[][][][]", getDefaultClassLoader()), IsEqual.equalTo(String[][][][].class));
+  }
+
+  @Test
+  public void testInnerClassNameConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("java.util.Map.Entry", getDefaultClassLoader()), IsEqual.equalTo(Map.Entry.class));
+  }
+
+  @Test
+  public void testInnerClassNameArrayConversion() throws ClassNotFoundException {
+    assertThat(getClassForName("java.util.Map.Entry[]", getDefaultClassLoader()), IsEqual.equalTo(Map.Entry[].class));
   }
 
   private void checkListenerConfigurationExists(Collection<?> configuration) {

--- a/xml/src/test/resources/configs/pretty-typed-caches.xml
+++ b/xml/src/test/resources/configs/pretty-typed-caches.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ehcache:config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns:ehcache='http://www.ehcache.org/v3'
+  xsi:schemaLocation="http://www.ehcache.org/v3 ../../../main/resources/ehcache-core.xsd">
+
+  <ehcache:cache alias="byte-array">
+    <ehcache:key-type>java.lang.Integer</ehcache:key-type>
+    <ehcache:value-type>byte[]</ehcache:value-type>
+    <ehcache:heap>5</ehcache:heap>
+  </ehcache:cache>
+
+  <ehcache:cache alias="string-array">
+    <ehcache:key-type>java.lang.String</ehcache:key-type>
+    <ehcache:value-type>java.lang.String[]</ehcache:value-type>
+    <ehcache:heap>5</ehcache:heap>
+  </ehcache:cache>
+
+  <ehcache:cache alias="string-2d-array">
+    <ehcache:key-type>java.lang.String</ehcache:key-type>
+    <ehcache:value-type>java.lang.String[][]</ehcache:value-type>
+    <ehcache:heap>5</ehcache:heap>
+  </ehcache:cache>
+
+  <ehcache:cache alias="map-entry">
+    <ehcache:key-type>java.lang.String</ehcache:key-type>
+    <ehcache:value-type>java.util.Map.Entry</ehcache:value-type>
+    <ehcache:heap>5</ehcache:heap>
+  </ehcache:cache>
+</ehcache:config>


### PR DESCRIPTION
The only wrinkle that I can see with this is that we don't map back to the pretty class names when marshaling a configuration out to XML.