### PR TITLE
Bump NMS timeout to 2 minutes.

### DIFF
--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusterWithManagement.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusterWithManagement.java
@@ -119,7 +119,7 @@ public final class ClusterWithManagement implements TestRule {
     NmsEntity tmsAgentEntity = entityFactory.retrieveOrCreate(new NmsConfig());
 
     NmsService nmsService = new DefaultNmsService(tmsAgentEntity);
-    nmsService.setOperationTimeout(10, TimeUnit.SECONDS);
+    nmsService.setOperationTimeout(2, TimeUnit.MINUTES);
     return nmsService;
   }
 


### PR DESCRIPTION
Slowness doesn't indicate failure as these are not performance tests. Slow monkeys should be allowed to be slow.