### PR TITLE
Quick proof-of-concept that strips unnecessary deserialization calls

### DIFF
--- a/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/loaderwriter/DelegatingLoaderWriterStore.java
+++ b/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/loaderwriter/DelegatingLoaderWriterStore.java
@@ -106,12 +106,12 @@ public class DelegatingLoaderWriterStore<K, V> implements WrapperStore<K, V> {
   }
 
   @Override
-  public ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws StoreAccessException {
+  public ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction) throws StoreAccessException {
     throw new UnsupportedOperationException("Implement me");
   }
 
   @Override
-  public ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException {
+  public ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException {
     throw new UnsupportedOperationException("Implement me");
   }
 
@@ -121,12 +121,12 @@ public class DelegatingLoaderWriterStore<K, V> implements WrapperStore<K, V> {
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
     return delegate.bulkCompute(keys, remappingFunction);
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException {
     throw new UnsupportedOperationException("Implement me");
   }
 

--- a/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -49,6 +49,7 @@ import org.ehcache.core.events.StoreEventSink;
 import org.ehcache.core.spi.service.ExecutionService;
 import org.ehcache.core.spi.service.StatisticsService;
 import org.ehcache.core.spi.store.Store;
+import org.ehcache.core.spi.store.Store.ValueHolder;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
 import org.ehcache.core.spi.store.events.StoreEventSource;
@@ -478,13 +479,13 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
   }
 
   @Override
-  public ValueHolder<V> getAndCompute(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction) {
+  public ValueHolder<V> getAndCompute(final K key, final BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction) {
     // TODO: Make appropriate ServerStoreProxy call
     throw new UnsupportedOperationException("Implement me");
   }
 
   @Override
-  public ValueHolder<V> computeAndGet(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction, final Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) {
+  public ValueHolder<V> computeAndGet(final K key, final BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction, final Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) {
     // TODO: Make appropriate ServerStoreProxy call
     throw new UnsupportedOperationException("Implement me");
   }
@@ -499,7 +500,7 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
    * The assumption is that this method will be invoked only by cache.putAll and cache.removeAll methods.
    */
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(final Set<? extends K> keys, final Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction)
+  public Map<K, ValueHolder<V>> bulkCompute(final Set<? extends K> keys, final Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction)
       throws StoreAccessException {
     Map<K, ValueHolder<V>> valueHolderMap = new HashMap<>();
     if(remappingFunction instanceof Ehcache.PutAllFunction) {
@@ -525,7 +526,7 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(final Set<? extends K> keys, final Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, final Supplier<Boolean> replaceEqual) {
+  public Map<K, ValueHolder<V>> bulkCompute(final Set<? extends K> keys, final Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, final Supplier<Boolean> replaceEqual) {
     // TODO: Make appropriate ServerStoreProxy call
     throw new UnsupportedOperationException("Implement me");
   }

--- a/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
+++ b/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
@@ -520,7 +520,7 @@ public class ClusteredStoreTest {
   @Test(expected = UnsupportedOperationException.class)
   public void testBulkComputeThrowsForGenericFunction() throws Exception {
     @SuppressWarnings("unchecked")
-    Function<Iterable<? extends Map.Entry<? extends Long, ? extends String>>, Iterable<? extends Map.Entry<? extends Long, ? extends String>>> remappingFunction
+    Function<Iterable<? extends Map.Entry<? extends Long, ? extends Store.ValueHolder<String>>>, Iterable<? extends Map.Entry<? extends Long, ? extends String>>> remappingFunction
         = mock(Function.class);
     store.bulkCompute(new HashSet<>(Arrays.asList(1L, 2L)), remappingFunction);
   }

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/JCacheClusteredTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/JCacheClusteredTest.java
@@ -47,6 +47,7 @@ public class JCacheClusteredTest {
 
   private static final Properties TCK_PROPERTIES = new Properties();
   static {
+    TCK_PROPERTIES.setProperty("org.jsr107.tck.support.server.address", "127.0.0.1");
     TCK_PROPERTIES.setProperty("java.net.preferIPv4Stack", "true");
     TCK_PROPERTIES.setProperty("javax.management.builder.initial", "org.ehcache.jsr107.internal.tck.Eh107MBeanServerBuilder");
     TCK_PROPERTIES.setProperty("org.jsr107.tck.management.agentId", "Eh107MBeanServer");

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreBulkComputeTest.java
@@ -81,8 +81,8 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       Map<K, Store.ValueHolder<V>> mapFromRemappingFunction = kvStore.bulkCompute(inputKeys, entries -> {
         Map<K, V> update = new HashMap<>();
-        for (Map.Entry<? extends K, ? extends V> entry : entries) {
-          update.put(entry.getKey(), entry.getValue());
+        for (Map.Entry<? extends K, ? extends Store.ValueHolder<V>> entry : entries) {
+          update.put(entry.getKey(), entry.getValue().get());
         }
         return update.entrySet();
       }
@@ -134,7 +134,7 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.bulkCompute(inputKeys, entries -> {
         Map<K, V> update = new HashMap<>();
-        for (Map.Entry<? extends K, ? extends V> entry : entries) {
+        for (Map.Entry<? extends K, ? extends Store.ValueHolder<V>> entry : entries) {
           update.put(entry.getKey(), null);
         }
         return update.entrySet();
@@ -167,13 +167,13 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.bulkCompute(inputKeys, entries -> {
         Map<K, V> update = new HashMap<>();
-        for (Map.Entry<? extends K, ? extends V> entry : entries) {
+        for (Map.Entry<? extends K, ? extends Store.ValueHolder<V>> entry : entries) {
           if (mappedEntries.containsKey(entry.getKey())) {
-            assertThat(entry.getValue(), is(mappedEntries.get(entry.getKey())));
+            assertThat(entry.getValue().get(), is(mappedEntries.get(entry.getKey())));
           } else {
             assertThat(entry.getValue(), is(nullValue()));
           }
-          update.put(entry.getKey(), entry.getValue());
+          update.put(entry.getKey(), entry.getValue().get());
         }
         return update.entrySet();
       }
@@ -199,7 +199,7 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.bulkCompute(inputKeys, entries -> {
         Map<K, V> update = new HashMap<>();
-        for (Map.Entry<? extends K, ? extends V> entry : entries) {
+        for (Map.Entry<? extends K, ? extends Store.ValueHolder<V>> entry : entries) {
           update.put(entry.getKey(), computedEntries.get(entry.getKey()));
         }
         return update.entrySet();
@@ -230,7 +230,7 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.bulkCompute(inputKeys, entries -> {
         Map<K, V> update = new HashMap<>();
-        for (Map.Entry<? extends K, ? extends V> entry : entries) {
+        for (Map.Entry<? extends K, ? extends Store.ValueHolder<V>> entry : entries) {
           if (factory.getKeyType() == String.class) {
             update.put((K)new StringBuffer(entry.getKey().toString()), computedEntries.get(entry.getKey()));
           } else {
@@ -264,7 +264,7 @@ public class StoreBulkComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.bulkCompute(inputKeys, entries -> {
         Map<K, V> update = new HashMap<>();
-        for (Map.Entry<? extends K, ? extends V> entry : entries) {
+        for (Map.Entry<? extends K, ? extends Store.ValueHolder<V>> entry : entries) {
           if (factory.getKeyType() == String.class) {
             update.put(entry.getKey(), (V)new StringBuffer(computedEntries.get(entry.getKey()).toString()));
           } else {

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetAndComputeTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetAndComputeTest.java
@@ -226,7 +226,7 @@ public class StoreGetAndComputeTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.put(key, value);
       assertThat(kvStore.get(key).get(), is(value));
 
-      kvStore.computeAndGet(key, (keyParam, oldValue) -> oldValue, () -> { throw re; }, () -> false);
+      kvStore.computeAndGet(key, (keyParam, oldValue) -> oldValue.get(), () -> { throw re; }, () -> false);
     } catch (StoreAccessException e) {
       assertThat(e.getCause(), is(re));
     }
@@ -248,7 +248,7 @@ public class StoreGetAndComputeTest<K, V> extends SPIStoreTester<K, V> {
       kvStore.put(key, value);
       assertThat(kvStore.get(key).get(), is(value));
 
-      kvStore.computeAndGet(key, (keyParam, oldValue) -> oldValue, () -> { throw re; }, () -> false);
+      kvStore.computeAndGet(key, (keyParam, oldValue) -> oldValue.get(), () -> { throw re; }, () -> false);
     } catch (RuntimeException e) {
       assertThat(e, is(exception));
     }
@@ -268,7 +268,7 @@ public class StoreGetAndComputeTest<K, V> extends SPIStoreTester<K, V> {
     try {
       kvStore.put(key, value);
 
-      Store.ValueHolder<V> result = kvStore.getAndCompute(key, (k, v) -> v);
+      Store.ValueHolder<V> result = kvStore.getAndCompute(key, (k, v) -> v.get());
       assertThat(result.get(), is(value));
       assertThat(kvStore.get(key), nullValue());
     } catch (StoreAccessException e) {

--- a/ehcache-107/build.gradle
+++ b/ehcache-107/build.gradle
@@ -109,6 +109,7 @@ task tckTest(type: Test, dependsOn: unpackTckTests) {
   reports.junitXml.destination = file("$buildDir/tck-tests-results")
   reports.html.destination = file("$buildDir/reports/tck-tests")
 
+  systemProperty 'org.jsr107.tck.support.server.address', '127.0.0.1'
   systemProperty 'java.net.preferIPv4Stack', 'true'
   systemProperty 'javax.management.builder.initial', 'org.ehcache.jsr107.internal.tck.Eh107MBeanServerBuilder'
   systemProperty 'org.jsr107.tck.management.agentId', 'Eh107MBeanServer'

--- a/ehcache-core/src/main/java/org/ehcache/core/spi/store/Store.java
+++ b/ehcache-core/src/main/java/org/ehcache/core/spi/store/Store.java
@@ -333,7 +333,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
    * @throws StoreAccessException if the mapping can't be changed
    *
    */
-  ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws StoreAccessException;
+  ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction) throws StoreAccessException;
 
   /**
    * Compute the value for the given key by invoking the given function to produce the value.
@@ -376,7 +376,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
    * @throws StoreAccessException if the mapping can't be changed
    *
    */
-  ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException;
+  ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException;
 
   /**
    * Compute the value for the given key (only if absent or expired) by invoking the given function to produce the value.
@@ -438,7 +438,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
    * @throws NullPointerException if any of the arguments is null
    * @throws StoreAccessException if mappings can't be changed
    */
-  Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException;
+  Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException;
 
   /**
    * Compute a value for every key passed in the {@link Set} {@code keys} argument, using the {@code remappingFunction} to compute the value.
@@ -467,7 +467,7 @@ public interface Store<K, V> extends ConfigurationChangeSupport {
    * @throws NullPointerException if any of the arguments is null
    * @throws StoreAccessException if mappings can't be changed
    */
-  Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException;
+  Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException;
 
   /**
    * Compute a value for every key passed in the {@link Set} <code>keys</code> argument using the <code>mappingFunction</code>

--- a/ehcache-core/src/test/java/org/ehcache/core/EhcacheBasicPutAllTest.java
+++ b/ehcache-core/src/test/java/org/ehcache/core/EhcacheBasicPutAllTest.java
@@ -300,7 +300,7 @@ public class EhcacheBasicPutAllTest extends EhcacheBasicCrudBase {
    * @return a Mockito {@code any} matcher for {@code Function}
    */
   @SuppressWarnings("unchecked")
-  static Function<Iterable<? extends Map.Entry<? extends String, ? extends String>>, Iterable<? extends Map.Entry<? extends String, ? extends String>>> getAnyEntryIterableFunction() {
+  static Function<Iterable<? extends Map.Entry<? extends String, ? extends Store.ValueHolder<String>>>, Iterable<? extends Map.Entry<? extends String, ? extends String>>> getAnyEntryIterableFunction() {
     return any(Function.class);   // unchecked
   }
 

--- a/ehcache-core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
+++ b/ehcache-core/src/test/java/org/ehcache/core/EhcacheBasicRemoveAllTest.java
@@ -271,7 +271,7 @@ public class EhcacheBasicRemoveAllTest extends EhcacheBasicCrudBase {
    * @return a Mockito {@code any} matcher for {@code Function}
    */
   @SuppressWarnings("unchecked")
-  static Function<Iterable<? extends Map.Entry<? extends String, ? extends String>>, Iterable<? extends Map.Entry<? extends String, ? extends String>>> getAnyEntryIterableFunction() {
+  static Function<Iterable<? extends Map.Entry<? extends String, ? extends Store.ValueHolder<String>>>, Iterable<? extends Map.Entry<? extends String, ? extends String>>> getAnyEntryIterableFunction() {
     return any(Function.class);   // unchecked
   }
 

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/basic/NopStore.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/basic/NopStore.java
@@ -163,12 +163,12 @@ public class NopStore<K, V> implements AuthoritativeTier<K, V> {
   }
 
   @Override
-  public ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) {
+  public ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction) {
     return null;
   }
 
   @Override
-  public ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) {
+  public ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) {
     return null;
   }
 
@@ -178,12 +178,12 @@ public class NopStore<K, V> implements AuthoritativeTier<K, V> {
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
     return bulkCompute(keys, remappingFunction, null);
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) {
     Map<K, ValueHolder<V>> map = new HashMap<>(keys.size());
     for(K key : keys) {
       map.put(key, null);

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -93,6 +93,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.util.Collections.singletonMap;
 import static org.ehcache.config.Eviction.noAdvice;
 import static org.ehcache.core.config.ExpiryUtils.isExpiryDurationInfinite;
 import static org.ehcache.core.exceptions.StorePassThroughException.handleException;
@@ -1109,7 +1110,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
   }
 
   @Override
-  public ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws StoreAccessException {
+  public ValueHolder<V> getAndCompute(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction) throws StoreAccessException {
     checkKey(key);
 
     computeObserver.begin();
@@ -1131,13 +1132,12 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         }
 
         OnHeapValueHolder<V> holder;
-        V existingValue = mappedValue == null ? null : mappedValue.get();
         if (mappedValue != null) {
           oldValue.set(mappedValue);
         }
-        V computedValue = mappingFunction.apply(mappedKey, existingValue);
+        V computedValue = mappingFunction.apply(mappedKey, mappedValue);
         if (computedValue == null) {
-          if (existingValue != null) {
+          if (mappedValue != null) {
             eventSink.removed(mappedKey, mappedValue);
             outcome.set(StoreOperationOutcomes.ComputeOutcome.REMOVED);
             delta -= mappedValue.size();
@@ -1177,7 +1177,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
   }
 
   @Override
-  public ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super V, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException {
+  public ValueHolder<V> computeAndGet(K key, BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction, Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException {
     checkKey(key);
 
     computeObserver.begin();
@@ -1199,16 +1199,15 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
         }
 
         OnHeapValueHolder<V> holder;
-        V existingValue = mappedValue == null ? null : mappedValue.get();
-        V computedValue = mappingFunction.apply(mappedKey, existingValue);
+        V computedValue = mappingFunction.apply(mappedKey, mappedValue);
         if (computedValue == null) {
-          if (existingValue != null) {
+          if (mappedValue != null) {
             eventSink.removed(mappedKey, mappedValue);
             outcome.set(StoreOperationOutcomes.ComputeOutcome.REMOVED);
             delta -= mappedValue.size();
           }
           holder = null;
-        } else if (Objects.equals(existingValue, computedValue) && !replaceEqual.get() && mappedValue != null) {
+        } else if (mappedValue != null && !replaceEqual.get() && Objects.equals(mappedValue.get(), computedValue)) {
           holder = strategy.setAccessAndExpiryWhenCallerlUnderLock(key, mappedValue, now, eventSink);
           outcome.set(StoreOperationOutcomes.ComputeOutcome.HIT);
           if (holder == null) {
@@ -1358,12 +1357,12 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Entry<? extends K, ? extends V>>, Iterable<? extends Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
     return bulkCompute(keys, remappingFunction, REPLACE_EQUALS_TRUE);
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K,? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K,? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException {
 
     // The Store here is free to slice & dice the keys as it sees fit
     // As this OnHeapStore doesn't operate in segments, the best it can do is do a "bulk" write in batches of... one!
@@ -1373,8 +1372,7 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
       checkKey(key);
 
       ValueHolder<V> newValue = computeAndGet(key, (k, oldValue) -> {
-        Set<Entry<K, V>> entrySet = Collections.singletonMap(k, oldValue).entrySet();
-        Iterable<? extends Entry<? extends K, ? extends V>> entries = remappingFunction.apply(entrySet);
+        Iterable<? extends Entry<? extends K, ? extends V>> entries = remappingFunction.apply(Collections.singletonMap(k, oldValue).entrySet());
         java.util.Iterator<? extends Entry<? extends K, ? extends V>> iterator = entries.iterator();
         Entry<? extends K, ? extends V> next = iterator.next();
 

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/tiering/TieredStore.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/tiering/TieredStore.java
@@ -302,7 +302,7 @@ public class TieredStore<K, V> implements Store<K, V> {
   }
 
   @Override
-  public ValueHolder<V> getAndCompute(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction) throws StoreAccessException {
+  public ValueHolder<V> getAndCompute(final K key, final BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction) throws StoreAccessException {
     try {
       return authoritativeTier.getAndCompute(key, mappingFunction);
     } finally {
@@ -311,7 +311,7 @@ public class TieredStore<K, V> implements Store<K, V> {
   }
 
   @Override
-  public ValueHolder<V> computeAndGet(final K key, final BiFunction<? super K, ? super V, ? extends V> mappingFunction, final Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException {
+  public ValueHolder<V> computeAndGet(final K key, final BiFunction<? super K, ? super ValueHolder<V>, ? extends V> mappingFunction, final Supplier<Boolean> replaceEqual, Supplier<Boolean> invokeWriter) throws StoreAccessException {
     try {
       return authoritativeTier.computeAndGet(key, mappingFunction, replaceEqual, () -> false);
     } finally {
@@ -334,7 +334,7 @@ public class TieredStore<K, V> implements Store<K, V> {
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
     try {
       return authoritativeTier.bulkCompute(keys, remappingFunction);
     } finally {
@@ -345,7 +345,7 @@ public class TieredStore<K, V> implements Store<K, V> {
   }
 
   @Override
-  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException {
+  public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction, Supplier<Boolean> replaceEqual) throws StoreAccessException {
     try {
       return authoritativeTier.bulkCompute(keys, remappingFunction, replaceEqual);
     } finally {

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/BaseOnHeapStoreTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/BaseOnHeapStoreTest.java
@@ -575,7 +575,7 @@ public abstract class BaseOnHeapStoreTest {
     long accessTime = installedHolder.lastAccessTime();
     timeSource.advanceTime(1);
 
-    ValueHolder<String> newValue = store.computeAndGet("key", (mappedKey, mappedValue) -> mappedValue, () -> true, () -> false);
+    ValueHolder<String> newValue = store.computeAndGet("key", (mappedKey, mappedValue) -> mappedValue.get(), () -> true, () -> false);
 
     assertThat(newValue.get(), equalTo("value"));
     assertThat(createTime + 1, equalTo(newValue.creationTime()));
@@ -596,7 +596,7 @@ public abstract class BaseOnHeapStoreTest {
     long accessTime = installedHolder.lastAccessTime();
     timeSource.advanceTime(1);
 
-    ValueHolder<String> newValue = store.computeAndGet("key", (mappedKey, mappedValue) -> mappedValue, () -> false, () -> false);
+    ValueHolder<String> newValue = store.computeAndGet("key", (mappedKey, mappedValue) -> mappedValue.get(), () -> false, () -> false);
 
     assertThat(newValue.get(), equalTo("value"));
     assertThat(createTime, equalTo(newValue.creationTime()));
@@ -672,7 +672,7 @@ public abstract class BaseOnHeapStoreTest {
 
     ValueHolder<String> oldValue = store.getAndCompute("key", (mappedKey, mappedValue) -> {
       assertThat(mappedKey, equalTo("key"));
-      assertThat(mappedValue, equalTo("value"));
+      assertThat(mappedValue.get(), equalTo("value"));
       return "value2";
     });
 
@@ -731,7 +731,7 @@ public abstract class BaseOnHeapStoreTest {
     OnHeapStore<String, String> store = newStore(timeSource, expiry().access(Duration.ZERO).build());
 
     store.put("key", "value");
-    ValueHolder<String> result = store.computeAndGet("key", (key, value) -> value, () -> false, () -> false);
+    ValueHolder<String> result = store.computeAndGet("key", (key, value) -> value.get(), () -> false, () -> false);
     assertThat(result, valueHeld("value"));
   }
 

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreBulkMethodsTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreBulkMethodsTest.java
@@ -84,8 +84,8 @@ public class OnHeapStoreBulkMethodsTest {
 
     Map<Number, Store.ValueHolder<Number>> result = store.bulkCompute(new HashSet<Number>(Arrays.asList(1, 2, 3, 4, 5, 6)), entries -> {
       Map<Number, Number> newValues = new HashMap<>();
-      for (Map.Entry<? extends Number, ? extends Number> entry : entries) {
-        final Number currentValue = entry.getValue();
+      for (Map.Entry<? extends Number, ? extends Store.ValueHolder<Number>> entry : entries) {
+        final Store.ValueHolder<Number> currentValue = entry.getValue();
         if(currentValue == null) {
           if(entry.getKey().equals(4)) {
             newValues.put(entry.getKey(), null);
@@ -93,7 +93,7 @@ public class OnHeapStoreBulkMethodsTest {
             newValues.put(entry.getKey(), 0);
           }
         } else {
-          newValues.put(entry.getKey(), currentValue.intValue() * 2);
+          newValues.put(entry.getKey(), currentValue.get().intValue() * 2);
         }
 
       }
@@ -133,7 +133,7 @@ public class OnHeapStoreBulkMethodsTest {
 
     Map<Number, Store.ValueHolder<CharSequence>> result = store.bulkCompute(new HashSet<Number>(Arrays.asList(1, 2)), entries -> {
       Map<Number, CharSequence> newValues = new HashMap<>();
-      for (Map.Entry<? extends Number, ? extends CharSequence> entry : entries) {
+      for (Map.Entry<? extends Number, ? extends Store.ValueHolder<CharSequence>> entry : entries) {
         if(entry.getKey().intValue() == 1) {
           newValues.put(entry.getKey(), "un");
         } else if (entry.getKey().intValue() == 2)  {
@@ -164,7 +164,7 @@ public class OnHeapStoreBulkMethodsTest {
 
     Map<Number, Store.ValueHolder<CharSequence>> result = store.bulkCompute(new HashSet<Number>(Arrays.asList(2, 1, 5)), entries -> {
       Map<Number, CharSequence> newValues = new HashMap<>();
-      for (Map.Entry<? extends Number, ? extends CharSequence> entry : entries) {
+      for (Map.Entry<? extends Number, ? extends Store.ValueHolder<CharSequence>> entry : entries) {
         newValues.put(entry.getKey(), null);
       }
       return newValues.entrySet();
@@ -188,13 +188,13 @@ public class OnHeapStoreBulkMethodsTest {
 
     Map<Number, Store.ValueHolder<CharSequence>> result = store.bulkCompute(new HashSet<Number>(Arrays.asList(1, 2, 3)), entries -> {
       Map<Number, CharSequence> result1 = new HashMap<>();
-      for (Map.Entry<? extends Number, ? extends CharSequence> entry : entries) {
+      for (Map.Entry<? extends Number, ? extends Store.ValueHolder<CharSequence>> entry : entries) {
         if (entry.getKey().equals(1)) {
           result1.put(entry.getKey(), null);
         } else if (entry.getKey().equals(3)) {
           result1.put(entry.getKey(), null);
         } else {
-          result1.put(entry.getKey(), entry.getValue());
+          result1.put(entry.getKey(), entry.getValue().get());
         }
       }
       return result1.entrySet();

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreKeyCopierTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreKeyCopierTest.java
@@ -136,13 +136,13 @@ public class OnHeapStoreKeyCopierTest {
       if (copyForWrite) {
         assertThat(value, nullValue());
       } else {
-        assertThat(value, is(VALUE));
+        assertThat(value.get(), is(VALUE));
         assertThat(key, is(copyKey));
         if (copyForRead) {
           key.state = "Changed!";
         }
       }
-      return value;
+      return value == null ? null : value.get();
     });
 
     if (copyForRead) {
@@ -162,13 +162,13 @@ public class OnHeapStoreKeyCopierTest {
       if (copyForWrite) {
         assertThat(value, nullValue());
       } else {
-        assertThat(value, is(VALUE));
+        assertThat(value.get(), is(VALUE));
         assertThat(key, is(copyKey));
         if (copyForRead) {
           key.state = "Changed!";
         }
       }
-      return value;
+      return value == null ? null : value.get();
     }, NOT_REPLACE_EQUAL, () -> false);
 
     if (copyForRead) {
@@ -188,13 +188,13 @@ public class OnHeapStoreKeyCopierTest {
       if (copyForWrite) {
         assertThat(value, nullValue());
       } else {
-        assertThat(value, is(VALUE));
+        assertThat(value.get(), is(VALUE));
         assertThat(key, is(copyKey));
         if (copyForRead) {
           key.state = "Changed!";
         }
       }
-      return value;
+      return value == null ? null : value.get();
     }, REPLACE_EQUAL, () -> false);
 
     if (copyForRead) {

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreValueCopierTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/OnHeapStoreValueCopierTest.java
@@ -37,9 +37,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toMap;
 import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -125,8 +127,8 @@ public class OnHeapStoreValueCopierTest {
     Store.ValueHolder<Value> computedVal = store.getAndCompute(KEY, (aLong, value) -> VALUE);
     Store.ValueHolder<Value> oldValue = store.get(KEY);
     store.getAndCompute(KEY, (aLong, value) -> {
-      compareReadValues(value, oldValue.get());
-      return value;
+      compareReadValues(value.get(), oldValue.get());
+      return value.get();
     });
 
     compareValues(VALUE, computedVal.get());
@@ -136,8 +138,8 @@ public class OnHeapStoreValueCopierTest {
   public void testComputeWithoutReplaceEqual() throws StoreAccessException {
     final Store.ValueHolder<Value> firstValue = store.computeAndGet(KEY, (aLong, value) -> VALUE, NOT_REPLACE_EQUAL, () -> false);
     store.computeAndGet(KEY, (aLong, value) -> {
-      compareReadValues(value, firstValue.get());
-      return value;
+      compareReadValues(value.get(), firstValue.get());
+      return value.get();
     }, NOT_REPLACE_EQUAL, () -> false);
 
     compareValues(VALUE, firstValue.get());
@@ -147,8 +149,8 @@ public class OnHeapStoreValueCopierTest {
   public void testComputeWithReplaceEqual() throws StoreAccessException {
     final Store.ValueHolder<Value> firstValue = store.computeAndGet(KEY, (aLong, value) -> VALUE, REPLACE_EQUAL, () -> false);
     store.computeAndGet(KEY, (aLong, value) -> {
-      compareReadValues(value, firstValue.get());
-      return value;
+      compareReadValues(value.get(), firstValue.get());
+      return value.get();
     }, REPLACE_EQUAL, () -> false);
 
     compareValues(VALUE, firstValue.get());
@@ -169,8 +171,8 @@ public class OnHeapStoreValueCopierTest {
   public void testBulkCompute() throws StoreAccessException {
     final Map<Long, Store.ValueHolder<Value>> results = store.bulkCompute(singleton(KEY), entries -> singletonMap(KEY, VALUE).entrySet());
     store.bulkCompute(singleton(KEY), entries -> {
-      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue());
-      return entries;
+      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue().get());
+      return StreamSupport.stream(entries.spliterator(), false).collect(toMap(e -> e.getKey(), e -> e.getValue().get())).entrySet();
     });
     compareValues(VALUE, results.get(KEY).get());
   }
@@ -179,8 +181,8 @@ public class OnHeapStoreValueCopierTest {
   public void testBulkComputeWithoutReplaceEqual() throws StoreAccessException {
     final Map<Long, Store.ValueHolder<Value>> results = store.bulkCompute(singleton(KEY), entries -> singletonMap(KEY, VALUE).entrySet(), NOT_REPLACE_EQUAL);
     store.bulkCompute(singleton(KEY), entries -> {
-      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue());
-      return entries;
+      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue().get());
+      return StreamSupport.stream(entries.spliterator(), false).collect(toMap(e -> e.getKey(), e -> e.getValue().get())).entrySet();
     }, NOT_REPLACE_EQUAL);
     compareValues(VALUE, results.get(KEY).get());
   }
@@ -189,8 +191,8 @@ public class OnHeapStoreValueCopierTest {
   public void testBulkComputeWithReplaceEqual() throws StoreAccessException {
     final Map<Long, Store.ValueHolder<Value>> results = store.bulkCompute(singleton(KEY), entries -> singletonMap(KEY, VALUE).entrySet(), REPLACE_EQUAL);
     store.bulkCompute(singleton(KEY), entries -> {
-      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue());
-      return entries;
+      compareReadValues(results.get(KEY).get(), entries.iterator().next().getValue().get());
+      return StreamSupport.stream(entries.spliterator(), false).collect(toMap(e -> e.getKey(), e -> e.getValue().get())).entrySet();
     }, REPLACE_EQUAL);
     compareValues(VALUE, results.get(KEY).get());
   }

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/ByteAccountingTest.java
@@ -435,7 +435,7 @@ public class ByteAccountingTest {
     OnHeapStoreForTests<String, String> store = newStore(timeSource, expiry().access(Duration.ZERO).build());
 
     store.put(KEY, VALUE);
-    store.computeAndGet(KEY, (s, s2) -> s2, () -> false, () -> false);
+    store.computeAndGet(KEY, (s, s2) -> s2.get(), () -> false, () -> false);
 
     assertThat(store.getCurrentUsageInBytes(), is(0L));
   }
@@ -446,7 +446,7 @@ public class ByteAccountingTest {
     OnHeapStoreForTests<String, String> store = newStore(timeSource, expiry().update(Duration.ZERO).build());
 
     store.put(KEY, VALUE);
-    store.getAndCompute(KEY, (s, s2) -> s2);
+    store.getAndCompute(KEY, (s, s2) -> s2.get());
 
     assertThat(store.getCurrentUsageInBytes(), is(0L));
   }

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreBulkMethodsTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/heap/bytesized/OnHeapStoreBulkMethodsTest.java
@@ -91,8 +91,8 @@ public class OnHeapStoreBulkMethodsTest extends org.ehcache.impl.internal.store.
 
     Map<Number, Store.ValueHolder<Number>> result = store.bulkCompute(new HashSet<Number>(Arrays.asList(1, 2, 3, 4, 5, 6)), entries -> {
       Map<Number, Number> newValues = new HashMap<>();
-      for (Map.Entry<? extends Number, ? extends Number> entry : entries) {
-        final Number currentValue = entry.getValue();
+      for (Map.Entry<? extends Number, ? extends Store.ValueHolder<Number>> entry : entries) {
+        final Store.ValueHolder<Number> currentValue = entry.getValue();
         if(currentValue == null) {
           if(entry.getKey().equals(4)) {
             newValues.put(entry.getKey(), null);
@@ -100,7 +100,7 @@ public class OnHeapStoreBulkMethodsTest extends org.ehcache.impl.internal.store.
             newValues.put(entry.getKey(), 0);
           }
         } else {
-          newValues.put(entry.getKey(), currentValue.intValue() * 2);
+          newValues.put(entry.getKey(), currentValue.get().intValue() * 2);
         }
 
       }

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStoreTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/offheap/AbstractOffHeapStoreTest.java
@@ -376,7 +376,7 @@ public abstract class AbstractOffHeapStoreTest {
       expiry().access(Duration.ZERO).update(Duration.ZERO).build());
 
     offHeapStore.put("key", "value");
-    Store.ValueHolder<String> result = offHeapStore.computeAndGet("key", (s, s2) -> s2, () -> false, () -> false);
+    Store.ValueHolder<String> result = offHeapStore.computeAndGet("key", (s, s2) -> s2.get(), () -> false, () -> false);
 
     assertThat(result, valueHeld("value"));
   }

--- a/ehcache-transactions/src/common/java/org/ehcache/transactions/xa/internal/XATransactionContext.java
+++ b/ehcache-transactions/src/common/java/org/ehcache/transactions/xa/internal/XATransactionContext.java
@@ -120,12 +120,6 @@ public class XATransactionContext<K, V> {
     return command != null ? command.getNewValueHolder() : null;
   }
 
-  public V newValueOf(K key) {
-    Command<V> command = commands.get(key);
-    XAValueHolder<V> valueHolder = command == null ? null : command.getNewValueHolder();
-    return valueHolder == null ? null : valueHolder.get();
-  }
-
   public int prepare() throws StoreAccessException, IllegalStateException, TransactionTimeoutException {
     try {
       if (hasTimedOut()) {

--- a/ehcache-transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
+++ b/ehcache-transactions/src/test/java/org/ehcache/transactions/xa/internal/XAStoreTest.java
@@ -710,14 +710,14 @@ public class XAStoreTest {
       assertThat(xaStore.get(1L).get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return "un";
       });
       assertThat(computed2.get(), equalTo("one"));
       assertThat(xaStore.get(1L).get(), equalTo("un"));
       Store.ValueHolder<String> computed3 = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("un"));
+        assertThat(s.get(), equalTo("un"));
         return null;
       });
       assertThat(computed3.get(), equalTo("un"));
@@ -738,7 +738,7 @@ public class XAStoreTest {
       assertThat(xaStore.get(1L).get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return null;
       });
       assertThat(computed2.get(), equalTo("one"));
@@ -759,7 +759,7 @@ public class XAStoreTest {
       assertThat(xaStore.get(1L).get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return null;
       });
       assertThat(computed2.get(), equalTo("one"));
@@ -780,7 +780,7 @@ public class XAStoreTest {
       assertThat(xaStore.get(1L).get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return "un";
       });
       assertThat(computed2.get(), equalTo("one"));
@@ -794,7 +794,7 @@ public class XAStoreTest {
     {
       Store.ValueHolder<String> computed = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("un"));
+        assertThat(s.get(), equalTo("un"));
         return "eins";
       });
       assertThat(computed.get(), equalTo("un"));
@@ -808,7 +808,7 @@ public class XAStoreTest {
     {
       Store.ValueHolder<String> computed = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("eins"));
+        assertThat(s.get(), equalTo("eins"));
         return null;
       });
       assertThat(computed.get(), equalTo("eins"));
@@ -822,7 +822,7 @@ public class XAStoreTest {
     {
       Store.ValueHolder<String> computed1 = xaStore.getAndCompute(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("eins"));
+        assertThat(s.get(), equalTo("eins"));
         return null;
       });
       assertThat(computed1.get(), equalTo("eins"));
@@ -899,13 +899,13 @@ public class XAStoreTest {
       assertThat(computed1.get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return "un";
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed2.get(), equalTo("un"));
       Store.ValueHolder<String> computed3 = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("un"));
+        assertThat(s.get(), equalTo("un"));
         return null;
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed3, is(nullValue()));
@@ -924,7 +924,7 @@ public class XAStoreTest {
       assertThat(computed1.get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return null;
       }, SUPPLY_FALSE, SUPPLY_FALSE);
       assertThat(computed2, is(nullValue()));
@@ -943,7 +943,7 @@ public class XAStoreTest {
       assertThat(computed1.get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return null;
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed2, is(nullValue()));
@@ -962,7 +962,7 @@ public class XAStoreTest {
       assertThat(computed1.get(), equalTo("one"));
       Store.ValueHolder<String> computed2 = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("one"));
+        assertThat(s.get(), equalTo("one"));
         return "un";
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed2.get(), equalTo("un"));
@@ -975,7 +975,7 @@ public class XAStoreTest {
     {
       Store.ValueHolder<String> computed = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("un"));
+        assertThat(s.get(), equalTo("un"));
         return "eins";
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed.get(), equalTo("eins"));
@@ -988,7 +988,7 @@ public class XAStoreTest {
     {
       Store.ValueHolder<String> computed = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("eins"));
+        assertThat(s.get(), equalTo("eins"));
         return null;
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed, is(nullValue()));
@@ -1001,7 +1001,7 @@ public class XAStoreTest {
     {
       Store.ValueHolder<String> computed1 = xaStore.computeAndGet(1L, (aLong, s) -> {
         assertThat(aLong, is(1L));
-        assertThat(s, equalTo("eins"));
+        assertThat(s.get(), equalTo("eins"));
         return null;
       }, SUPPLY_TRUE, SUPPLY_FALSE);
       assertThat(computed1, is(nullValue()));
@@ -1295,9 +1295,9 @@ public class XAStoreTest {
     {
       Map<Long, Store.ValueHolder<String>> computedMap = xaStore.bulkCompute(asSet(1L, 2L, 3L), entries -> {
         Map<Long, String> result = new HashMap<>();
-        for (Map.Entry<? extends Long, ? extends String> entry : entries) {
+        for (Map.Entry<? extends Long, ? extends Store.ValueHolder<String>> entry : entries) {
           Long key = entry.getKey();
-          String value = entry.getValue();
+          Store.ValueHolder<String> value = entry.getValue();
           assertThat(value, is(nullValue()));
           result.put(key, "stuff#" + key);
         }
@@ -1311,9 +1311,9 @@ public class XAStoreTest {
 
       computedMap = xaStore.bulkCompute(asSet(0L, 1L, 3L), entries -> {
         Map<Long, String> result = new HashMap<>();
-        for (Map.Entry<? extends Long, ? extends String> entry : entries) {
+        for (Map.Entry<? extends Long, ? extends Store.ValueHolder<String>> entry : entries) {
           Long key = entry.getKey();
-          String value = entry.getValue();
+          Store.ValueHolder<String> value = entry.getValue();
 
           switch (key.intValue()) {
             case 0:
@@ -1321,7 +1321,7 @@ public class XAStoreTest {
               break;
             case 1:
             case 3:
-              assertThat(value, equalTo("stuff#" + key));
+              assertThat(value.get(), equalTo("stuff#" + key));
               break;
           }
 

--- a/ehcache-transactions/src/test/java/org/ehcache/transactions/xa/internal/XATransactionContextTest.java
+++ b/ehcache-transactions/src/test/java/org/ehcache/transactions/xa/internal/XATransactionContextTest.java
@@ -86,7 +86,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), is(nullValue()));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
 
     xaTransactionContext.addCommand(1L, new StorePutCommand<>("old", new XAValueHolder<>("new", timeSource.getTimeMillis())));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -95,7 +94,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), equalTo("new"));
 
     xaTransactionContext.addCommand(1L, new StoreRemoveCommand<>("old"));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -104,7 +102,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
 
     xaTransactionContext.addCommand(1L, new StoreEvictCommand<>("old"));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -113,7 +110,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(true));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
   }
 
   @Test
@@ -126,7 +122,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), equalTo("new"));
 
     xaTransactionContext.addCommand(1L, new StoreRemoveCommand<>("old"));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -135,7 +130,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
 
     xaTransactionContext.addCommand(1L, new StoreRemoveCommand<>("old2"));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -144,7 +138,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old2"));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
 
     xaTransactionContext.addCommand(1L, new StorePutCommand<>("old2", new XAValueHolder<>("new2", timeSource.getTimeMillis())));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -153,7 +146,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new2"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old2"));
-    assertThat(xaTransactionContext.newValueOf(1L), equalTo("new2"));
   }
 
   @Test
@@ -167,7 +159,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(false));
     assertThat(xaTransactionContext.newValueHolderOf(1L).get(), equalTo("new"));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), equalTo("new"));
 
     xaTransactionContext.addCommand(1L, new StoreEvictCommand<>("old"));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -176,7 +167,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(true));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
 
     xaTransactionContext.addCommand(1L, new StorePutCommand<>("old2", new XAValueHolder<>("new2", timeSource.getTimeMillis())));
     assertThat(xaTransactionContext.touched(1L), is(true));
@@ -185,7 +175,6 @@ public class XATransactionContextTest {
     assertThat(xaTransactionContext.evicted(1L), is(true));
     assertThat(xaTransactionContext.newValueHolderOf(1L), is(nullValue()));
     assertThat(xaTransactionContext.oldValueOf(1L), equalTo("old"));
-    assertThat(xaTransactionContext.newValueOf(1L), is(nullValue()));
   }
 
   @Test

--- a/integration-test/src/test/java/org/ehcache/integration/DeserializationOnRemovalTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/DeserializationOnRemovalTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.integration;
+
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.ResourcePools;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.core.internal.resilience.ThrowingResilienceStrategy;
+import org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration;
+import org.ehcache.impl.serialization.PlainJavaSerializer;
+import org.ehcache.spi.serialization.SerializerException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.terracotta.org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.util.Collections.singleton;
+import static org.ehcache.config.builders.CacheConfigurationBuilder.newCacheConfigurationBuilder;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.newResourcePoolsBuilder;
+import static org.ehcache.config.units.EntryUnit.ENTRIES;
+import static org.ehcache.config.units.MemoryUnit.MB;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@RunWith(Parameterized.class)
+public class DeserializationOnRemovalTest {
+
+  @Rule
+  public final TemporaryFolder folder = new TemporaryFolder();
+
+  private final ResourcePools resources;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+      //1 tier
+      { newResourcePoolsBuilder().offheap(1, MB) },
+      { newResourcePoolsBuilder().disk(1, MB) },
+
+      //2 tiers
+      { newResourcePoolsBuilder().heap(1, MB).offheap(2, MB) },
+      { newResourcePoolsBuilder().heap(1, ENTRIES).offheap(2, MB) },
+      { newResourcePoolsBuilder().heap(1, MB).disk(2, MB) },
+      { newResourcePoolsBuilder().heap(1, ENTRIES).disk(2, MB) },
+
+      //3 tiers
+      { newResourcePoolsBuilder().heap(1, MB).offheap(2, MB).disk(3, MB) },
+      { newResourcePoolsBuilder().heap(1, ENTRIES).offheap(2, MB).disk(3, MB) }
+    });
+  }
+
+  public DeserializationOnRemovalTest(ResourcePoolsBuilder poolBuilder) {
+    this.resources = poolBuilder.build();
+  }
+
+  @Test
+  public void testForDeserializationOnRemove() throws IOException {
+    try (CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
+      .with(new CacheManagerPersistenceConfiguration(folder.newFolder()))
+      .withCache("test-cache", newCacheConfigurationBuilder(Long.class, String.class, resources)
+        .withResilienceStrategy(new ThrowingResilienceStrategy<>())
+        .withValueSerializer(new PlainJavaSerializer<String>(DeserializationOnRemovalTest.class.getClassLoader()) {
+          @Override
+          public String read(ByteBuffer entry) throws SerializerException {
+            throw new AssertionError("No deserialization allowed");
+          }
+        })).build(true)) {
+
+      Cache<Long, String> cache = manager.getCache("test-cache", Long.class, String.class);
+
+      cache.put(1L, "one");
+      cache.remove(1L);
+
+      assertThat(cache.get(1L), is(nullValue()));
+    }
+  }
+
+  @Test
+  public void testForDeserializationOnRemoveAll() throws IOException {
+    try (CacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
+      .with(new CacheManagerPersistenceConfiguration(folder.newFolder()))
+      .withCache("test-cache", newCacheConfigurationBuilder(Long.class, String.class, resources)
+        .withResilienceStrategy(new ThrowingResilienceStrategy<>())
+        .withValueSerializer(new PlainJavaSerializer<String>(DeserializationOnRemovalTest.class.getClassLoader()) {
+          @Override
+          public String read(ByteBuffer entry) throws SerializerException {
+            throw new AssertionError("No deserialization allowed");
+          }
+        })).build(true)) {
+
+      Cache<Long, String> cache = manager.getCache("test-cache", Long.class, String.class);
+
+      cache.put(1L, "one");
+      cache.removeAll(singleton(1L));
+
+      assertThat(cache.get(1L), is(nullValue()));
+    }
+
+  }
+
+
+}

--- a/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/EhcacheBulkMethodsITest.java
@@ -536,7 +536,7 @@ public class EhcacheBulkMethodsITest {
       final Copier defaultCopier = new IdentityCopier();
       return new OnHeapStore<K, V>(storeConfig, SystemTimeSource.INSTANCE, defaultCopier, defaultCopier,  new NoopSizeOfEngine(), NullStoreEventDispatcher.<K, V>nullStoreEventDispatcher(), new DefaultStatisticsService()) {
         @Override
-        public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends V>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
+        public Map<K, ValueHolder<V>> bulkCompute(Set<? extends K> keys, Function<Iterable<? extends Map.Entry<? extends K, ? extends ValueHolder<V>>>, Iterable<? extends Map.Entry<? extends K, ? extends V>>> remappingFunction) throws StoreAccessException {
           throw new StoreAccessException("Problem trying to bulk compute");
         }
 


### PR DESCRIPTION
This is a draft PR of a proof-of-concept that eliminates value deserialization from the removeAll call (and maybe some other things). There are two things that make this only a PoC:

1. The code is ugly and could do with a bunch of cleanup/rationalization.
2. I made no attempt to confirm that any "moved" deserialization happens safely when deserializing data pulled from offheap/disk. If we delay these deserializations too much then we may pull them outside of the relevant lock scope without taking defensive copies of the data. This could (or more likely would) lead to corruption under heavy multi-threaded access that may not be detected by the tests.

Before this is merged someone needs to go over this code to assess its safety on these dimensions (and cleanup up the general dogs dinner I left behind during my hacking).