### PR TITLE
Fixes #3169 : Avoid firing unneeded Events

### DIFF
--- a/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
+++ b/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/store/ClusteredStore.java
@@ -1016,6 +1016,12 @@ public class ClusteredStore<K, V> extends BaseStore<K, V> implements Authoritati
       }
       delegate.removeEventListener(eventListener);
     }
+
+    @Override
+    public void listenerModified() {
+      delegate.listenerModified();
+    }
+
     @Override
     public void addEventFilter(StoreEventFilter<K, V> eventFilter) {
       delegate.addEventFilter(eventFilter);

--- a/ehcache-api/src/main/java/org/ehcache/event/EventType.java
+++ b/ehcache-api/src/main/java/org/ehcache/event/EventType.java
@@ -16,6 +16,9 @@
 
 package org.ehcache.event;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * The different event types.
  */
@@ -44,6 +47,11 @@ public enum EventType {
   /**
    * Represents an existing {@link org.ehcache.Cache.Entry cache entry} being updated for a given key
    */
-  UPDATED,
+  UPDATED;
 
+  private static final Set<EventType> ALL_EVENT_TYPES = EnumSet.allOf(EventType.class);
+
+  public static Set<EventType> allAsSet() {
+    return ALL_EVENT_TYPES;
+  }
 }

--- a/ehcache-core/src/main/java/org/ehcache/core/events/EventListenerWrapper.java
+++ b/ehcache-core/src/main/java/org/ehcache/core/events/EventListenerWrapper.java
@@ -23,6 +23,7 @@ import org.ehcache.event.EventOrdering;
 import org.ehcache.event.EventType;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Internal wrapper for {@link CacheEventListener} and their configuration.
@@ -86,8 +87,8 @@ public final class EventListenerWrapper<K, V> implements CacheEventListener<K, V
     return listener;
   }
 
-  public boolean isForEventType(EventType type) {
-    return forEvents.contains(type);
+  public Set<EventType> getEventTypes() {
+    return forEvents;
   }
 
   public boolean isOrdered() {

--- a/ehcache-core/src/main/java/org/ehcache/core/events/NullStoreEventDispatcher.java
+++ b/ehcache-core/src/main/java/org/ehcache/core/events/NullStoreEventDispatcher.java
@@ -88,6 +88,11 @@ public class NullStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
   }
 
   @Override
+  public void listenerModified() {
+    // Do nothing
+  }
+
+  @Override
   public void addEventFilter(StoreEventFilter<K, V> eventFilter) {
     // Do nothing
   }

--- a/ehcache-core/src/main/java/org/ehcache/core/spi/store/events/StoreEventListener.java
+++ b/ehcache-core/src/main/java/org/ehcache/core/spi/store/events/StoreEventListener.java
@@ -16,7 +16,10 @@
 
 package org.ehcache.core.spi.store.events;
 
+import java.util.Set;
+
 import org.ehcache.core.events.StoreEventDispatcher;
+import org.ehcache.event.EventType;
 
 /**
  * Interface used to register on a {@link StoreEventSource} to get notified of events happening to mappings the
@@ -36,4 +39,15 @@ public interface StoreEventListener<K, V> {
    * @param event the actual {@link StoreEvent}
    */
   void onEvent(StoreEvent<K, V> event);
+
+  /**
+   * Specify which Events this Listener is handling.
+   * <p>
+   * Defaults return is all values of {@link EventType}
+   *
+   * @return Set of the {@link EventType} this listener handles.
+   */
+  default Set<EventType> getEventTypes() {
+    return EventType.allAsSet();
+  }
 }

--- a/ehcache-core/src/main/java/org/ehcache/core/spi/store/events/StoreEventSource.java
+++ b/ehcache-core/src/main/java/org/ehcache/core/spi/store/events/StoreEventSource.java
@@ -58,4 +58,9 @@ public interface StoreEventSource<K, V> {
    * @return {@code true} if ordering is on, {@code false} otherwise
    */
   boolean isEventOrdering();
+
+  /**
+   * Indicates that a listener was modified
+   */
+  void listenerModified();
 }

