### PR TITLE
Bump jakarta.xml.bind to allow 4.0.x

### DIFF
--- a/ehcache-xml/build.gradle
+++ b/ehcache-xml/build.gradle
@@ -105,7 +105,7 @@ dependencies {
   api 'javax.xml.bind:jaxb-api:[2.2,3)'
   runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:[2.2,3)'
 
-  jakartaApi 'jakarta.xml.bind:jakarta.xml.bind-api:[3,4)'
+  jakartaApi 'jakarta.xml.bind:jakarta.xml.bind-api:[3,4.1)'
   jakartaRuntimeOnly 'org.glassfish.jaxb:jaxb-runtime:[3,3.1)'
 
   testFixturesApi 'org.xmlunit:xmlunit-core:2.6.0', 'org.xmlunit:xmlunit-matchers:2.6.0'

--- a/ehcache-xml/build.gradle
+++ b/ehcache-xml/build.gradle
@@ -131,7 +131,7 @@ tasks.named('jakartaJar', Jar) {
   bundle {
     bnd (
       'Export-Package': 'org.ehcache.xml.*',
-      'Import-Package': "jakarta.xml.bind*;version=\"[3,4)\", *"
+      'Import-Package': "jakarta.xml.bind*;version=\"[3,4.1)\", *"
     )
   }
 }

--- a/ehcache/build.gradle
+++ b/ehcache/build.gradle
@@ -101,7 +101,7 @@ dependencies {
   javadocAdd 'javax.xml.bind:jaxb-api:[2.2,3)'
   
   jakartaJavadocAdd 'com.github.spotbugs:spotbugs-annotations:4.2.3'
-  jakartaJavadocAdd 'jakarta.xml.bind:jakarta.xml.bind-api:[3,4)'
+  jakartaJavadocAdd 'jakarta.xml.bind:jakarta.xml.bind-api:[3,4.1)'
 
 }
 
@@ -112,7 +112,7 @@ tasks.named('jakartaJar') {
     instruction Constants.BUNDLE_DESCRIPTION, 'Ehcache is an open-source caching library, compliant with the JSR-107 standard.'
     instruction Constants.BUNDLE_ACTIVATOR, 'org.ehcache.core.osgi.EhcacheActivator'
     instruction Constants.EXPORT_PACKAGE, '!org.ehcache.jsr107.tck, !org.ehcache.*.internal.*, org.ehcache.*'
-    instruction Constants.IMPORT_PACKAGE, 'javax.annotation.*;resolution:=optional, javax.cache.*;resolution:=optional, jdk.internal.misc;resolution:=optional, !javax.annotation, !sun.misc, jakarta.xml.bind*;version="[3,4)", *'
+    instruction Constants.IMPORT_PACKAGE, 'javax.annotation.*;resolution:=optional, javax.cache.*;resolution:=optional, jdk.internal.misc;resolution:=optional, !javax.annotation, !sun.misc, jakarta.xml.bind*;version="[3,4.1)", *'
   }
 }
 


### PR DESCRIPTION
Hey there,

This is a small PR to address an issue we encountered recently.
We're trying to update our internal dependencies to address some outdated ones, and would like to upgrade the Jakarta Bind-API to 4.0.*, which is just barely outside the supported range.

I validated that all tests are passing with this change, and do not expect any third-party degradations (but please let me know if I've missed something), I am happy to contribute further.

(this would also address https://github.com/ehcache/ehcache3/issues/3265)

Thanks in advance