### PR TITLE
Prevent failure during sourceJar task

### DIFF
--- a/buildSrc/src/main/groovy/EhDistribute.groovy
+++ b/buildSrc/src/main/groovy/EhDistribute.groovy
@@ -82,7 +82,7 @@ class EhDistribute implements Plugin<Project> {
       from(project.jar) {
         include 'META-INF/**', 'LICENSE', 'NOTICE'
       }
-      duplicatesStrategy = 'fail'
+      duplicatesStrategy = 'exclude'
     }
 
     project.signing {


### PR DESCRIPTION
This update is a circumvention for an XJC plugin fault that causes an
XJC-generated sourceSet to be observed twice during generation of a
source jar.

(The fault was apparently hidden by earlier Gradle versions ...)

This commit is DAGGY.