### PR TITLE
Fixes issue#2158 by adding Automatic-Module-Name

### DIFF
--- a/build-logic/src/main/java/org/ehcache/build/conventions/BndConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/BndConvention.java
@@ -14,6 +14,7 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPom;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.api.tasks.bundling.Jar;
@@ -67,6 +68,7 @@ public class BndConvention implements Plugin<Project> {
           properties.put(Constants.BUNDLE_DESCRIPTION, publication.getPom().getDescription());
         });
       });
+      properties.put(Constants.AUTOMATIC_MODULE_NAME, "org." + project.getName().replace('-','.'));
       properties.put(Constants.BUNDLE_SYMBOLICNAME, project.getGroup() + "." + project.getName());
       properties.put(Constants.BUNDLE_DOCURL, "http://ehcache.org");
       properties.put(Constants.BUNDLE_LICENSE, "LICENSE");

--- a/ehcache-107/build.gradle
+++ b/ehcache-107/build.gradle
@@ -89,6 +89,7 @@ javadoc {
 
 jar {
   bnd(
+    'Automatic-Module-Name': 'org.ehcache.jcache',
     'Export-Package': '!org.ehcache.jsr107.tck, !org.ehcache.jsr107.internal.*, org.ehcache.jsr107.*',
     'Import-Package': 'javax.cache.*;resolution:=optional, *',
   )


### PR DESCRIPTION
Adds `Automatic-Module-Name` to the manifest logic.

The default calculation will take the module name replace all `-` characters with `.` and prefixes is with `org.` in case of the module `ehcache-107` a specific automatic module declaration `org.ehcache.jcache` was added to replace the calculated default name.