### PR TITLE
Upgrade tc-platform to 5.8.0-pre5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ sizeofVersion = 0.3.0
 jaxbVersion = 2.3.1
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.8.0-pre4
+terracottaPlatformVersion = 5.8.0-pre5
 terracottaApisVersion = 1.7.0-pre2
 terracottaCoreVersion = 5.7.0-pre29
 terracottaPassthroughTestingVersion = 1.7.0-pre13


### PR DESCRIPTION
This update brings the switch to runnel for the dynamic topology entity.

Note: model is still annotated with jackson annotations, which will create some warnings and fail when compiling with `-Werror`.

There is a WIP PR in tc-platform (https://github.com/Terracotta-OSS/terracotta-platform/pull/716) that is removing all annotations from the model classes and moves them to jackson mixins. This PR will be ready tomorrow I hope but it might be to late for the XPC, that is why we can use the `5.8.0-pre5` release at the moment.