### PR TITLE
Revert upgrade to nexus-publish plugin 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ import org.gradle.internal.jvm.Jvm
 
 plugins {
   // This adds tasks to auto close or release nexus staging repos
-  // see https://github.com/gradle-nexus/publish-plugin
-  id 'io.github.gradle-nexus.publish-plugin'
+  // see https://github.com/Codearte/gradle-nexus-staging-plugin/
+  id 'io.codearte.nexus-staging'
   //OWASP Security Vulnerability Detection
   id 'org.owasp.dependencycheck'
   // Declare spotbugs at the top
@@ -32,27 +32,38 @@ wrapper {
   distributionType = Wrapper.DistributionType.ALL
 }
 
-nexusPublishing {
-  repositories {
-    sonatype {
-      username = sonatypeUser
-      password = sonatypePwd
-      packageGroup = 'org.ehcache' //Sonatype staging repository name
-    }
-    nexus {
-      username = tcDeployUser
-      password = tcDeployPassword
-      packageGroup = 'Ehcache OS' //internal staging repository name
-      nexusUrl.set(uri('https://nexus.terracotta.eur.ad.sag:8443/service/local/'))
-      snapshotRepositoryUrl.set(uri("https://nexus.terracotta.eur.ad.sag:8443/content/repositories/terracotta-os-snapshots/"))
-    }
+if (deployUrl.contains('nexus')) {
+  //internal terracotta config, shorten url for this plugin to end at local/
+  project.nexusStaging {
+    serverUrl = deployUrl.replaceAll(~/local\/.*$/, "local/")
+    packageGroup = 'Ehcache OS' //internal staging repository name
   }
-  // Sonatype is often very slow in these operations:
-  transitionCheckOptions {
-    delayBetween = Duration.ofSeconds((findProperty('delayBetweenRetriesInSeconds') ?: '10') as int)
-    maxRetries = (findProperty('numberOfRetries') ?: '100') as int
+  ext {
+    deployUser = tcDeployUser
+    deployPwd = tcDeployPassword
+  }
+} else {
+  project.nexusStaging {
+    packageGroup = 'org.ehcache' //Sonatype staging repository name
+  }
+  ext {
+    deployUser = sonatypeUser
+    deployPwd = sonatypePwd
   }
 }
+
+project.nexusStaging {
+  username = project.ext.deployUser
+  password = project.ext.deployPwd
+  logger.debug("Nexus Staging: Using login ${username} and url ${serverUrl}")
+  // Sonatype is often very slow in these operations:
+  delayBetweenRetriesInMillis = (findProperty('delayBetweenRetriesInMillis') ?: '10000') as int
+  numberOfRetries = (findProperty('numberOfRetries') ?: '100') as int
+}
+
+// Disable automatic promotion for added safety
+closeAndReleaseRepository.enabled = false
+
 
 ext {
 

--- a/buildSrc/src/main/groovy/EhDeploy.groovy
+++ b/buildSrc/src/main/groovy/EhDeploy.groovy
@@ -75,7 +75,7 @@ class EhDeploy implements Plugin<Project> {
 
           if (project.isReleaseVersion) {
             repository(url: project.deployUrl) {
-              authentication(userName: project.tcDeployUser, password: project.tcDeployPassword)
+              authentication(userName: project.deployUser, password: project.deployPwd)
             }
           } else {
             repository(id: 'sonatype-nexus-snapshot', url: 'https://oss.sonatype.org/content/repositories/snapshots') {

--- a/buildSrc/src/main/groovy/EhPomMangle.groovy
+++ b/buildSrc/src/main/groovy/EhPomMangle.groovy
@@ -82,7 +82,7 @@ class EhPomMangle implements Plugin<Project> {
 
           if (project.isReleaseVersion) {
             repository(url: project.deployUrl) {
-              authentication(userName: project.tcDeployUser, password: project.tcDeployPassword)
+              authentication(userName: project.deployUser, password: project.deployPwd)
             }
           } else {
             repository(id: 'sonatype-nexus-snapshot', url: 'https://oss.sonatype.org/content/repositories/snapshots') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,6 @@ jacocoVersion = 0.8.5
 
 sonatypeUser = OVERRIDE_ME
 sonatypePwd = OVERRIDE_ME
-tcDeployUser = OVERRIDE_ME
-tcDeployPassword = OVERRIDE_ME
 
 deployUrl = https://oss.sonatype.org/service/local/staging/deploy/maven2/
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 pluginManagement {
   plugins {
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
+    id 'io.codearte.nexus-staging' version '0.21.1'
     id 'com.github.spotbugs' version '4.2.3'
     id 'org.jayware.osgi-ds' version '0.5.6'
     id 'org.owasp.dependencycheck' version '5.2.4'


### PR DESCRIPTION
gradle 6 stuff in ehcache3 isn't currently fully compatible, this will have to wait until that's fixed.