### PR TITLE
Upgrade to Asciidoctor Gradle Plugin 2.3.0

### DIFF
--- a/buildSrc/src/main/groovy/EhDocs.groovy
+++ b/buildSrc/src/main/groovy/EhDocs.groovy
@@ -60,9 +60,9 @@ class EhDocs implements Plugin<Project> {
 
     }
 
-    project.task('asciidocZip', type: Zip, dependsOn: ':docs:asciidoctor') {
+    project.task('asciidocZip', type: Zip, dependsOn: ':docs:userDoc') {
       classifier = 'docs'
-      from project.tasks.getByPath(':docs:asciidoctor').outputDir
+      from project.tasks.getByPath(':docs:userDoc').outputDir
     }
 
     project.artifacts {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -14,50 +14,55 @@
  * limitations under the License.
  */
 
+import org.asciidoctor.gradle.jvm.AsciidoctorJBasePlugin
+import org.asciidoctor.gradle.jvm.AsciidoctorTask
+
 plugins {
-  id 'org.asciidoctor.convert' version '1.6.0'
+  id 'org.asciidoctor.jvm.base' version '2.3.0'
   id 'org.kordamp.gradle.livereload' version '0.2.1'
-  id 'com.github.jruby-gradle.base' version '1.6.0'
 }
 
-dependencies {
-  gems 'rubygems:asciidoctor-diagram:1.5.15'
-}
-
-configurations.asciidoctor {
-  resolutionStrategy {
-    force 'com.github.jnr:jnr-enxio:0.19'
-    force 'com.github.jnr:jnr-posix:3.0.49'
-    force 'com.github.jnr:jnr-constants:0.9.12'
-  }
-}
-
-task copyCSS(type: Copy) {
-  from ('css') {
-    include '**'
-  }
-  into("${buildDir}/asciidoc/user/css")
-}
-
-asciidoctor.dependsOn copyCSS
-
-asciidoctor {
-  dependsOn jrubyPrepare
-  gemPath = jrubyPrepare.outputDir
-  requires = ['asciidoctor-diagram']
-  separateOutputDirs = false
+asciidoctorj {
+  safeMode 'UNSAFE'
   attributes 'skip-front-matter': 'true'
+  fatalWarnings ~/.*/
+  modules {
+    diagram.version '1.5.18'
+  }
+}
 
+def createCopyCssTask(def asciidocTask) {
+  return tasks.register("copy${asciidocTask.name}CSS", Copy) {
+    from ('css') {
+      include '**'
+    } into("${asciidocTask.outputDir}/css")
+  }
+}
+
+tasks.withType(AsciidoctorTask) {
+  group = AsciidoctorJBasePlugin.TASK_GROUP
   resources {
     from('fonts') {
       include '*'
-      into('./user/fonts')
-    }
+    } into('./fonts')
   }
+  dependsOn createCopyCssTask(it)
+}
+
+tasks.register('userDoc', AsciidoctorTask) {
+  description = 'Generate the user documentation'
+  sourceDir file('src/docs/asciidoc/user')
+  outputDir file("$buildDir/asciidoc/user")
+}
+
+tasks.register('developerDoc', AsciidoctorTask) {
+  description = 'Generate the developer documentation'
+  sourceDir file('src/docs/asciidoc/developer')
+  outputDir file("$buildDir/asciidoc/developer")
 }
 
 liveReload {
-  docRoot asciidoctor.outputDir.canonicalPath
+  docRoot userDoc.outputDir.canonicalPath
 }
 
 dependencyCheck {

--- a/docs/src/docs/asciidoc/developer/design.tiering.adoc
+++ b/docs/src/docs/asciidoc/developer/design.tiering.adoc
@@ -2,7 +2,7 @@
 
 :toc:
 
-The `Store` in Ehcache is designed to hold data in a tiered model. 
+The `Store` in Ehcache is designed to hold data in a tiered model.
 A cache will always have at least one tier, possible multiple.
 As soon as there are multiple tiers, they are immediately divided between a single `AuthoritativeTier` and one or more `CachingTier`.
 It is the `TieredStore` that wires the authority and caching tiers and provides a unified view of the `Store` for the Cache.
@@ -49,7 +49,7 @@ authority.
 
 [plantuml]
 ....
-include::../../uml/put.puml[]
+include::{includedir}/../../uml/put.puml[]
 ....
  * All writes directly go to the Authoritative tier.This tier has all the data such that caching tier always has a subset of authority
  * On return, the mapping in the caching tier is invalidated.
@@ -57,7 +57,7 @@ include::../../uml/put.puml[]
 
 [plantuml]
 ....
-include::../../uml/get.puml[]
+include::{includedir}/../../uml/get.puml[]
 ....
  * Any reading thread tries to get data from the caching tier and returns
  * If the key is not found in caching tier, it is faulted from authority

--- a/docs/src/docs/asciidoc/developer/module.clustering.adoc
+++ b/docs/src/docs/asciidoc/developer/module.clustering.adoc
@@ -68,5 +68,5 @@ _HA_?
 
 [plantuml]
 ....
-include::../../uml/putIfAbsentUml.puml[]
+include::{includedir}/../../uml/putIfAbsentUml.puml[]
 ....

--- a/docs/src/docs/asciidoc/user/.asciidoctorconfig
+++ b/docs/src/docs/asciidoc/user/.asciidoctorconfig
@@ -1,0 +1,3 @@
+
+:includedir: .
+:gradle-rootdir: ../../../../..

--- a/docs/src/docs/asciidoc/user/107.adoc
+++ b/docs/src/docs/asciidoc/user/107.adoc
@@ -2,11 +2,11 @@
 ---
 = The Ehcache 3.x JSR-107 Provider
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[overview]]

--- a/docs/src/docs/asciidoc/user/cache-event-listeners.adoc
+++ b/docs/src/docs/asciidoc/user/cache-event-listeners.adoc
@@ -2,11 +2,11 @@
 ---
 = Cache Event Listeners
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[introduction]]

--- a/docs/src/docs/asciidoc/user/caching-concepts.adoc
+++ b/docs/src/docs/asciidoc/user/caching-concepts.adoc
@@ -2,11 +2,11 @@
 ---
 = Concepts Related to Caching
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[data-freshness-and-expiration]]

