### PR TITLE
[DO NOT MERGE] proposal: core XML extension to instantiate simple services

### DIFF
--- a/impl/src/main/java/org/ehcache/config/builders/CacheManagerBuilder.java
+++ b/impl/src/main/java/org/ehcache/config/builders/CacheManagerBuilder.java
@@ -110,7 +110,22 @@ public class CacheManagerBuilder<T extends CacheManager> implements Builder<T> {
    * @return a {@code CacheManager}
    */
   public static CacheManager newCacheManager(final Configuration configuration) {
-    return new EhcacheManager(configuration);
+    return newCacheManager(configuration, false);
+  }
+
+  /**
+   * Creates a new {@link CacheManager} based on the provided configuration.
+   *
+   * @param configuration the configuration to use
+   * @param init <code>true</code> to return an initialized {@link CacheManager}, <code>false</code> otherwise.
+   * @return a {@code CacheManager}
+   */
+  public static CacheManager newCacheManager(final Configuration configuration, boolean init) {
+    EhcacheManager ehcacheManager = new EhcacheManager(configuration);
+    if (init) {
+      ehcacheManager.init();
+    }
+    return ehcacheManager;
   }
 
   T newCacheManager(Collection<Service> services, final Configuration configuration) {

--- a/xml/src/main/java/org/ehcache/xml/ss/ReflectionHelper.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/ReflectionHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.xml.ss;
+
+import org.ehcache.spi.service.Service;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class ReflectionHelper {
+
+  static Service instantiate(Class<? extends Service> clazz, List<String> unparsedArgs) throws Exception {
+    List<Constructor<?>> potentialCtors = new ArrayList<>();
+
+    for (Constructor<?> constructor : clazz.getConstructors()) {
+      if (constructor.getParameterTypes().length == unparsedArgs.size()) {
+        potentialCtors.add(constructor);
+      }
+    }
+
+    Constructor<?> targetCtor = null;
+    List<Object> targetArgs = new ArrayList<>();
+
+    for (Constructor<?> potentialCtor : potentialCtors) {
+      Class<?>[] parameterTypes = potentialCtor.getParameterTypes();
+      targetCtor = potentialCtor;
+
+      for (int i = 0; i < parameterTypes.length; i++) {
+        Class<?> parameterType = parameterTypes[i];
+        String unparsedArg = unparsedArgs.get(i);
+
+        if (parameterType.isAssignableFrom(String.class)) {
+          // this ctor arg accepts String
+          targetArgs.add(unparsedArg);
+        } else {
+          Constructor<?> convertFromStringCtor = null;
+          try {
+            convertFromStringCtor = parameterType.getConstructor(String.class);
+          } catch (NoSuchMethodException | SecurityException e) {
+            // ignore, no such ctor
+          }
+          if (convertFromStringCtor != null) {
+            // this ctor arg accepts a type that has a String ctor
+            Object o = convertFromStringCtor.newInstance(unparsedArg);
+            targetArgs.add(o);
+          } else if (parameterType.isPrimitive()) {
+            targetArgs.add(convertToPrimitive(parameterType, unparsedArg));
+          } else {
+            // unusable ctor
+            targetArgs.clear();
+            targetCtor = null;
+            break;
+          }
+        }
+      }
+    }
+
+    if (targetCtor != null) {
+      return (Service) targetCtor.newInstance(targetArgs.toArray());
+    }
+
+    throw new IllegalArgumentException("Cannot instantiate '" + clazz.getName() + "' with args " + unparsedArgs);
+  }
+
+
+  private static Object convertToPrimitive(Class<?> primitiveType, String valueAsString) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Class<?> wrapperType = PRIMITIVES_TO_WRAPPERS.get(primitiveType);
+    Method valueOfMethod = wrapperType.getMethod("valueOf", String.class);
+    return valueOfMethod.invoke(wrapperType, valueAsString);
+  }
+
+  private static final Map<Class<?>, Class<?>> PRIMITIVES_TO_WRAPPERS = new HashMap<>();
+
+  static {
+    PRIMITIVES_TO_WRAPPERS.put(boolean.class, Boolean.class);
+    PRIMITIVES_TO_WRAPPERS.put(byte.class, Byte.class);
+    PRIMITIVES_TO_WRAPPERS.put(char.class, Character.class);
+    PRIMITIVES_TO_WRAPPERS.put(double.class, Double.class);
+    PRIMITIVES_TO_WRAPPERS.put(float.class, Float.class);
+    PRIMITIVES_TO_WRAPPERS.put(int.class, Integer.class);
+    PRIMITIVES_TO_WRAPPERS.put(long.class, Long.class);
+    PRIMITIVES_TO_WRAPPERS.put(short.class, Short.class);
+    PRIMITIVES_TO_WRAPPERS.put(void.class, Void.class);
+  }
+
+}

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfiguration.java
@@ -18,28 +18,41 @@ package org.ehcache.xml.ss;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
 
-import java.util.Collections;
 import java.util.List;
 
-public class SimpleServiceConfiguration implements ServiceCreationConfiguration<SimpleServiceProvider, Void> {
-  private final Class<? extends Service> clazz;
-  private final List<String> unparsedArgs;
+public class SimpleServiceConfiguration implements ServiceCreationConfiguration<SimpleServiceProvider, Service> {
 
-  public SimpleServiceConfiguration(Class<? extends Service> clazz, List<String> unparsedArgs) {
-    this.clazz = clazz;
-    this.unparsedArgs = Collections.unmodifiableList(unparsedArgs);
+  private final Service service;
+
+  public SimpleServiceConfiguration(Class<? extends Service> clazz, List<String> unparsedArgs) throws Exception {
+    this.service = ReflectionHelper.instantiate(clazz, unparsedArgs);
   }
 
-  public Class<? extends Service> getClazz() {
-    return clazz;
+  private SimpleServiceConfiguration(Service service) {
+    this.service = service;
   }
 
-  public List<String> getUnparsedArgs() {
-    return unparsedArgs;
+  public Service getService() {
+    return service;
   }
 
   @Override
   public Class<SimpleServiceProvider> getServiceType() {
     return SimpleServiceProvider.class;
+  }
+
+  @Override
+  public Service derive() {
+    return service;
+  }
+
+  @Override
+  public ServiceCreationConfiguration<SimpleServiceProvider, ?> build(Service representation) {
+    return new SimpleServiceConfiguration(representation);
+  }
+
+  @Override
+  public boolean compatibleWith(ServiceCreationConfiguration<?, ?> other) {
+    return true; // supports many instances
   }
 }

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfiguration.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.xml.ss;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SimpleServiceConfiguration implements ServiceCreationConfiguration<SimpleServiceProvider, Void> {
+  private final Class<? extends Service> clazz;
+  private final List<String> unparsedArgs;
+
+  public SimpleServiceConfiguration(Class<? extends Service> clazz, List<String> unparsedArgs) {
+    this.clazz = clazz;
+    this.unparsedArgs = Collections.unmodifiableList(unparsedArgs);
+  }
+
+  public Class<? extends Service> getClazz() {
+    return clazz;
+  }
+
+  public List<String> getUnparsedArgs() {
+    return unparsedArgs;
+  }
+
+  @Override
+  public Class<SimpleServiceProvider> getServiceType() {
+    return SimpleServiceProvider.class;
+  }
+}

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfigurationParser.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.xml.ss;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+import org.ehcache.xml.CacheManagerServiceConfigurationParser;
+import org.ehcache.xml.exceptions.XmlConfigurationException;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.ehcache.core.util.ClassLoading.delegationChain;
+
+public class SimpleServiceConfigurationParser implements CacheManagerServiceConfigurationParser<SimpleServiceProvider> {
+
+  private static final URI NAMESPACE = URI.create("http://www.ehcache.org/v3/ss");
+  private static final URL XML_SCHEMA = SimpleServiceConfigurationParser.class.getResource("/ehcache-simple-service-ext.xsd");
+
+  @Override
+  public Source getXmlSchema() throws IOException {
+    return new StreamSource(XML_SCHEMA.openStream());
+  }
+
+  @Override
+  public URI getNamespace() {
+    return NAMESPACE;
+  }
+
+  @Override
+  public ServiceCreationConfiguration<SimpleServiceProvider, ?> parseServiceCreationConfiguration(Element fragment, ClassLoader classLoader) {
+    String localName = fragment.getLocalName();
+    if ("instance".equals(localName)) {
+      String serviceClassName = fragment.getAttribute("class");
+      try {
+        Class<?> aClass = Class.forName(serviceClassName, true, delegationChain(
+          () -> Thread.currentThread().getContextClassLoader(),
+          getClass().getClassLoader(),
+          classLoader
+        ));
+        Class<? extends Service> clazz = uncheckedCast(aClass);
+
+        List<String> unparsedArgs = new ArrayList<>();
+        NodeList childNodes = fragment.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+          Node node = childNodes.item(i);
+          if ("arg".equals(node.getLocalName())) {
+            String value = ((Element) node).getAttribute("value");
+            unparsedArgs.add(value);
+          }
+        }
+
+        return new SimpleServiceConfiguration(clazz, unparsedArgs);
+      } catch (Exception e) {
+        throw new XmlConfigurationException("Error configuring simple service", e);
+      }
+    } else {
+      throw new XmlConfigurationException(String.format("XML configuration element <%s> in <%s> is not supported",
+        fragment.getTagName(), (fragment.getParentNode() == null ? "null" : fragment.getParentNode().getLocalName())));
+    }
+  }
+
+  /**
+   * Perform a (warning suppressed) unchecked cast to an inferred type {@code U}.
+   */
+  @SuppressWarnings("unchecked")
+  private static <U> U uncheckedCast(Object o) {
+    return (U) o;
+  }
+
+  @Override
+  public Class<SimpleServiceProvider> getServiceType() {
+    return SimpleServiceProvider.class;
+  }
+
+  @Override
+  public Element unparseServiceCreationConfiguration(ServiceCreationConfiguration<SimpleServiceProvider, ?> serviceCreationConfiguration) {
+    return null;
+  }
+}

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfigurationParser.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceConfigurationParser.java
@@ -68,7 +68,7 @@ public class SimpleServiceConfigurationParser implements CacheManagerServiceConf
           if ("arg".equals(node.getLocalName())) {
             String value = ((Element) node).getAttribute("value");
             unparsedArgs.add(value);
-          }
+          } // TODO else throw?
         }
 
         return new SimpleServiceConfiguration(clazz, unparsedArgs);
@@ -96,6 +96,6 @@ public class SimpleServiceConfigurationParser implements CacheManagerServiceConf
 
   @Override
   public Element unparseServiceCreationConfiguration(ServiceCreationConfiguration<SimpleServiceProvider, ?> serviceCreationConfiguration) {
-    return null;
+    return null; // TODO implement
   }
 }

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceProvider.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceProvider.java
@@ -18,9 +18,12 @@ package org.ehcache.xml.ss;
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceProvider;
 
+import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 public class SimpleServiceProvider implements Service {
   private final SimpleServiceConfiguration configuration;
-  private volatile Service startedService;
+  private volatile Collection<Service> startedServices;
 
   public SimpleServiceProvider(SimpleServiceConfiguration configuration) {
     this.configuration = configuration;
@@ -29,8 +32,8 @@ public class SimpleServiceProvider implements Service {
   @Override
   public void start(ServiceProvider<Service> serviceProvider) {
     try {
-      startedService = configuration.getService();
-      startedService.start(serviceProvider);
+      startedServices = configuration.getServices();
+      startedServices.forEach(service -> service.start(serviceProvider));
     } catch (Exception e) {
       throw new RuntimeException("Error instantiating simple service", e);
     }
@@ -38,8 +41,8 @@ public class SimpleServiceProvider implements Service {
 
   @Override
   public void stop() {
-    startedService.stop();
-    startedService = null;
+    startedServices.forEach(Service::stop);
+    startedServices = null;
   }
 
 }

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceProvider.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceProvider.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.xml.ss;
+
+import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceProvider;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SimpleServiceProvider implements Service {
+  private final SimpleServiceConfiguration configuration;
+  private volatile Service startedService;
+
+  public SimpleServiceProvider(SimpleServiceConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  @Override
+  public void start(ServiceProvider<Service> serviceProvider) {
+    try {
+      startedService = instantiate();
+      startedService.start(serviceProvider);
+    } catch (Exception e) {
+      throw new RuntimeException("Error instantiating simple service", e);
+    }
+  }
+
+  @Override
+  public void stop() {
+    startedService.stop();
+    startedService = null;
+  }
+
+  private Service instantiate() throws Exception {
+    List<Constructor<?>> potentialCtors = new ArrayList<>();
+
+    for (Constructor<?> constructor : configuration.getClazz().getConstructors()) {
+      if (constructor.getParameterTypes().length == configuration.getUnparsedArgs().size()) {
+        potentialCtors.add(constructor);
+      }
+    }
+
+    Constructor<?> targetCtor = null;
+    List<Object> targetArgs = new ArrayList<>();
+
+    for (Constructor<?> potentialCtor : potentialCtors) {
+      Class<?>[] parameterTypes = potentialCtor.getParameterTypes();
+
+      for (int i = 0; i < parameterTypes.length; i++) {
+        Class<?> parameterType = parameterTypes[i];
+        String unparsedArg = configuration.getUnparsedArgs().get(i);
+
+        if (parameterType.isAssignableFrom(String.class)) {
+          // this ctor arg accepts String
+          targetArgs.add(unparsedArg);
+          targetCtor = potentialCtor;
+        } else {
+          Constructor<?> convertFromStringCtor = null;
+          try {
+            convertFromStringCtor = parameterType.getConstructor(String.class);
+          } catch (NoSuchMethodException | SecurityException e) {
+            // ignore, no such ctor
+          }
+          if (convertFromStringCtor != null) {
+            // this ctor arg accepts a type that has a String ctor
+            Object o = convertFromStringCtor.newInstance(unparsedArg);
+            targetArgs.add(o);
+            targetCtor = potentialCtor;
+          } else if (parameterType.isPrimitive()) {
+            targetArgs.add(convertToPrimitive(parameterType, unparsedArg));
+            targetCtor = potentialCtor;
+          } else {
+            // unusable ctor
+            targetArgs.clear();
+            targetCtor = null;
+            break;
+          }
+        }
+      }
+    }
+
+    if (targetCtor != null) {
+      return (Service) targetCtor.newInstance(targetArgs.toArray());
+    }
+
+    throw new IllegalArgumentException("Cannot instantiate '" + configuration.getClazz().getName() + "' with args " + configuration.getUnparsedArgs());
+  }
+
+  private Object convertToPrimitive(Class<?> primitiveType, String valueAsString) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Class<?> wrapperType = PRIMITIVES_TO_WRAPPERS.get(primitiveType);
+    Method valueOfMethod = wrapperType.getMethod("valueOf", String.class);
+    return valueOfMethod.invoke(wrapperType, valueAsString);
+  }
+
+  private static final Map<Class<?>, Class<?>> PRIMITIVES_TO_WRAPPERS = new HashMap<>();
+
+  static {
+    PRIMITIVES_TO_WRAPPERS.put(boolean.class, Boolean.class);
+    PRIMITIVES_TO_WRAPPERS.put(byte.class, Byte.class);
+    PRIMITIVES_TO_WRAPPERS.put(char.class, Character.class);
+    PRIMITIVES_TO_WRAPPERS.put(double.class, Double.class);
+    PRIMITIVES_TO_WRAPPERS.put(float.class, Float.class);
+    PRIMITIVES_TO_WRAPPERS.put(int.class, Integer.class);
+    PRIMITIVES_TO_WRAPPERS.put(long.class, Long.class);
+    PRIMITIVES_TO_WRAPPERS.put(short.class, Short.class);
+    PRIMITIVES_TO_WRAPPERS.put(void.class, Void.class);
+  }
+
+}

--- a/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceProviderFactory.java
+++ b/xml/src/main/java/org/ehcache/xml/ss/SimpleServiceProviderFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.xml.ss;
+
+import org.ehcache.core.spi.service.ServiceFactory;
+import org.ehcache.spi.service.ServiceCreationConfiguration;
+
+@ServiceFactory.RequiresConfiguration
+public class SimpleServiceProviderFactory implements ServiceFactory<SimpleServiceProvider> {
+  @Override
+  public SimpleServiceProvider create(ServiceCreationConfiguration<SimpleServiceProvider, ?> configuration) {
+    return new SimpleServiceProvider(((SimpleServiceConfiguration) configuration));
+  }
+
+  @Override
+  public Class<? extends SimpleServiceProvider> getServiceType() {
+    return SimpleServiceProvider.class;
+  }
+
+}

--- a/xml/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
+++ b/xml/src/main/resources/META-INF/services/org.ehcache.core.spi.service.ServiceFactory
@@ -1,0 +1,1 @@
+org.ehcache.xml.ss.SimpleServiceProviderFactory

--- a/xml/src/main/resources/META-INF/services/org.ehcache.xml.CacheManagerServiceConfigurationParser
+++ b/xml/src/main/resources/META-INF/services/org.ehcache.xml.CacheManagerServiceConfigurationParser
@@ -1,0 +1,1 @@
+org.ehcache.xml.ss.SimpleServiceConfigurationParser

--- a/xml/src/main/resources/ehcache-simple-service-ext.xsd
+++ b/xml/src/main/resources/ehcache-simple-service-ext.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema version="1.0"
+           xmlns:ss="http://www.ehcache.org/v3/ss"
+           xmlns:eh="http://www.ehcache.org/v3"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.ehcache.org/v3/ss">
+  <xs:import namespace="http://www.ehcache.org/v3"/>
+
+  <xs:element name="instance" type="ss:service-instance" substitutionGroup="eh:service-creation-configuration"/>
+
+  <xs:complexType name="service-instance">
+    <xs:sequence>
+      <xs:element name="arg" type="ss:service-arg-type" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="class" type="eh:fqcn-type" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="service-arg-type">
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/xml/src/test/java/com/pany/ehcache/service/AcceptAnObjectService.java
+++ b/xml/src/test/java/com/pany/ehcache/service/AcceptAnObjectService.java
@@ -13,33 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehcache.xml.ss;
+package com.pany.ehcache.service;
 
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceProvider;
 
-public class SimpleServiceProvider implements Service {
-  private final SimpleServiceConfiguration configuration;
-  private volatile Service startedService;
+public class AcceptAnObjectService implements Service {
 
-  public SimpleServiceProvider(SimpleServiceConfiguration configuration) {
-    this.configuration = configuration;
+  public AcceptAnObjectService(Object anything) {
+    System.getProperties(); // no-op
   }
 
   @Override
   public void start(ServiceProvider<Service> serviceProvider) {
-    try {
-      startedService = configuration.getService();
-      startedService.start(serviceProvider);
-    } catch (Exception e) {
-      throw new RuntimeException("Error instantiating simple service", e);
-    }
+    System.getProperties(); // no-op
   }
 
   @Override
   public void stop() {
-    startedService.stop();
-    startedService = null;
+    System.getProperties(); // no-op
   }
-
 }

--- a/xml/src/test/java/com/pany/ehcache/service/AccountingService.java
+++ b/xml/src/test/java/com/pany/ehcache/service/AccountingService.java
@@ -13,33 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ehcache.xml.ss;
+package com.pany.ehcache.service;
 
 import org.ehcache.spi.service.Service;
 import org.ehcache.spi.service.ServiceProvider;
 
-public class SimpleServiceProvider implements Service {
-  private final SimpleServiceConfiguration configuration;
-  private volatile Service startedService;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-  public SimpleServiceProvider(SimpleServiceConfiguration configuration) {
-    this.configuration = configuration;
+public class AccountingService implements Service {
+
+  public enum Action {
+    START, STOP
+  }
+
+  public static final List<Action> ACTIONS = new CopyOnWriteArrayList<>();
+
+  public AccountingService() {
+    System.getProperties(); // no-op
   }
 
   @Override
   public void start(ServiceProvider<Service> serviceProvider) {
-    try {
-      startedService = configuration.getService();
-      startedService.start(serviceProvider);
-    } catch (Exception e) {
-      throw new RuntimeException("Error instantiating simple service", e);
-    }
+    ACTIONS.add(Action.START);
   }
 
   @Override
   public void stop() {
-    startedService.stop();
-    startedService = null;
+    ACTIONS.add(Action.STOP);
   }
 
 }

--- a/xml/src/test/java/org/ehcache/xml/ss/SimpleServiceTest.java
+++ b/xml/src/test/java/org/ehcache/xml/ss/SimpleServiceTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.xml.ss;
+
+import org.ehcache.CacheManager;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.xml.XmlConfiguration;
+import org.junit.Test;
+
+public class SimpleServiceTest {
+
+  @Test
+  public void name() {
+    XmlConfiguration xmlConfiguration = new XmlConfiguration(getClass().getResource("/configs/simple-service.xml"));
+
+    CacheManager cacheManager = CacheManagerBuilder.newCacheManager(xmlConfiguration);
+    cacheManager.init();
+
+    cacheManager.close();
+  }
+
+}

--- a/xml/src/test/java/org/ehcache/xml/ss/SimpleServiceTest.java
+++ b/xml/src/test/java/org/ehcache/xml/ss/SimpleServiceTest.java
@@ -15,10 +15,13 @@
  */
 package org.ehcache.xml.ss;
 
+import com.pany.ehcache.service.AccountingService;
 import org.ehcache.CacheManager;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.xml.XmlConfiguration;
 import org.junit.Test;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class SimpleServiceTest {
 
@@ -26,10 +29,12 @@ public class SimpleServiceTest {
   public void name() {
     XmlConfiguration xmlConfiguration = new XmlConfiguration(getClass().getResource("/configs/simple-service.xml"));
 
-    CacheManager cacheManager = CacheManagerBuilder.newCacheManager(xmlConfiguration);
-    cacheManager.init();
+    try (CacheManager cacheManager = CacheManagerBuilder.newCacheManager(xmlConfiguration, true)) {
+    }
 
-    cacheManager.close();
+    assertThat(AccountingService.ACTIONS.get(0)).isSameAs(AccountingService.Action.START);
+    assertThat(AccountingService.ACTIONS.get(1)).isSameAs(AccountingService.Action.STOP);
+    assertThat(AccountingService.ACTIONS.size()).isEqualTo(2);
   }
 
 }

--- a/xml/src/test/resources/configs/simple-service.xml
+++ b/xml/src/test/resources/configs/simple-service.xml
@@ -26,6 +26,15 @@
       <ss:arg value="10000"/>
     </ss:instance>
   </service>
+  <service>
+    <ss:instance class="com.pany.ehcache.service.AccountingService">
+    </ss:instance>
+  </service>
+  <service>
+    <ss:instance class="com.pany.ehcache.service.AcceptAnObjectService">
+      <ss:arg value="whatever"/>
+    </ss:instance>
+  </service>
 
   <cache alias="simpleCache">
     <key-type>java.lang.String</key-type>

--- a/xml/src/test/resources/configs/simple-service.xml
+++ b/xml/src/test/resources/configs/simple-service.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright Terracotta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns='http://www.ehcache.org/v3'
+  xmlns:ss="http://www.ehcache.org/v3/ss"
+  xsi:schemaLocation="http://www.ehcache.org/v3 ../../../../../xml/src/main/resources/ehcache-core.xsd
+                        http://www.ehcache.org/v3/ss ../../../../../xml/src/main/resources/ehcache-simple-service-ext.xsd">
+
+  <service>
+    <ss:instance class="org.ehcache.core.spi.time.TickingTimeSource">
+      <ss:arg value="10"/>
+      <ss:arg value="10000"/>
+    </ss:instance>
+  </service>
+
+  <cache alias="simpleCache">
+    <key-type>java.lang.String</key-type>
+    <value-type>java.lang.String</value-type>
+    <heap>20</heap>
+  </cache>
+
+</config>


### PR DESCRIPTION
Currently, the XML config proposes no way to configure custom services without resorting to the whole write-an-extension-xsd-with-parser-provider-factories shebang.

This quick prototype demonstrates that trivial services could be configured with a simple embedded XML config extension parser that uses simple reflection to instantiate the service.

This would allow for instance configuring the documented `TickingTimeSource` (https://www.ehcache.org/documentation/3.8/performance.html#time-source) via XML with a simple block, solving the problem mentioned here https://stackoverflow.com/questions/55866367/how-to-switch-to-tickingtimesource-for-ehcache-3:

```
<service>
  <ss:instance class="org.ehcache.core.spi.time.TickingTimeSource">
    <ss:arg value="10"/>
    <ss:arg value="10000"/>
  </ss:instance>
</service>
```

Opinions & reviews welcome.