### PR TITLE
Remove unused credential references

### DIFF
--- a/buildSrc/src/main/groovy/EhDeploy.groovy
+++ b/buildSrc/src/main/groovy/EhDeploy.groovy
@@ -72,16 +72,6 @@ class EhDeploy implements Plugin<Project> {
       repositories {
         mavenDeployer ({
           beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment)}
-
-          if (project.isReleaseVersion) {
-            repository(url: project.deployUrl) {
-              authentication(userName: project.deployUser, password: project.deployPwd)
-            }
-          } else {
-            repository(id: 'sonatype-nexus-snapshot', url: 'https://oss.sonatype.org/content/repositories/snapshots') {
-              authentication(userName: project.sonatypeUser, password: project.sonatypePwd)
-            }
-          }
         } << artifactFiltering)
       }
     }

--- a/buildSrc/src/main/groovy/EhPomMangle.groovy
+++ b/buildSrc/src/main/groovy/EhPomMangle.groovy
@@ -79,16 +79,6 @@ class EhPomMangle implements Plugin<Project> {
       repositories {
         mavenDeployer ({
           beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment)}
-
-          if (project.isReleaseVersion) {
-            repository(url: project.deployUrl) {
-              authentication(userName: project.deployUser, password: project.deployPwd)
-            }
-          } else {
-            repository(id: 'sonatype-nexus-snapshot', url: 'https://oss.sonatype.org/content/repositories/snapshots') {
-              authentication(userName: project.sonatypeUser, password: project.sonatypePwd)
-            }
-          }
         } << artifactFiltering)
       }
     }


### PR DESCRIPTION
Currently releasing does not work in 3.9.   

This PR fixes the  credential error, but Nexus staging repo validation still fails (3.9 seems not to publish source or javadoc).