--- a/docs/src/docs/asciidoc/user/caching-patterns.adoc
+++ b/docs/src/docs/asciidoc/user/caching-patterns.adoc
@@ -2,11 +2,11 @@
 ---
 = Cache Usage Patterns
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 There are several common access patterns when using a cache.

--- a/docs/src/docs/asciidoc/user/caching-terms.adoc
+++ b/docs/src/docs/asciidoc/user/caching-terms.adoc
@@ -2,11 +2,11 @@
 ---
 = Terms Related to Caching
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Basic Terms

--- a/docs/src/docs/asciidoc/user/class-loading.adoc
+++ b/docs/src/docs/asciidoc/user/class-loading.adoc
@@ -2,11 +2,11 @@
 ---
 = Class loading
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[about]]

--- a/docs/src/docs/asciidoc/user/clustered-cache.adoc
+++ b/docs/src/docs/asciidoc/user/clustered-cache.adoc
@@ -2,11 +2,11 @@
 ---
 = Clustered Cache
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Introduction

--- a/docs/src/docs/asciidoc/user/common.adoc
+++ b/docs/src/docs/asciidoc/user/common.adoc
@@ -11,7 +11,7 @@ ifdef::basebackend-html[:outfilesuffix: .html]
 :icons: font
 :iconfont-remote!:
 :iconfont-name: font-awesome.min
-:sourcedir38: ../../../../../
+:sourcedir38: {gradle-rootdir}
 :imagesdir: images
 :sectanchors:
 :idprefix:

--- a/docs/src/docs/asciidoc/user/config-derive.adoc
+++ b/docs/src/docs/asciidoc/user/config-derive.adoc
@@ -2,11 +2,11 @@
 ---
 = Configuration Derivation
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Principles

--- a/docs/src/docs/asciidoc/user/eviction-advisor.adoc
+++ b/docs/src/docs/asciidoc/user/eviction-advisor.adoc
@@ -2,11 +2,11 @@
 ---
 = Eviction Advisor
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 
 == Introduction
 

--- a/docs/src/docs/asciidoc/user/examples.adoc
+++ b/docs/src/docs/asciidoc/user/examples.adoc
@@ -2,11 +2,11 @@
 ---
 = Examples
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Peeper - a simple message board

--- a/docs/src/docs/asciidoc/user/expiry.adoc
+++ b/docs/src/docs/asciidoc/user/expiry.adoc
@@ -2,11 +2,11 @@
 ---
 = Expiry
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Introduction