--- a/ehcache-impl/src/main/java/org/ehcache/impl/events/CacheEventDispatcherImpl.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/events/CacheEventDispatcherImpl.java
@@ -34,11 +34,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.Stream;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.EnumSet.allOf;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Stream.concat;
 
 /**
  * Per-cache component that manages cache event listener registrations, and provides event delivery based on desired
@@ -55,10 +65,12 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
   private static final Logger LOGGER = LoggerFactory.getLogger(CacheEventDispatcherImpl.class);
   private final ExecutorService unOrderedExectuor;
   private final ExecutorService orderedExecutor;
-  private int listenersCount = 0;
-  private int orderedListenerCount = 0;
-  private final List<EventListenerWrapper<K, V>> syncListenersList = new CopyOnWriteArrayList<>();
-  private final List<EventListenerWrapper<K, V>> aSyncListenersList = new CopyOnWriteArrayList<>();
+
+  private final Map<EventType, List<EventListenerWrapper<K, V>>> syncListenersList = unmodifiableMap(allOf(EventType.class).stream()
+    .collect(toMap(identity(), t -> new CopyOnWriteArrayList<>(), (a, b) -> { throw new AssertionError(); }, () -> new EnumMap<>(EventType.class))));
+  private final Map<EventType, List<EventListenerWrapper<K, V>>> asyncListenersList = unmodifiableMap(allOf(EventType.class).stream()
+    .collect(toMap(identity(), t -> new CopyOnWriteArrayList<>(), (a, b) -> { throw new AssertionError(); }, () -> new EnumMap<>(EventType.class))));
+
   private final StoreEventListener<K, V> eventListener = new StoreListener();
 
   private volatile Cache<K, V> listenerSource;
@@ -94,69 +106,76 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
    * @param wrapper the listener wrapper to register
    */
   private synchronized void registerCacheEventListener(EventListenerWrapper<K, V> wrapper) {
-    if(aSyncListenersList.contains(wrapper) || syncListenersList.contains(wrapper)) {
+
+    if(allListeners().anyMatch(wrapper::equals)) {
       throw new IllegalStateException("Cache Event Listener already registered: " + wrapper.getListener());
     }
 
-    if (wrapper.isOrdered() && orderedListenerCount++ == 0) {
+    boolean firstListener = !allListeners().findAny().isPresent();
+
+    if (wrapper.isOrdered() && (firstListener || allListeners().noneMatch(EventListenerWrapper::isOrdered))) {
       storeEventSource.setEventOrdering(true);
     }
 
     switch (wrapper.getFiringMode()) {
       case ASYNCHRONOUS:
-        aSyncListenersList.add(wrapper);
+        wrapper.getEventTypes().forEach(type -> asyncListenersList.get(type).add(wrapper));
         break;
       case SYNCHRONOUS:
-        if (syncListenersList.isEmpty()) {
+        if (!syncListeners().findAny().isPresent()) {
           storeEventSource.setSynchronous(true);
         }
-        syncListenersList.add(wrapper);
+        wrapper.getEventTypes().forEach(type -> syncListenersList.get(type).add(wrapper));
         break;
       default:
         throw new AssertionError("Unhandled EventFiring value: " + wrapper.getFiringMode());
     }
 
-    if (listenersCount++ == 0) {
+    if (firstListener) {
       storeEventSource.addEventListener(eventListener);
     }
+  }
+
+  private Stream<EventListenerWrapper<K, V>> allListeners() {
+    return concat(asyncListeners(), syncListeners());
+  }
+
+  private Stream<EventListenerWrapper<K, V>> syncListeners() {
+    return syncListenersList.values().stream().flatMap(Collection::stream);
+  }
+
+  private Stream<EventListenerWrapper<K, V>> asyncListeners() {
+    return asyncListenersList.values().stream().flatMap(Collection::stream);
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public void deregisterCacheEventListener(CacheEventListener<? super K, ? super V> listener) {
+  public synchronized  void deregisterCacheEventListener(CacheEventListener<? super K, ? super V> listener) {
     EventListenerWrapper<K, V> wrapper = new EventListenerWrapper<>(listener);
 
-    if (!removeWrapperFromList(wrapper, aSyncListenersList)) {
-      if (!removeWrapperFromList(wrapper, syncListenersList)) {
-        throw new IllegalStateException("Unknown cache event listener: " + listener);
-      }
-    }
-  }
+    boolean removed = Stream.of(asyncListenersList, syncListenersList)
+      .flatMap(list -> list.values().stream())
+      .map(list -> list.remove(wrapper))
+      .reduce((a, b) -> a || b).orElse(false);
 
-  /**
-   * Synchronized to make sure listener removal is atomic
-   *
-   * @param wrapper the listener wrapper to unregister
-   * @param listenersList the listener list to remove from
-   */
-  private synchronized boolean removeWrapperFromList(EventListenerWrapper<K, V> wrapper, List<EventListenerWrapper<K, V>> listenersList) {
-    int index = listenersList.indexOf(wrapper);
-    if (index != -1) {
-      EventListenerWrapper<K, V> containedWrapper = listenersList.remove(index);
-      if(containedWrapper.isOrdered() && --orderedListenerCount == 0) {
+    if (!removed) {
+      throw new IllegalStateException("Unknown cache event listener: " + listener);
+    }
+
+    if (!allListeners().findAny().isPresent()) {
+      storeEventSource.setSynchronous(false);
+      storeEventSource.setEventOrdering(false);
+      storeEventSource.removeEventListener(eventListener);
+    } else {
+      if (allListeners().noneMatch(EventListenerWrapper::isOrdered)) {
         storeEventSource.setEventOrdering(false);
       }
-      if (--listenersCount == 0) {
-        storeEventSource.removeEventListener(eventListener);
-      }
-      if (syncListenersList.isEmpty()) {
+      if (!syncListeners().findAny().isPresent()) {
         storeEventSource.setSynchronous(false);
       }
-      return true;
     }
-    return false;
   }
 
   /**
@@ -167,8 +186,8 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
     storeEventSource.removeEventListener(eventListener);
     storeEventSource.setEventOrdering(false);
     storeEventSource.setSynchronous(false);
-    syncListenersList.clear();
-    aSyncListenersList.clear();
+    syncListenersList.values().forEach(Collection::clear);
+    asyncListenersList.values().forEach(Collection::clear);
     unOrderedExectuor.shutdown();
     orderedExecutor.shutdown();
   }
@@ -188,11 +207,13 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
     } else {
       executor = unOrderedExectuor;
     }
-    if (!aSyncListenersList.isEmpty()) {
-      executor.submit(new EventDispatchTask<>(event, aSyncListenersList));
+    List<EventListenerWrapper<K, V>> asyncTargets = asyncListenersList.get(event.getType());
+    if (!asyncTargets.isEmpty()) {
+      executor.submit(new EventDispatchTask<>(event, asyncTargets));
     }
-    if (!syncListenersList.isEmpty()) {
-      Future<?> future = executor.submit(new EventDispatchTask<>(event, syncListenersList));
+    List<EventListenerWrapper<K, V>> syncTargets = syncListenersList.get(event.getType());
+    if (!syncTargets.isEmpty()) {
+      Future<?> future = executor.submit(new EventDispatchTask<>(event, syncTargets));
       try {
         future.get();
       } catch (Exception e) {

--- a/ehcache-impl/src/main/java/org/ehcache/impl/events/CacheEventDispatcherImpl.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/events/CacheEventDispatcherImpl.java
@@ -119,7 +119,7 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
       storeEventSource.setEventOrdering(true);
     }
 
-    registeredEventTypes.addAll(wrapper.getEventTypes()); // add EventType of new wrapper to list or relevant EntryTypes
+    registeredEventTypes.addAll(wrapper.getEventTypes()); // add EventType of new wrapper to list of relevant EntryTypes
 
     switch (wrapper.getFiringMode()) {
       case ASYNCHRONOUS:

--- a/ehcache-impl/src/main/java/org/ehcache/impl/events/CacheEventDispatcherImpl.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/events/CacheEventDispatcherImpl.java
@@ -217,23 +217,30 @@ public class CacheEventDispatcherImpl<K, V> implements CacheEventDispatcher<K, V
   }
 
   void onEvent(CacheEvent<K, V> event) {
-    ExecutorService executor;
-    if (storeEventSource.isEventOrdering()) {
-      executor = orderedExecutor;
-    } else {
-      executor = unOrderedExectuor;
-    }
     List<EventListenerWrapper<K, V>> asyncTargets = asyncListenersList.get(event.getType());
-    if (!asyncTargets.isEmpty()) {
-      executor.submit(new EventDispatchTask<>(event, asyncTargets));
-    }
     List<EventListenerWrapper<K, V>> syncTargets = syncListenersList.get(event.getType());
-    if (!syncTargets.isEmpty()) {
-      Future<?> future = executor.submit(new EventDispatchTask<>(event, syncTargets));
-      try {
-        future.get();
-      } catch (Exception e) {
-        LOGGER.error("Exception received as result from synchronous listeners", e);
+    if (storeEventSource.isEventOrdering()) {
+      if (!asyncTargets.isEmpty()) {
+        orderedExecutor.submit(new EventDispatchTask<>(event, asyncTargets));
+      }
+      if (!syncTargets.isEmpty()) {
+        Future<?> future = orderedExecutor.submit(new EventDispatchTask<>(event, syncTargets));
+        try {
+          future.get();
+        } catch (Exception e) {
+          LOGGER.error("Exception received as result from synchronous listeners", e);
+        }
+      }
+    } else {
+      if (!asyncTargets.isEmpty()) {
+        unOrderedExectuor.submit(new EventDispatchTask<>(event, asyncTargets));
+      }
+      if (!syncTargets.isEmpty()) {
+        try {
+          new EventDispatchTask<>(event, syncTargets).run();
+        } catch (Exception e) {
+          LOGGER.error("Exception received as result from synchronous listeners", e);
+        }
       }
     }
   }

--- a/ehcache-impl/src/main/java/org/ehcache/impl/events/EventDispatchTask.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/events/EventDispatchTask.java
@@ -40,12 +40,10 @@ class EventDispatchTask<K, V> implements Runnable {
   @Override
   public void run() {
     for(EventListenerWrapper<K, V> listenerWrapper : listenerWrappers) {
-      if (listenerWrapper.isForEventType(cacheEvent.getType())) {
-        try {
-          listenerWrapper.onEvent(cacheEvent);
-        } catch (Exception e) {
-          LOGGER.warn(listenerWrapper.getListener() + " Failed to fire Event due to ", e);
-        }
+      try {
+        listenerWrapper.onEvent(cacheEvent);
+      } catch (Exception e) {
+        LOGGER.warn(listenerWrapper.getListener() + " Failed to fire Event due to ", e);
       }
     }
   }

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/events/AbstractStoreEventDispatcher.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/events/AbstractStoreEventDispatcher.java
@@ -20,7 +20,9 @@ import org.ehcache.core.events.StoreEventDispatcher;
 import org.ehcache.core.events.StoreEventSink;
 import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
+import org.ehcache.event.EventType;
 
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -77,6 +79,7 @@ public abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDi
   private final Set<StoreEventFilter<K, V>> filters = new CopyOnWriteArraySet<>();
   private final Set<StoreEventListener<K, V>> listeners = new CopyOnWriteArraySet<>();
   private final BlockingQueue<FireableStoreEventHolder<K, V>>[] orderedQueues;
+  private final Set<EventType> relevantEventTypes = EnumSet.noneOf(EventType.class);
   private volatile boolean ordered = false;
 
   protected AbstractStoreEventDispatcher(int dispatcherConcurrency) {
@@ -92,6 +95,16 @@ public abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDi
     }
   }
 
+  private void computeRelevantEventTypes() {
+    // collect all EventTypes the listeners are interested in.
+    for (StoreEventListener<K, V> listener : listeners) {
+      relevantEventTypes.addAll(listener.getEventTypes());
+    }
+    if (relevantEventTypes.isEmpty()) { // mocks are empty -> handle all types
+      relevantEventTypes.addAll(EnumSet.allOf(EventType.class));
+    }
+  }
+
   protected Set<StoreEventListener<K, V>> getListeners() {
     return listeners;
   }
@@ -104,14 +117,25 @@ public abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDi
     return orderedQueues;
   }
 
+  protected Set<EventType> getRelevantEventTypes() {
+    return relevantEventTypes;
+  }
+
   @Override
   public void addEventListener(StoreEventListener<K, V> eventListener) {
     listeners.add(eventListener);
+    computeRelevantEventTypes(); // refresh
   }
 
   @Override
   public void removeEventListener(StoreEventListener<K, V> eventListener) {
     listeners.remove(eventListener);
+    computeRelevantEventTypes(); // refresh
+  }
+
+  @Override
+  public void listenerModified() {
+    computeRelevantEventTypes(); // refresh
   }
 
   @Override
@@ -151,6 +175,6 @@ public abstract class AbstractStoreEventDispatcher<K, V> implements StoreEventDi
 
   @Override
   public StoreEventSink<K, V> eventSink() {
-    return new InvocationScopedEventSink<>(getFilters(), isEventOrdering(), getOrderedQueues(), getListeners());
+    return new InvocationScopedEventSink<>(getFilters(), isEventOrdering(), getOrderedQueues(), getListeners(), getRelevantEventTypes());
   }
 }

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSink.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSink.java
@@ -40,8 +40,9 @@ class FudgingInvocationScopedEventSink<K, V> extends InvocationScopedEventSink<K
 
   FudgingInvocationScopedEventSink(Set<StoreEventFilter<K, V>> filters, boolean ordered,
                                    BlockingQueue<FireableStoreEventHolder<K, V>>[] orderedQueues,
-                                   Set<StoreEventListener<K, V>> listeners) {
-    super(filters, ordered, orderedQueues, listeners);
+                                   Set<StoreEventListener<K, V>> listeners,
+                                   Set<EventType> relevantEventTypes) {
+    super(filters, ordered, orderedQueues, listeners, relevantEventTypes);
   }
 
   @Override

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/events/ThreadLocalStoreEventDispatcher.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/events/ThreadLocalStoreEventDispatcher.java
@@ -39,7 +39,7 @@ public class ThreadLocalStoreEventDispatcher<K, V> extends AbstractStoreEventDis
     } else {
       StoreEventSink<K, V> eventSink = tlEventSink.get();
       if (eventSink == null) {
-        eventSink = new FudgingInvocationScopedEventSink<>(getFilters(), isEventOrdering(), getOrderedQueues(), getListeners());
+        eventSink = new FudgingInvocationScopedEventSink<>(getFilters(), isEventOrdering(), getOrderedQueues(), getListeners(), getRelevantEventTypes());
         tlEventSink.set(eventSink);
         usageDepth.set(0);
       } else {

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/basic/NopStore.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/basic/NopStore.java
@@ -144,6 +144,10 @@ public class NopStore<K, V> implements AuthoritativeTier<K, V> {
       public boolean isEventOrdering() {
         return false;
       }
+
+      @Override
+      public void listenerModified() {
+      }
     };
   }
 

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
@@ -16,13 +16,12 @@
 
 package org.ehcache.impl.internal.events;
 
-import org.ehcache.core.spi.store.events.StoreEvent;
-import org.ehcache.event.EventType;
-import org.ehcache.core.spi.store.events.StoreEventListener;
-import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
+import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
+import static org.ehcache.test.MockitoUtil.uncheckedGenericMock;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -30,12 +29,13 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
-import static org.ehcache.test.MockitoUtil.uncheckedGenericMock;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import org.ehcache.core.spi.store.events.StoreEvent;
+import org.ehcache.core.spi.store.events.StoreEventListener;
+import org.ehcache.event.EventType;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
 
 /**
  * FudgingInvocationScopedEventSinkTest
@@ -52,9 +52,11 @@ public class FudgingInvocationScopedEventSinkTest {
     Set<StoreEventListener<String, String>> storeEventListeners = new HashSet<>();
     listener = uncheckedGenericMock(StoreEventListener.class);
     storeEventListeners.add(listener);
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    BlockingQueue<FireableStoreEventHolder<String, String>>[] blockingQueues = new BlockingQueue[] { new ArrayBlockingQueue<FireableStoreEventHolder<String, String>>(10) };
-    eventSink = new FudgingInvocationScopedEventSink<>(new HashSet<>(), false, blockingQueues, storeEventListeners, EnumSet.allOf(EventType.class));
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    BlockingQueue<FireableStoreEventHolder<String, String>>[] blockingQueues = new BlockingQueue[] {
+        new ArrayBlockingQueue<FireableStoreEventHolder<String, String>>(10) };
+    eventSink = new FudgingInvocationScopedEventSink<>(new HashSet<>(), false, blockingQueues, storeEventListeners,
+        EnumSet.allOf(EventType.class));
   }
 
   @Test
@@ -64,7 +66,6 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(2)).getEventTypes();
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     verifyNoMoreInteractions(listener);
@@ -77,7 +78,6 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(3)).getEventTypes();
     inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -91,7 +91,6 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(4)).getEventTypes();
     inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -106,7 +105,6 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(5)).getEventTypes();
     inOrder.verify(listener, times(3)).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -122,7 +120,6 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(6)).getEventTypes();
     inOrder.verify(listener, times(3)).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -136,7 +133,6 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(3)).getEventTypes();
     Matcher<StoreEvent<String, String>> updatedMatcher = eventType(EventType.UPDATED);
     inOrder.verify(listener).onEvent(argThat(updatedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/FudgingInvocationScopedEventSinkTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -53,7 +54,7 @@ public class FudgingInvocationScopedEventSinkTest {
     storeEventListeners.add(listener);
     @SuppressWarnings({"unchecked", "rawtypes"})
     BlockingQueue<FireableStoreEventHolder<String, String>>[] blockingQueues = new BlockingQueue[] { new ArrayBlockingQueue<FireableStoreEventHolder<String, String>>(10) };
-    eventSink = new FudgingInvocationScopedEventSink<>(new HashSet<>(), false, blockingQueues, storeEventListeners);
+    eventSink = new FudgingInvocationScopedEventSink<>(new HashSet<>(), false, blockingQueues, storeEventListeners, EnumSet.allOf(EventType.class));
   }
 
   @Test
@@ -63,6 +64,7 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(2)).getEventTypes();
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     verifyNoMoreInteractions(listener);
@@ -75,6 +77,7 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(3)).getEventTypes();
     inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -88,6 +91,7 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(4)).getEventTypes();
     inOrder.verify(listener).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -102,6 +106,7 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(5)).getEventTypes();
     inOrder.verify(listener, times(3)).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -117,6 +122,7 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(6)).getEventTypes();
     inOrder.verify(listener, times(3)).onEvent(argThat(evictedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     verifyNoMoreInteractions(listener);
@@ -130,6 +136,7 @@ public class FudgingInvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(3)).getEventTypes();
     Matcher<StoreEvent<String, String>> updatedMatcher = eventType(EventType.UPDATED);
     inOrder.verify(listener).onEvent(argThat(updatedMatcher));
     inOrder.verify(listener).onEvent(argThat(createdMatcher));

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
@@ -16,8 +16,21 @@
 
 package org.ehcache.impl.internal.events;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
 import org.ehcache.core.spi.store.events.StoreEvent;
-import org.ehcache.core.spi.store.events.StoreEventFilter;
 import org.ehcache.core.spi.store.events.StoreEventListener;
 import org.ehcache.event.EventType;
 import org.hamcrest.Matcher;
@@ -28,21 +41,6 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /**
  * InvocationScopedEventSinkTest
@@ -67,7 +65,8 @@ public class InvocationScopedEventSinkTest {
 
   private InvocationScopedEventSink<String, String> createEventSink(boolean ordered) {
     @SuppressWarnings("unchecked")
-    BlockingQueue<FireableStoreEventHolder<String, String>>[] queues = (BlockingQueue<FireableStoreEventHolder<String, String>>[]) new BlockingQueue<?>[] { blockingQueue };
+    BlockingQueue<FireableStoreEventHolder<String, String>>[] queues = (BlockingQueue<FireableStoreEventHolder<String, String>>[])new BlockingQueue<?>[] {
+        blockingQueue };
     return new InvocationScopedEventSink<>(Collections.emptySet(), ordered, queues, storeEventListeners, EnumSet.allOf(EventType.class));
   }
 
@@ -84,7 +83,6 @@ public class InvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
-    inOrder.verify(listener, times(5)).getEventTypes();
     Matcher<StoreEvent<String, String>> createdMatcher = eventType(EventType.CREATED);
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     Matcher<StoreEvent<String, String>> updatedMatcher = eventType(EventType.UPDATED);
@@ -95,8 +93,8 @@ public class InvocationScopedEventSinkTest {
   }
 
   /**
-   * Make sure an interrupted sink sets the interrupted flag and keep both event queues in the state
-   * as of before the event that was interrupted.
+   * Make sure an interrupted sink sets the interrupted flag and keep both event queues in the state as of before the event that was
+   * interrupted.
    *
    * @throws InterruptedException
    */
@@ -116,7 +114,7 @@ public class InvocationScopedEventSinkTest {
     });
 
     t.start();
-    while(blockingQueue.remainingCapacity() != 0) {
+    while (blockingQueue.remainingCapacity() != 0) {
       System.out.println(blockingQueue.remainingCapacity());
     }
 
@@ -126,11 +124,11 @@ public class InvocationScopedEventSinkTest {
     assertThat(wasInterrupted).isTrue();
     assertThat(blockingQueue).hasSize(10);
     IntStream.range(0, 10).forEachOrdered(i -> {
-        try {
-          assertThat(blockingQueue.take().getEvent().getKey()).isEqualTo("k" + i);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
+      try {
+        assertThat(blockingQueue.take().getEvent().getKey()).isEqualTo("k" + i);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     });
     assertThat(eventSink.getEvents()).hasSize(10);
     assertThat(eventSink.getEvents().getLast().getEvent().getKey()).isEqualTo("k9");

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/InvocationScopedEventSinkTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -39,6 +40,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ehcache.impl.internal.store.offheap.AbstractOffHeapStoreTest.eventType;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
@@ -66,7 +68,7 @@ public class InvocationScopedEventSinkTest {
   private InvocationScopedEventSink<String, String> createEventSink(boolean ordered) {
     @SuppressWarnings("unchecked")
     BlockingQueue<FireableStoreEventHolder<String, String>>[] queues = (BlockingQueue<FireableStoreEventHolder<String, String>>[]) new BlockingQueue<?>[] { blockingQueue };
-    return new InvocationScopedEventSink<>(Collections.emptySet(), ordered, queues, storeEventListeners);
+    return new InvocationScopedEventSink<>(Collections.emptySet(), ordered, queues, storeEventListeners, EnumSet.allOf(EventType.class));
   }
 
   @Test
@@ -82,6 +84,7 @@ public class InvocationScopedEventSinkTest {
     eventSink.close();
 
     InOrder inOrder = inOrder(listener);
+    inOrder.verify(listener, times(5)).getEventTypes();
     Matcher<StoreEvent<String, String>> createdMatcher = eventType(EventType.CREATED);
     inOrder.verify(listener).onEvent(argThat(createdMatcher));
     Matcher<StoreEvent<String, String>> updatedMatcher = eventType(EventType.UPDATED);

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/TestStoreEventDispatcher.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/events/TestStoreEventDispatcher.java
@@ -76,6 +76,11 @@ public class TestStoreEventDispatcher<K, V> implements StoreEventDispatcher<K, V
   }
 
   @Override
+  public void listenerModified() {
+    // No-op
+  }
+
+  @Override
   public void addEventFilter(StoreEventFilter<K, V> eventFilter) {
     filters.add(eventFilter);
   }

--- a/ehcache-impl/src/test/java/org/ehcache/impl/store/DefaultStoreEventDispatcherTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/store/DefaultStoreEventDispatcherTest.java
@@ -107,6 +107,7 @@ public class DefaultStoreEventDispatcherTest {
     sink.created("new", "and shiny");
     dispatcher.releaseEventSink(sink);
 
+    verify(listener).getEventTypes();
     Matcher<StoreEvent<String, String>> matcher = eventOfType(EventType.CREATED);
     verify(listener).onEvent(argThat(matcher));
     verifyNoMoreInteractions(listener);

--- a/ehcache-transactions/src/common/java/org/ehcache/transactions/xa/internal/StoreEventSourceWrapper.java
+++ b/ehcache-transactions/src/common/java/org/ehcache/transactions/xa/internal/StoreEventSourceWrapper.java
@@ -61,6 +61,11 @@ class StoreEventSourceWrapper<K, V> implements StoreEventSource<K, V> {
   }
 
   @Override
+  public void listenerModified() {
+    underlying.listenerModified();
+  }
+
+  @Override
   public void addEventFilter(final StoreEventFilter<K, V> eventFilter) {
     underlying.addEventFilter((type, key, oldValue, newValue) -> {
       V unwrappedOldValue = null;


### PR DESCRIPTION
Based on #3170 Track event listeners keyed by type to allow earlier event firing veto 

- #3170 only triggers the listeners interested in the current event
- Don't even register an Event if no Listener is interested in this event
- Inline execution of Unordered Synchron listeners as it incurs a massive delay to spin up a separate Thread (20us vs 1us) an wait for it completion anyway