### PR TITLE
Issue 2494 Refix

### DIFF
--- a/ehcache-107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
+++ b/ehcache-107/src/main/java/org/ehcache/jsr107/Eh107CacheManager.java
@@ -35,8 +35,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,6 +51,8 @@ import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
 
+import org.ehcache.core.events.CacheManagerListener;
+import org.ehcache.core.spi.store.InternalCacheManager;
 import static org.ehcache.jsr107.CloseUtil.chain;
 import static org.ehcache.jsr107.CloseUtil.closeAll;
 
@@ -83,27 +85,34 @@ class Eh107CacheManager implements CacheManager {
     this.configurationMerger = configurationMerger;
     this.statisticsService = jsr107Service.getStatistics();
 
-    refreshAllCaches();
-  }
+    ((InternalCacheManager) ehCacheManager).registerListener(new CacheManagerListener() {
+        @Override
+        public void cacheAdded(String alias, org.ehcache.Cache<?, ?> cache) {
+          loadCache(alias, cache);
+        }
 
-  private void refreshAllCaches() {
-    for (Map.Entry<String, CacheConfiguration<?, ?>> entry : ehCacheManager.getRuntimeConfiguration().getCacheConfigurations().entrySet()) {
-      String name = entry.getKey();
-      CacheConfiguration<?, ?> config = entry.getValue();
-
-      if (!caches.containsKey(name)) {
-        Eh107Cache<?, ?> wrappedCache = wrapEhcacheCache(name, config);
-        if (caches.putIfAbsent(name, wrappedCache) == null) {
-          @SuppressWarnings("unchecked")
-          Eh107Configuration<?, ?> configuration = wrappedCache.getConfiguration(Eh107Configuration.class);
-          if (configuration.isManagementEnabled()) {
-            enableManagement(wrappedCache, true);
-          }
-          if (configuration.isStatisticsEnabled()) {
-            enableStatistics(wrappedCache, true);
+        @Override
+        public void cacheRemoved(String alias, org.ehcache.Cache<?, ?> cache) {
+          Eh107Cache<?, ?> jcache = caches.get(alias);
+          if (jcache != null) {
+            close(jcache);
           }
         }
-      }
+
+        @Override
+        public void stateTransition(Status from, Status to) {
+        }
+
+    });
+    loadAllCaches();
+  }
+
+  private void loadAllCaches() {
+    for (Map.Entry<String, CacheConfiguration<?, ?>> entry : ehCacheManager.getRuntimeConfiguration().getCacheConfigurations().entrySet()) {
+      CacheConfiguration<?, ?> config = entry.getValue();
+      InternalCache<?, ?> cache = (InternalCache<?, ?>) ehCacheManager.getCache(entry.getKey(), config.getKeyType(), config.getValueType());
+
+      loadCache(entry.getKey(), cache);
     }
 
     for (Eh107Cache<?, ?> wrappedCache : caches.values()) {
@@ -111,9 +120,36 @@ class Eh107CacheManager implements CacheManager {
     }
   }
 
-  private <K, V> Eh107Cache<K, V> wrapEhcacheCache(String alias, CacheConfiguration<K, V> ehConfig) {
-    org.ehcache.Cache<K, V> cache = ehCacheManager.getCache(alias, ehConfig.getKeyType(), ehConfig.getValueType());
-    return wrapEhcacheCache(alias, (InternalCache<K, V>)cache);
+  @SuppressWarnings("unchecked")
+  private <K, V> Cache<K, V> loadCache(String alias, org.ehcache.Cache<K, V> cache) {
+    return (Cache<K, V>) caches.computeIfAbsent(alias, name -> {
+      Eh107Cache<?, ?> wrappedCache = wrapEhcacheCache(name, (InternalCache<K, V>) cache);
+      @SuppressWarnings("unchecked")
+      Eh107Configuration<?, ?> configuration = wrappedCache.getConfiguration(Eh107Configuration.class);
+      if (configuration.isManagementEnabled()) {
+        enableManagement(wrappedCache, true);
+      }
+      if (configuration.isStatisticsEnabled()) {
+        enableStatistics(wrappedCache, true);
+      }
+      return wrappedCache;
+    });
+  }
+
+  @SuppressWarnings("unchecked")
+  private <K, V> Cache<K, V> reloadCache(String alias, Eh107Cache<K, V> jcache) {
+    return (Cache<K, V>) caches.computeIfPresent(alias, (name, existing) -> {
+      @SuppressWarnings("unchecked")
+      Eh107Configuration<?, ?> oldConfiguration = existing.getConfiguration(Eh107Configuration.class);
+      Eh107Configuration<?, ?> newConfiguration = jcache.getConfiguration(Eh107Configuration.class);
+      if (oldConfiguration.isManagementEnabled() != newConfiguration.isManagementEnabled()) {
+        enableManagement(jcache, newConfiguration.isManagementEnabled());
+      }
+      if (oldConfiguration.isStatisticsEnabled() != newConfiguration.isStatisticsEnabled()) {
+        enableStatistics(jcache, newConfiguration.isStatisticsEnabled());
+      }
+      return jcache;
+    });
   }
 
   private <K, V> Eh107Cache<K, V> wrapEhcacheCache(String alias, InternalCache<K, V> cache) {
@@ -176,67 +212,42 @@ class Eh107CacheManager implements CacheManager {
         @SuppressWarnings("unchecked")
         Eh107Configuration.Eh107ConfigurationWrapper<K, V> configurationWrapper = (Eh107Configuration.Eh107ConfigurationWrapper<K, V>)config;
         CacheConfiguration<K, V> unwrap = configurationWrapper.getCacheConfiguration();
-        final org.ehcache.Cache<K, V> ehcache;
         try {
-          ehcache = ehCacheManager.createCache(cacheName, unwrap);
+          ehCacheManager.createCache(cacheName, unwrap);
         } catch (IllegalArgumentException e) {
           throw new CacheException("A Cache named [" + cacheName + "] already exists");
         }
-        Eh107Cache<K, V> cache = wrapEhcacheCache(cacheName, (InternalCache<K, V>)ehcache);
-        assert safeCacheRetrieval(cacheName) == null;
-        caches.put(cacheName, cache);
+        return safeCacheRetrieval(cacheName);
+      } else {
+        ConfigurationMerger.ConfigHolder<K, V> configHolder = configurationMerger.mergeConfigurations(cacheName, config);
 
-        @SuppressWarnings("unchecked")
-        Eh107Configuration<?, ?> configuration = cache.getConfiguration(Eh107Configuration.class);
-        if (configuration.isManagementEnabled()) {
-          enableManagement(cacheName, true);
+        final InternalCache<K, V> ehCache;
+        try {
+          ehCache = (InternalCache<K, V>)ehCacheManager.createCache(cacheName, configHolder.cacheConfiguration);
+        } catch (IllegalArgumentException e) {
+          throw configHolder.cacheResources.closeResourcesAfter(new CacheException("A Cache named [" + cacheName + "] already exists"));
+        } catch (Throwable t) {
+          // something went wrong in ehcache land, make sure to clean up our stuff
+          throw configHolder.cacheResources.closeResourcesAfter(new CacheException(t));
         }
 
-        if (configuration.isStatisticsEnabled()) {
-          enableStatistics(cacheName, true);
-        }
+        Eh107Cache<K, V> cache = null;
+        CacheResources<K, V> cacheResources = configHolder.cacheResources;
+        try {
+          if (configHolder.useEhcacheLoaderWriter) {
+            cacheResources = new CacheResources<>(cacheName, wrapCacheLoaderWriter(ehCache.getCacheLoaderWriter()),
+              cacheResources.getExpiryPolicy(), cacheResources.getListenerResources());
+          }
+          cache = new Eh107Cache<>(cacheName, new Eh107CompleteConfiguration<>(configHolder.jsr107Configuration, ehCache
+            .getRuntimeConfiguration()), cacheResources, ehCache, statisticsService, this);
 
-        return cache;
-      }
-
-      ConfigurationMerger.ConfigHolder<K, V> configHolder = configurationMerger.mergeConfigurations(cacheName, config);
-
-      final InternalCache<K, V> ehCache;
-      try {
-        ehCache = (InternalCache<K, V>)ehCacheManager.createCache(cacheName, configHolder.cacheConfiguration);
-      } catch (IllegalArgumentException e) {
-        throw configHolder.cacheResources.closeResourcesAfter(new CacheException("A Cache named [" + cacheName + "] already exists"));
-      } catch (Throwable t) {
-        // something went wrong in ehcache land, make sure to clean up our stuff
-        throw configHolder.cacheResources.closeResourcesAfter(new CacheException(t));
-      }
-
-      Eh107Cache<K, V> cache = null;
-      CacheResources<K, V> cacheResources = configHolder.cacheResources;
-      try {
-        if (configHolder.useEhcacheLoaderWriter) {
-          cacheResources = new CacheResources<>(cacheName, wrapCacheLoaderWriter(ehCache.getCacheLoaderWriter()),
-            cacheResources.getExpiryPolicy(), cacheResources.getListenerResources());
-        }
-        cache = new Eh107Cache<>(cacheName, new Eh107CompleteConfiguration<>(configHolder.jsr107Configuration, ehCache
-          .getRuntimeConfiguration()), cacheResources, ehCache, statisticsService, this);
-
-        caches.put(cacheName, cache);
-
-        if (configHolder.jsr107Configuration.isManagementEnabled()) {
-          enableManagement(cacheName, true);
-        }
-
-        if (configHolder.jsr107Configuration.isStatisticsEnabled()) {
-          enableStatistics(cacheName, true);
-        }
-
-        return cache;
-      } catch (Throwable t) {
-        if (cache != null) {
-          throw cache.closeInternalAfter(new CacheException(t));
-        } else {
-          throw cacheResources.closeResourcesAfter(new CacheException(t));
+          return reloadCache(cacheName, cache);
+        } catch (Throwable t) {
+          if (cache != null) {
+            throw cache.closeInternalAfter(new CacheException(t));
+          } else {
+            throw cacheResources.closeResourcesAfter(new CacheException(t));
+          }
         }
       }
     }
@@ -307,8 +318,7 @@ class Eh107CacheManager implements CacheManager {
   @Override
   public Iterable<String> getCacheNames() {
     checkClosed();
-    refreshAllCaches();
-    return Collections.unmodifiableList(new ArrayList<>(caches.keySet()));
+    return Collections.unmodifiableSet(new HashSet<>(ehCacheManager.getRuntimeConfiguration().getCacheConfigurations().keySet()));
   }
 
   @Override

--- a/ehcache-107/src/test/java/org/ehcache/jsr107/Eh107XmlIntegrationTest.java
+++ b/ehcache-107/src/test/java/org/ehcache/jsr107/Eh107XmlIntegrationTest.java
@@ -48,6 +48,7 @@ import javax.cache.integration.CompletionListenerFuture;
 import javax.cache.spi.CachingProvider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -67,6 +68,11 @@ public class Eh107XmlIntegrationTest {
     cachingProvider = Caching.getCachingProvider();
     cacheManager = cachingProvider.getCacheManager(getClass().getResource("/ehcache-107-integration.xml")
         .toURI(), cachingProvider.getDefaultClassLoader());
+  }
+
+  @Test
+  public void testImmediateCacheNames() {
+    assertThat(cacheManager.getCacheNames(), containsInAnyOrder("customerCache", "productCache"));
   }
 
   @Test

--- a/ehcache-107/src/test/java/org/ehcache/jsr107/UnwrapTest.java
+++ b/ehcache-107/src/test/java/org/ehcache/jsr107/UnwrapTest.java
@@ -29,9 +29,13 @@ import javax.cache.configuration.MutableConfiguration;
 import javax.cache.event.EventType;
 import javax.cache.spi.CachingProvider;
 
+import static org.ehcache.config.builders.CacheConfigurationBuilder.newCacheConfigurationBuilder;
+import static org.ehcache.config.builders.ResourcePoolsBuilder.heap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * @author rism
@@ -76,6 +80,22 @@ public class UnwrapTest {
     Eh107CacheEntryEvent<String, String> cacheEntryEvent = new Eh107CacheEntryEvent.NormalEvent<>(cache, EventType.CREATED, ehEvent, false);
     assertThat(cacheEntryEvent.unwrap(org.ehcache.event.CacheEvent.class), is(instanceOf(CacheEvent.class)));
     assertThat(cacheEntryEvent.unwrap(cacheEntryEvent.getClass()), is(instanceOf(Eh107CacheEntryEvent.NormalEvent.class)));
+  }
+
+  @Test
+  public void testCacheMutationViaUnwrap() {
+    org.ehcache.CacheManager ehcacheManager = cacheManager.unwrap(org.ehcache.CacheManager.class);
+    org.ehcache.Cache<Integer, String> cache = ehcacheManager.createCache("jcache", newCacheConfigurationBuilder(Integer.class, String.class, heap(5)));
+
+    Cache<Integer, String> javaxCache = cacheManager.getCache("jcache", Integer.class, String.class);
+    assertThat(javaxCache, is(notNullValue()));
+
+    cache.put(1, "one");
+
+    assertThat(javaxCache.get(1), is("one"));
+
+    ehcacheManager.removeCache("jcache");
+    assertThat(cacheManager.getCache("jcache", Integer.class, String.class), is(nullValue()));
   }
 
   private class EhEvent implements CacheEvent<String,String> {


### PR DESCRIPTION
We move back here to a non-lazy approach to building the map of 107 wrappers. This means we generate all the wrappers up front, and then we generate new wrappers by listening for added caches, and remove when we see a cache removed. This should mean that direct additions/removals to the Ehcache manager will be immediately reflected in the JSR-107 manager.