### PR TITLE
Update dependency versions

### DIFF
--- a/demos/build.gradle
+++ b/demos/build.gradle
@@ -7,10 +7,6 @@ subprojects {
   apply plugin: 'org.ehcache.build.conventions.war'
   apply plugin: 'org.gretty'
 
-  repositories {
-    jcenter()
-  }
-
   gretty {
     httpPort = 8080
     contextPath = '/'
@@ -20,7 +16,45 @@ subprojects {
   dependencies {
     implementation project(':ehcache-impl')
     implementation 'javax.servlet:javax.servlet-api:3.1.0'
-    runtimeOnly 'ch.qos.logback:logback-classic:1.2.3'
+    runtimeOnly 'ch.qos.logback:logback-classic:1.2.11'
     runtimeOnly 'com.h2database:h2:1.4.196'
+  }
+
+  configurations.all {
+    resolutionStrategy {
+      dependencySubstitution {
+        substitute(module('org.slf4j:slf4j-api'))
+          .because('org.gretty:gretty-runner-jetty declares a very old version of slf4j')
+          .with(module('org.slf4j:slf4j-api:' + project.property('slf4jVersion')))
+      }
+    }
+  }
+
+  /*
+   * This substitution is solely to permit the 'dependencies' task to complete normally --
+   * the Jetty 8 environment provided by gretty is not used in this module.
+   */
+  configurations.named('grettyRunnerJetty8') {
+    resolutionStrategy {
+      dependencySubstitution {
+        substitute(module('org.eclipse.jetty.orbit:javax.servlet.jsp:2.1.0.v201105211820'))
+          .because('gretty plug-in pulls in older version for Jetty8')
+          .with(module('org.eclipse.jetty.orbit:javax.servlet.jsp:2.2.0.v201112011158'))
+      }
+    }
+  }
+
+  /*
+   * This substitution is solely to permit the 'dependencies' task to complete normally --
+   * the Jetty 9.3 environment provided by gretty is not used in this module.
+   */
+  configurations.named('grettyRunnerJetty93') {
+    resolutionStrategy {
+      dependencySubstitution {
+        substitute(module('org.eclipse.jetty.toolchain:jetty-schemas:3.1.M0'))
+          .because('gretty plug-in pulls in older version for Jetty9.3')
+          .with(module('org.eclipse.jetty.toolchain:jetty-schemas:3.1'))
+      }
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 ehcacheVersion = 3.10-SNAPSHOT
 
 # Terracotta third parties
-offheapVersion = 2.5.2
-statisticVersion = 2.1
+offheapVersion = 2.5.3
+statisticVersion = 2.1.2
 jcacheVersion = 1.1.0
-slf4jVersion = 1.7.25
-sizeofVersion = 0.4.0
+slf4jVersion = 1.7.36
+sizeofVersion = 0.4.3
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.9.2
-terracottaApisVersion = 1.8.1
-terracottaCoreVersion = 5.9.2
-terracottaPassthroughTestingVersion = 1.8.2
-terracottaUtilitiesVersion = 0.0.11
+terracottaPlatformVersion = 5.9.6
+terracottaApisVersion = 1.8.2
+terracottaCoreVersion = 5.9.5
+terracottaPassthroughTestingVersion = 1.8.4
+terracottaUtilitiesVersion = 0.0.15
 
 # Test lib versions
 junitVersion = 4.13.1


### PR DESCRIPTION
This commit updates dependency versions to adopt upstream
dependencies using version ranges for logging components.
In addition, this commit pins the following versions:

* slf4j 1.7.36
* terracotta-utilities 0.0.15

Except for demos, the logback version is inherited from
terracotta-core and terracotta-platform.
