### PR TITLE
Support starting with diagnostic mode and without offheap resources

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/NoOffheapTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/NoOffheapTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ehcache.clustered;
+
+import org.ehcache.StateTransitionException;
+import org.ehcache.config.units.MemoryUnit;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.terracotta.testing.rules.Cluster;
+
+import static java.util.function.UnaryOperator.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ehcache.clustered.client.config.builders.ClusteredResourcePoolBuilder.clusteredDedicated;
+import static org.ehcache.clustered.client.config.builders.ClusteringServiceConfigurationBuilder.cluster;
+import static org.ehcache.config.builders.CacheConfigurationBuilder.newCacheConfigurationBuilder;
+import static org.ehcache.config.builders.CacheManagerBuilder.newCacheManagerBuilder;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
+import static org.junit.Assert.fail;
+
+
+public class NoOffheapTest extends ClusteredTests {
+
+  @ClassRule
+  public static Cluster CLUSTER = newCluster().in(clusterPath()).build();
+
+  @Test
+  public void testNoOffheap() throws InterruptedException {
+    try {
+      newCacheManagerBuilder().with(cluster(CLUSTER.getConnectionURI().resolve("/no-offheap-cm"))
+        .autoCreate(identity()))
+        .withCache("testNoOffheap", newCacheConfigurationBuilder(Long.class, byte[].class, newResourcePoolsBuilder()
+          .with(clusteredDedicated("primary-server-resource", 1, MemoryUnit.MB))
+        )).build(true).close();
+      fail();
+    } catch (StateTransitionException e) {
+      assertThat(e).hasMessage("Could not create the cluster tier manager 'no-offheap-cm'.");
+    }
+  }
+}

--- a/clustered/server/service/src/main/java/org/ehcache/clustered/server/state/EhcacheStateServiceProvider.java
+++ b/clustered/server/service/src/main/java/org/ehcache/clustered/server/state/EhcacheStateServiceProvider.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -62,6 +63,8 @@ public class EhcacheStateServiceProvider implements ServiceProvider, Closeable {
   @Override
   public boolean initialize(ServiceProviderConfiguration configuration, PlatformConfiguration platformConfiguration) {
     Collection<OffHeapResources> extendedConfiguration = platformConfiguration.getExtendedConfiguration(OffHeapResources.class);
+    // When a server is activated, there will ALWAYS be one OffHeapResources, that will hold the mapping configured by the user with the "offheap-resources" setting.
+    // In diagnostic mode, no extended configuration is loaded, so there won't be any OffHeapResources. In that case, we ask this service to be discarded (by returning false).
     if (extendedConfiguration.size() > 1) {
       throw new UnsupportedOperationException("There are " + extendedConfiguration.size() + " OffHeapResourcesProvider, this is not supported. " +
         "There must be only one!");
@@ -73,7 +76,7 @@ public class EhcacheStateServiceProvider implements ServiceProvider, Closeable {
         LOGGER.warn("No offheap-resource defined - this will prevent provider from offering any EhcacheStateService.");
       }
     } else {
-      throw new UnsupportedOperationException("There are no offheap-resource defined, this is not supported");
+      return false;
     }
     return true;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ sizeofVersion = 0.4.0
 jaxbVersion = [2.2,3)
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.8.5
+terracottaPlatformVersion = 5.8.6-pre1
 terracottaApisVersion = 1.8.0
 terracottaCoreVersion = 5.8.1
 terracottaPassthroughTestingVersion = 1.8.1


### PR DESCRIPTION
In relation to: https://github.com/Terracotta-OSS/terracotta-platform/pull/1006

```
> start-tc-server.sh
> start-tc-server.sh -auto-activate
> start-tc-server.sh -config-file ...
> start-tc-server.sh -auto-activate -config-file ...
```

Config file with/without offheap-resources. 