--- a/docs/src/docs/asciidoc/user/getting-started.adoc
+++ b/docs/src/docs/asciidoc/user/getting-started.adoc
@@ -1,11 +1,11 @@
 = Ehcache 3.8 Documentation
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 We feel that the Ehcache 3.x API is a great improvement over the Ehcache 2.x API that has been used by millions of developers. We hope you enjoy this new generation of Ehcache!
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Configuring Ehcache

--- a/docs/src/docs/asciidoc/user/index.adoc
+++ b/docs/src/docs/asciidoc/user/index.adoc
@@ -1,10 +1,10 @@
 = Ehcache {version} Documentation Overview
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Table of Contents

--- a/docs/src/docs/asciidoc/user/management.adoc
+++ b/docs/src/docs/asciidoc/user/management.adoc
@@ -2,11 +2,11 @@
 ---
 = Management and Monitoring
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Intro

--- a/docs/src/docs/asciidoc/user/migration-guide.adoc
+++ b/docs/src/docs/asciidoc/user/migration-guide.adoc
@@ -2,11 +2,11 @@
 ---
 = Migration Guide
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 
 == Introduction
 

--- a/docs/src/docs/asciidoc/user/osgi.adoc
+++ b/docs/src/docs/asciidoc/user/osgi.adoc
@@ -2,11 +2,11 @@
 ---
 = OSGi Deployment
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == OSGi Compatible Bundles

--- a/docs/src/docs/asciidoc/user/performance.adoc
+++ b/docs/src/docs/asciidoc/user/performance.adoc
@@ -2,11 +2,11 @@
 ---
 = Performance Tuning
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Introduction

--- a/docs/src/docs/asciidoc/user/resilience.adoc
+++ b/docs/src/docs/asciidoc/user/resilience.adoc
@@ -2,11 +2,11 @@
 ---
 = Resilience
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Introduction

--- a/docs/src/docs/asciidoc/user/serializers-copiers.adoc
+++ b/docs/src/docs/asciidoc/user/serializers-copiers.adoc
@@ -2,11 +2,11 @@
 ---
 = Serializers and Copiers
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[overview]]

--- a/docs/src/docs/asciidoc/user/thread-pools.adoc
+++ b/docs/src/docs/asciidoc/user/thread-pools.adoc
@@ -2,11 +2,11 @@
 ---
 = Thread Pools
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[introduction]]

--- a/docs/src/docs/asciidoc/user/tiering.adoc
+++ b/docs/src/docs/asciidoc/user/tiering.adoc
@@ -2,11 +2,12 @@
 ---
 = Ehcache Tiering Options
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
+>>>>>>> Upgrade to Asciidoctor Gradle Plugin 2.0.0
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 
 == Introduction
 

--- a/docs/src/docs/asciidoc/user/usermanaged.adoc
+++ b/docs/src/docs/asciidoc/user/usermanaged.adoc
@@ -2,11 +2,11 @@
 ---
 = User managed caches
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[overview]]

--- a/docs/src/docs/asciidoc/user/writers.adoc
+++ b/docs/src/docs/asciidoc/user/writers.adoc
@@ -2,11 +2,11 @@
 ---
 = Cache Loaders and Writers
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 [[introduction]]

--- a/docs/src/docs/asciidoc/user/xa.adoc
+++ b/docs/src/docs/asciidoc/user/xa.adoc
@@ -2,11 +2,11 @@
 ---
 = XA transactional caches
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 
 == Introduction
 

--- a/docs/src/docs/asciidoc/user/xml.adoc
+++ b/docs/src/docs/asciidoc/user/xml.adoc
@@ -2,11 +2,11 @@
 ---
 = XML Configuration
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == Introduction

--- a/docs/src/docs/asciidoc/user/xsds.adoc
+++ b/docs/src/docs/asciidoc/user/xsds.adoc
@@ -2,11 +2,11 @@
 ---
 = Ehcache XSDs
 ifndef::sourcedir38[]
-include::common.adoc[]
+include::{includedir}/common.adoc[]
 endif::sourcedir38[]
 
 ifdef::notBuildingForSite[]
-include::menu.adoc[]
+include::{includedir}/menu.adoc[]
 endif::notBuildingForSite[]
 
 == XSD namespaces and locations


### PR DESCRIPTION
This is a fairly invasive set of changes to adopt the new 2.x version of the asciidoctor gradle plugin.  This needs to be reviewed for its impact on the website generation before it can be merged as there may need to be compensating changes there. In addition it would be good for a cross-section of developers to confirm their IDE integration is still working okay.