### PR TITLE
Upgrade tc-platform to 5.8.0-pre9

### DIFF
--- a/clustered/clustered-dist/build.gradle
+++ b/clustered/clustered-dist/build.gradle
@@ -88,7 +88,7 @@ jar {
     'Bundle-SymbolicName': 'org.ehcache.clustered',
     'Export-Package': '!com.tc.*, !com.terracotta.*, !org.terracotta.*, !org.ehcache.*.internal.*, !sun.misc, ' +
       'org.ehcache.clustered.client.*, org.ehcache.clustered.common.*',
-    'Import-Package': '!sun.misc.*, org.ehcache.xml.*;resolution:=optional, jdk.jfr.*;resolution:=optional, !com.fasterxml.jackson.annotation, *'
+    'Import-Package': '!sun.misc.*, org.ehcache.xml.*;resolution:=optional, jdk.jfr.*;resolution:=optional, !com.fasterxml.jackson.annotation, !com.fasterxml.jackson.core, !com.fasterxml.jackson.databind.module, *'
   )
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ sizeofVersion = 0.3.0
 jaxbVersion = 2.3.1
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.8.0-pre7
+terracottaPlatformVersion = 5.8.0-pre9
 terracottaApisVersion = 1.7.0-pre2
 terracottaCoreVersion = 5.7.0-pre29
 terracottaPassthroughTestingVersion = 1.7.0-pre13


### PR DESCRIPTION
Upgrade tc-platform to 5.8.0-pre9:
* TDB-4990: Refactoring of json wiring in dynamic config (https://github.com/Terracotta-OSS/terracotta-platform/pull/716)
* Added `<optional>` in dependencies so that felix can generate the right "resolution:=optional" attribute in the Import-Package manifest entry (https://github.com/Terracotta-OSS/terracotta-platform/pull/729)