### PR TITLE
Nexus staging plugin increase timeout (daggy 3.9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ project.nexusStaging {
   username = project.ext.deployUser
   password = project.ext.deployPwd
   logger.debug("Nexus Staging: Using login ${username} and url ${serverUrl}")
+  // Sonatype is often very slow in these operations:
+  delayBetweenRetriesInMillis = (findProperty('delayBetweenRetriesInMillis') ?: '10000') as int
+  numberOfRetries = (findProperty('numberOfRetries') ?: '100') as int
 }
 
 // Disable automatic promotion for added safety


### PR DESCRIPTION
Significant increase, however, at this time sonatype is taking a very long time to close repositories (>30 minutes)