### PR TITLE
Add custom manifest entries in jars

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ sizeofVersion = 0.4.0
 jaxbVersion = [2.2,3)
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.8.6-pre7
+terracottaPlatformVersion = 5.8.6-pre8
 terracottaApisVersion = 1.8.1
 terracottaCoreVersion = 5.8.2-pre6
 terracottaPassthroughTestingVersion = 1.8.2


### PR DESCRIPTION
Align manifest entries with https://github.com/Terracotta-OSS/terracotta-platform/pull/1023.

Example of manifest entries generated for clustered server module:

```
Implementation-Title: ehcache-server
Implementation-Revision: 97f13d24b0d600fabef627f344c5d98ef4ed64d4
Implementation-Version: 3.9-SNAPSHOT
Implementation-Vendor-Id: org.ehcache.modules
```