### PR TITLE
[3.9] terracottaPlatformVersion = 5.9.7 (fix required for docker container logging)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ sizeofVersion = 0.4.3
 jaxbVersion = [2.2,3)
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.9.6
+terracottaPlatformVersion = 5.9.7
 terracottaApisVersion = 1.8.2
 terracottaCoreVersion = 5.9.5
 terracottaPassthroughTestingVersion = 1.8.4


### PR DESCRIPTION
~~This PR is based on @cljohnso's one which has to be merged first: #3044~~