### PR TITLE
Switch to gradle nexus publish plugin (Daggy master)

### DIFF
--- a/build-logic/src/main/java/org/ehcache/build/conventions/DeployConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/DeployConvention.java
@@ -80,23 +80,6 @@ public class DeployConvention implements Plugin<Project> {
           dev.getOrganizationUrl().set("http://ehcache.org");
         }));
       }));
-      publishing.repositories(repositories -> repositories.maven(maven -> {
-        if (IS_RELEASE.test(project)) {
-          maven.setUrl(project.property("deployUrl"));
-          maven.credentials(creds -> {
-            creds.setUsername(project.property("deployUser").toString());
-            creds.setPassword(project.property("deployPwd").toString());
-          });
-          maven.setAllowInsecureProtocol(true);
-        } else {
-          maven.setName("sonatype-nexus-snapshot");
-          maven.setUrl("https://oss.sonatype.org/content/repositories/snapshots");
-          maven.credentials(creds -> {
-            creds.setUsername(project.property("sonatypeUser").toString());
-            creds.setPassword(project.property("sonatypePwd").toString());
-          });
-        }
-      }));
     });
 
     project.getExtensions().configure(SigningExtension.class, signing -> {

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@
 
 plugins {
   // This adds tasks to auto close or release nexus staging repos
-  // see https://github.com/Codearte/gradle-nexus-staging-plugin/
-  id 'io.codearte.nexus-staging'
+  // see https://github.com/gradle-nexus/publish-plugin
+  id 'io.github.gradle-nexus.publish-plugin'
   //OWASP Security Vulnerability Detection
   id 'org.owasp.dependencycheck'
 }
@@ -30,38 +30,26 @@ allprojects {
   version = findProperty('overrideVersion') ?: ehcacheVersion
 }
 
-if (deployUrl.contains('nexus')) {
-  //internal terracotta config, shorten url for this plugin to end at local/
-  project.nexusStaging {
-    serverUrl = deployUrl.replaceAll(~/local\/.*$/, "local/")
-    packageGroup = 'Ehcache OS' //internal staging repository name
+nexusPublishing {
+  repositories {
+    sonatype {
+      username = sonatypeUser
+      password = sonatypePwd
+      packageGroup = 'org.ehcache' //Sonatype staging repository name
+    }
+    nexus {
+      username = tcDeployUser
+      password = tcDeployPassword
+      packageGroup = 'Ehcache OS' //internal staging repository name
+      nexusUrl.set(uri('https://nexus.terracotta.eur.ad.sag:8443/service/local/'))
+      snapshotRepositoryUrl.set(uri("https://nexus.terracotta.eur.ad.sag:8443/content/repositories/terracotta-os-snapshots/"))
+    }
   }
-  ext {
-    deployUser = tcDeployUser
-    deployPwd = tcDeployPassword
-  }
-} else {
-  project.nexusStaging {
-    packageGroup = 'org.ehcache' //Sonatype staging repository name
-  }
-  ext {
-    deployUser = sonatypeUser
-    deployPwd = sonatypePwd
-  }
-}
-
-nexusStaging {
-  username = project.ext.deployUser
-  password = project.ext.deployPwd
-  logger.debug("Nexus Staging: Using login ${username} and url ${serverUrl}")
   // Sonatype is often very slow in these operations:
-  delayBetweenRetriesInMillis = (findProperty('delayBetweenRetriesInMillis') ?: '10000') as int
-  numberOfRetries = (findProperty('numberOfRetries') ?: '100') as int
-}
-
-tasks.named('closeAndReleaseRepository') {
-  // Disable automatic promotion for added safety
-  enabled = false;
+  transitionCheckOptions {
+    delayBetween = Duration.ofSeconds((findProperty('delayBetweenRetriesInSeconds') ?: '10') as int)
+    maxRetries = (findProperty('numberOfRetries') ?: '100') as int
+  }
 }
 
 assert (JavaVersion.current().isJava8Compatible()) : 'The Ehcache 3 build requires Java 8+ to run'

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,8 @@ jcacheTckVersion = 1.1.0
 
 sonatypeUser = OVERRIDE_ME
 sonatypePwd = OVERRIDE_ME
+tcDeployUser = OVERRIDE_ME
+tcDeployPassword = OVERRIDE_ME
 
 deployUrl = https://oss.sonatype.org/service/local/staging/deploy/maven2/
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 pluginManagement {
   plugins {
-    id 'io.codearte.nexus-staging' version '0.30.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
     id 'org.owasp.dependencycheck' version '7.1.0.1'
     id 'org.gretty' version '3.0.6'
     id 'org.asciidoctor.jvm.base' version '3.3.2'


### PR DESCRIPTION
Old plugin is no longer supported and new one *should* work better.

Removed convention code that is hopefully unnecessary.

* [ ] Update releaser jobs to use new tasks (`closeAndReleaseSonatypeStagingRepository`, `closeAndReleaseNexusStagingRepository`)