### PR TITLE
Traversers start at the start and are recycled

### DIFF
--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/Backend.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/Backend.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Random;
 import java.util.function.BiFunction;
 
 /**
@@ -76,5 +75,5 @@ interface Backend<K, V> {
 
   void updateUsageInBytesIfRequired(long delta);
 
-  Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(Random random, int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionAdvisor<Object, ? super OnHeapValueHolder<?>> evictionAdvisor);
+  Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionAdvisor<Object, ? super OnHeapValueHolder<?>> evictionAdvisor);
 }

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/OnHeapStore.java
@@ -1567,14 +1567,13 @@ public class OnHeapStore<K, V> extends BaseStore<K, V> implements HigherCachingT
    */
   boolean evict(StoreEventSink<K, V> eventSink) {
     evictionObserver.begin();
-    Random random = new Random();
 
     @SuppressWarnings("unchecked")
-    Map.Entry<K, OnHeapValueHolder<V>> candidate = map.getEvictionCandidate(random, SAMPLE_SIZE, EVICTION_PRIORITIZER, EVICTION_ADVISOR);
+    Map.Entry<K, OnHeapValueHolder<V>> candidate = map.getEvictionCandidate(SAMPLE_SIZE, EVICTION_PRIORITIZER, EVICTION_ADVISOR);
 
     if (candidate == null) {
       // 2nd attempt without any advisor
-      candidate = map.getEvictionCandidate(random, SAMPLE_SIZE, EVICTION_PRIORITIZER, noAdvice());
+      candidate = map.getEvictionCandidate(SAMPLE_SIZE, EVICTION_PRIORITIZER, noAdvice());
     }
 
     if (candidate == null) {

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/SimpleBackend.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/heap/SimpleBackend.java
@@ -50,8 +50,8 @@ class SimpleBackend<K, V> implements Backend<K, V> {
   }
 
   @Override
-  public Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(Random random, int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionAdvisor<Object, ? super OnHeapValueHolder<?>> evictionAdvisor) {
-    return realMap.getEvictionCandidate(random, size, prioritizer, evictionAdvisor);
+  public Map.Entry<K, OnHeapValueHolder<V>> getEvictionCandidate(int size, final Comparator<? super Store.ValueHolder<V>> prioritizer, final EvictionAdvisor<Object, ? super OnHeapValueHolder<?>> evictionAdvisor) {
+    return realMap.getEvictionCandidate(size, prioritizer, evictionAdvisor);
   }
 
   @Override

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMapTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMapTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 
 import static org.ehcache.config.Eviction.noAdvice;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -118,21 +117,21 @@ public class ConcurrentHashMapTest {
     @Test
     public void testRandomSampleOnEmptyMap() {
         ConcurrentHashMap<String, String> map = new ConcurrentHashMap<>();
-        assertThat(map.getEvictionCandidate(new Random(), 1, null, noAdvice()), nullValue());
+        assertThat(map.getEvictionCandidate(1, null, noAdvice()), nullValue());
     }
 
     @Test
     public void testEmptyRandomSample() {
         ConcurrentHashMap<String, String> map = new ConcurrentHashMap<>();
         map.put("foo", "bar");
-        assertThat(map.getEvictionCandidate(new Random(), 0, null, noAdvice()), nullValue());
+        assertThat(map.getEvictionCandidate(0, null, noAdvice()), nullValue());
     }
 
     @Test
     public void testOversizedRandomSample() {
         ConcurrentHashMap<String, String> map = new ConcurrentHashMap<>();
         map.put("foo", "bar");
-        Entry<String, String> candidate = map.getEvictionCandidate(new Random(), 2, null, noAdvice());
+        Entry<String, String> candidate = map.getEvictionCandidate(2, null, noAdvice());
         assertThat(candidate.getKey(), is("foo"));
         assertThat(candidate.getValue(), is("bar"));
     }
@@ -143,7 +142,7 @@ public class ConcurrentHashMapTest {
         for (int i = 0; i < 1000; i++) {
           map.put(Integer.toString(i), Integer.toString(i));
         }
-        Entry<String, String> candidate = map.getEvictionCandidate(new Random(), 2, (t, t1) -> 0, noAdvice());
+        Entry<String, String> candidate = map.getEvictionCandidate(2, (t, t1) -> 0, noAdvice());
         assertThat(candidate, notNullValue());
     }
 
@@ -153,7 +152,7 @@ public class ConcurrentHashMapTest {
         for (int i = 0; i < 1000; i++) {
           map.put(Integer.toString(i), Integer.toString(i));
         }
-        Entry<String, String> candidate = map.getEvictionCandidate(new Random(), 2, null, (key, value) -> true);
+        Entry<String, String> candidate = map.getEvictionCandidate(2, null, (key, value) -> true);
         assertThat(candidate, nullValue());
     }
 
@@ -163,7 +162,7 @@ public class ConcurrentHashMapTest {
         for (int i = 0; i < 1000; i++) {
           map.put(Integer.toString(i), Integer.toString(i));
         }
-        Entry<String, String> candidate = map.getEvictionCandidate(new Random(), 20, (t, t1) -> 0, (key, value) -> key.length() > 1);
+        Entry<String, String> candidate = map.getEvictionCandidate(20, (t, t1) -> 0, (key, value) -> key.length() > 1);
         assertThat(candidate.getKey().length(), is(1));
     }
 

--- a/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
+++ b/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -46,6 +47,7 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 import java.util.Spliterator;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
@@ -6478,72 +6480,54 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
         return invalidated;
     }
 
-    public Entry<K, V> getEvictionCandidate(Random rndm, int size, Comparator<? super V> prioritizer, EvictionAdvisor<? super K, ? super V> evictionAdvisor) {
-        Node<K,V>[] tab = table;
-        if (tab == null || size == 0) {
-            return null;
+    private final Deque<Traverser<K, V>> evictionTraversers = new ConcurrentLinkedDeque<>();
+
+    public Entry<K, V> getEvictionCandidate(int size, Comparator<? super V> prioritizer, EvictionAdvisor<? super K, ? super V> evictionAdvisor) {
+      if (size == 0) {
+        return null;
+      }
+
+      K maxKey = null;
+      V maxValue = null;
+
+      boolean exhaustive = false;
+      do {
+        Traverser<K, V> t = evictionTraversers.poll();
+        if (t == null) {
+          Node<K, V>[] tab;
+          int f = (tab = table) == null ? 0 : tab.length;
+          t = new Traverser<>(tab, f, 0, f);
+          exhaustive = true;
         }
 
-        K maxKey = null;
-        V maxValue = null;
-
-        int n = tab.length;
-        int start = rndm.nextInt(n);
-
-        Traverser<K, V> t = new Traverser<>(tab, n, start, n);
-        for (Node<K, V> p; (p = t.advance()) != null;) {
+        boolean exhausted = false;
+        try {
+          for (Node<K, V> p; (p = t.advance()) != null; ) {
             K key = p.key;
             V val = p.val;
             if (!evictionAdvisor.adviseAgainstEviction(key, val)) {
-                if (maxKey == null || prioritizer.compare(val, maxValue) > 0) {
-                    maxKey = key;
-                    maxValue = val;
-                }
-                if (--size == 0) {
-                    for (int terminalIndex = t.index; (p = t.advance()) != null && t.index == terminalIndex; ) {
-                        key = p.key;
-                        val = p.val;
-                        if (!evictionAdvisor.adviseAgainstEviction(key, val) && prioritizer.compare(val, maxValue) > 0) {
-                            maxKey = key;
-                            maxValue = val;
-                        }
-                    }
-                    return new MapEntry<>(maxKey, maxValue, this);
-                }
+              if (maxKey == null || prioritizer.compare(val, maxValue) > 0) {
+                maxKey = key;
+                maxValue = val;
+              }
+              if (--size == 0) {
+                return new MapEntry<>(maxKey, maxValue, this);
+              }
             }
+          }
+          exhausted = true;
+        } finally {
+          if (!exhausted) {
+            evictionTraversers.push(t);
+          }
         }
+      } while (!exhaustive);
 
-        return getEvictionCandidateWrap(tab, start, size, maxKey, maxValue, prioritizer, evictionAdvisor);
-    }
-
-    private Entry<K, V> getEvictionCandidateWrap(Node<K,V>[] tab, int start, int size, K maxKey, V maxVal, Comparator<? super V> prioritizer, EvictionAdvisor<? super K, ? super V> evictionAdvisor) {
-        Traverser<K, V> t = new Traverser<>(tab, tab.length, 0, start);
-        for (Node<K, V> p; (p = t.advance()) != null;) {
-            K key = p.key;
-            V val = p.val;
-            if (!evictionAdvisor.adviseAgainstEviction(key, val)) {
-                if (maxKey == null || prioritizer.compare(val, maxVal) > 0) {
-                    maxKey = key;
-                    maxVal = val;
-                }
-                if (--size == 0) {
-                    for (int terminalIndex = t.index; (p = t.advance()) != null && t.index == terminalIndex; ) {
-                        key = p.key;
-                        val = p.val;
-                        if (!evictionAdvisor.adviseAgainstEviction(key, val) && prioritizer.compare(val, maxVal) > 0) {
-                            maxKey = key;
-                            maxVal = val;
-                        }
-                    }
-                    return new MapEntry<>(maxKey, maxVal, this);
-                }
-            }
-        }
-        if (maxKey == null) {
-            return null;
-        } else {
-            return new MapEntry<>(maxKey, maxVal, this);
-        }
+      if (maxKey == null) {
+        return null;
+      } else {
+        return new MapEntry<>(maxKey, maxValue, this);
+      }
     }
     // END OF EHCACHE SPECIFIC
 }

--- a/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/EvictingConcurrentMap.java
+++ b/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/EvictingConcurrentMap.java
@@ -29,13 +29,12 @@ public interface EvictingConcurrentMap<K, V> extends ConcurrentMap<K, V>{
   /**
    * Return the preferred entry to evict based on a sample of entries taken from the map.
    *
-   * @param rndm Random implementation used to determine the sample randomly
    * @param size Number of sampled entries
    * @param prioritizer Prioritizer used to determine the best entry to evict in the sample
    * @param evictionAdvisor Can veto against the eviction of an entry
    * @return Entry to evict or null is none was found
    */
-  Entry<K, V> getEvictionCandidate(Random rndm, int size, Comparator<? super V> prioritizer, EvictionAdvisor<? super K, ? super V> evictionAdvisor);
+  Entry<K, V> getEvictionCandidate(int size, Comparator<? super V> prioritizer, EvictionAdvisor<? super K, ? super V> evictionAdvisor);
 
   /**
    * Returns the number of mappings. This method should be used


### PR DESCRIPTION
Prevent hash 'clumping' where unevenness in table slot usage can be exacerbated by the fact that we sample uniformly through the table, but not through the table usage when creating a traverser for selecting our eviction sample. This leads to slots in low density areas having a higher chance of being evicted, therefore leading to increased clumping. To prevent this we start traversers at the start of the table and then recycle them for subsequent evictions as they are exhausted. This ensures every slot has an equal chance of being selected for eviction. 