### PR TITLE
[TDB-19854/3.11] - Refactor the Demos to remove vulnerable dependencies (backport of master)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,44 +25,25 @@ resources:
       name: terracotta/terracotta
 
 jobs:
-- template: build-templates/gradle-common.yml@templates
-  parameters:
-    jdkVersion: '1.8'
-    jobName: 'LinuxJava8'
-    gradleTasks: 'check -x dependencyCheckAggregate'
+  - template: build-templates/gradle-common.yml@templates
+    parameters:
+      jdkVersion: '17'
+      options: '-PtestVM=java17Home'
+      jobName: 'LinuxJava17'
+      gradleTasks: 'check -x dependencyCheckAggregate'
 
-- template: build-templates/gradle-common.yml@templates
-  parameters:
-    jdkVersion: '1.8'
-    options: '-PtestVM=java11Home'
-    jobName: 'LinuxJava11'
-    gradleTasks: 'check -x dependencyCheckAggregate'
+  - template: build-templates/gradle-common.yml@templates
+    parameters:
+      jdkVersion: '17'
+      options: '-PtestVM=java21Home'
+      jobName: 'LinuxJava21'
+      gradleTasks: 'check -x dependencyCheckAggregate'
 
-- template: build-templates/gradle-common.yml@templates
-  parameters:
-    jdkVersion: '1.8'
-    options: '-PtestVM=java17Home'
-    jobName: 'LinuxJava17'
-    gradleTasks: 'check -x dependencyCheckAggregate'
 
-- template: build-templates/gradle-common.yml@templates
-  parameters:
-    jdkVersion: '1.8'
-    options: '-PtestVM=java21Home'
-    jobName: 'LinuxJava21'
-    gradleTasks: 'check -x dependencyCheckAggregate'
-
-- template: build-templates/gradle-common.yml@templates
-  parameters:
-    vmImage: 'windows-latest'
-    jdkVersion: '1.8'
-    jobName: 'WindowsJava8'
-    gradleTasks: 'check -x dependencyCheckAggregate'
-
-- template: build-templates/gradle-common.yml@templates
-  parameters:
-    vmImage: 'windows-latest'
-    jdkVersion: '1.8'
-    options: '-PtestVM=java21Home'
-    jobName: 'WindowsJava21'
-    gradleTasks: 'check -x dependencyCheckAggregate'
+  - template: build-templates/gradle-common.yml@templates
+    parameters:
+      vmImage: 'windows-latest'
+      jdkVersion: '17'
+      options: '-PtestVM=java21Home'
+      jobName: 'WindowsJava21'
+      gradleTasks: 'check -x dependencyCheckAggregate'

--- a/build-logic/src/main/java/org/ehcache/build/conventions/CheckstyleConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/CheckstyleConvention.java
@@ -13,10 +13,28 @@ public class CheckstyleConvention implements Plugin<Project> {
     project.getPlugins().apply(CheckstylePlugin.class);
 
     project.getExtensions().configure(CheckstyleExtension.class, checkstyle -> {
+      checkstyle.setToolVersion("10.18.1");
       checkstyle.setConfigFile(project.getRootProject().file("config/checkstyle.xml"));
       Map<String, Object> properties = checkstyle.getConfigProperties();
       properties.put("projectDir", project.getProjectDir());
       properties.put("rootDir", project.getRootDir());
+    });
+
+    project.getConfigurations().named("checkstyle", config -> {
+      config.getResolutionStrategy().dependencySubstitution(subs -> {
+        subs.substitute(subs.module("org.codehaus.plexus:plexus-utils:3.1.1"))
+          .using(subs.module("org.codehaus.plexus:plexus-utils:3.3.0"))
+          .because("Checkstyle 10.18.1 pulls mismatched plexus-utils versions");
+        subs.substitute(subs.module("org.apache.commons:commons-lang3:3.7"))
+          .using(subs.module("org.apache.commons:commons-lang3:3.8.1"))
+          .because("Checkstyle transitives mix commons-lang3 versions");
+        subs.substitute(subs.module("org.apache.httpcomponents:httpcore:4.4.13"))
+          .using(subs.module("org.apache.httpcomponents:httpcore:4.4.14"))
+          .because("Align httpcore to latest bugfix release");
+        subs.substitute(subs.module("commons-codec:commons-codec:1.11"))
+          .using(subs.module("commons-codec:commons-codec:1.15"))
+          .because("Checkstyle transitive dependencies depend on different commons-codec versions");
+      });
     });
   }
 }

--- a/build-logic/src/main/java/org/ehcache/build/conventions/JavaConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/JavaConvention.java
@@ -1,7 +1,9 @@
 package org.ehcache.build.conventions;
 
+import java.util.Map;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.JavaPlugin;
 
@@ -20,15 +22,28 @@ public class JavaConvention implements Plugin<Project> {
 
     dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "junit:junit:" + project.property("junitVersion"));
     dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.assertj:assertj-core:" + project.property("assertjVersion"));
+    dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "net.bytebuddy:byte-buddy:" + project.property("byteBuddyVersion"));
+    dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "net.bytebuddy:byte-buddy-agent:" + project.property("byteBuddyVersion"));
     dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.hamcrest:hamcrest:" + project.property("hamcrestVersion"));
     dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.mockito:mockito-core:" + project.property("mockitoVersion"));
-    dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.terracotta:terracotta-utilities-test-tools:" + project.property("terracottaUtilitiesVersion"));
+    ModuleDependency md = (ModuleDependency)dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, "org.terracotta:terracotta-utilities-test-tools:" + project.property("terracottaUtilitiesVersion"));
+    if (md != null) {
+      md.exclude(Map.of("group", "org.slf4j"));
+    }
 
     project.getConfigurations().all(config -> {
       config.getResolutionStrategy().dependencySubstitution(subs -> {
         subs.substitute(subs.module("org.hamcrest:hamcrest-core:1.3")).with(subs.module("org.hamcrest:hamcrest-core:" + project.property("hamcrestVersion")));
         subs.substitute(subs.module("org.hamcrest:hamcrest-library:1.3")).with(subs.module("org.hamcrest:hamcrest-library:" + project.property("hamcrestVersion")));
         subs.substitute(subs.module("junit:junit:4.12")).using(subs.module("junit:junit:4.13.1"));
+      });
+      config.getResolutionStrategy().eachDependency(details -> {
+        String group = details.getRequested().getGroup();
+        String name = details.getRequested().getName();
+        if ("net.bytebuddy".equals(group) && ("byte-buddy".equals(name) || "byte-buddy-agent".equals(name))) {
+          details.useVersion(project.property("byteBuddyVersion").toString());
+          details.because("Align Byte Buddy family versions across AssertJ and Mockito");
+        }
       });
     });
   }

--- a/build-logic/src/main/java/org/ehcache/build/conventions/SpotbugsConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/SpotbugsConvention.java
@@ -17,8 +17,8 @@ public class SpotbugsConvention implements Plugin<Project> {
     SpotBugsExtension spotbugs = project.getExtensions().getByType(SpotBugsExtension.class);
 
     spotbugs.getIgnoreFailures().set(false);
-    // Later versions of Spotbugs have stupid heuristics for EI_EXPOSE_REP*
-    spotbugs.getToolVersion().set("4.2.3");
+    spotbugs.getToolVersion().set("4.9.8");
+    spotbugs.getOmitVisitors().addAll("FindReturnRef", "ConstructorThrow");
 
     project.getPlugins().withType(JavaBasePlugin.class).configureEach(plugin -> {
 
@@ -46,6 +46,12 @@ public class SpotbugsConvention implements Plugin<Project> {
         subs.substitute(subs.module("org.apache.commons:commons-lang3:3.11"))
           .using(subs.module("org.apache.commons:commons-lang3:3.12.0"))
           .because("Spotbugs has dependency divergences");
+        subs.substitute(subs.module("org.apache.commons:commons-lang3:3.18.0"))
+          .using(subs.module("org.apache.commons:commons-lang3:3.19.0"))
+          .because("Spotbugs 4.9.8 has dependency divergences");
+        subs.substitute(subs.module("org.apache.logging.log4j:log4j-core:2.25.2"))
+          .using(subs.module("org.apache.logging.log4j:log4j-core:2.25.3"))
+          .because("Security vulnerability fix");
       });
     });
 

--- a/clustered/ehcache-client/build.gradle
+++ b/clustered/ehcache-client/build.gradle
@@ -37,7 +37,9 @@ dependencies {
   implementation "org.terracotta:lease-api:$terracottaPlatformVersion"
   implementation "org.terracotta.dynamic-config.entities:dynamic-config-topology-entity-client:$terracottaPlatformVersion"
   implementation "org.terracotta:connection-api:$terracottaApisVersion"
-  implementation "org.terracotta:terracotta-utilities-tools:$terracottaUtilitiesVersion"
+  implementation ("org.terracotta:terracotta-utilities-tools:$terracottaUtilitiesVersion") {
+    exclude group: 'org.slf4j'
+  }
 
   compileOnly 'org.osgi:org.osgi.service.component.annotations:1.3.0'
 
@@ -60,5 +62,7 @@ dependencies {
     exclude group:'org.slf4j', module:'slf4j-api'
   }
   testImplementation testFixtures(project(':ehcache-xml'))
-  testImplementation ("org.terracotta:statistics:$parent.statisticVersion")
+  testImplementation ("org.terracotta:statistics:$parent.statisticVersion") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 }

--- a/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
+++ b/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/service/DefaultClusteringService.java
@@ -377,6 +377,7 @@ public class DefaultClusteringService implements ClusteringService, EntityServic
     return connectionState;
   }
 
+  @SuppressWarnings("removal")
   private static ExecutorService createAsyncWorker() {
     SecurityManager s = System.getSecurityManager();
     ThreadGroup initialGroup = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();

--- a/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/store/CommonServerStoreProxy.java
+++ b/clustered/ehcache-client/src/main/java/org/ehcache/clustered/client/internal/store/CommonServerStoreProxy.java
@@ -232,6 +232,7 @@ class CommonServerStoreProxy implements ServerStoreProxy {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         protected void finalize() throws Throwable {
           if (!lastBatch) {
             entity.invokeAndWaitForReceive(new ServerStoreOpMessage.IteratorCloseMessage(iteratorId), false);

--- a/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/service/DefaultClusteringServiceDestroyTest.java
+++ b/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/service/DefaultClusteringServiceDestroyTest.java
@@ -55,6 +55,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import org.mockito.quality.Strictness;
+
 /**
  * DefaultClusteringServiceDestroyTest
  */
@@ -194,7 +196,7 @@ public class DefaultClusteringServiceDestroyTest {
 
   private void mockLockForWriteLockSuccess() throws org.terracotta.exception.EntityNotProvidedException, org.terracotta.exception.EntityNotFoundException, org.terracotta.exception.EntityVersionMismatchException {
     when(connection.<VoltronReadWriteLockClient, Object, Void>getEntityRef(same(VoltronReadWriteLockClient.class), eq(1L), any())).thenReturn(lockEntityRef);
-    VoltronReadWriteLockClient lockClient = mock(VoltronReadWriteLockClient.class, withSettings().lenient());
+    VoltronReadWriteLockClient lockClient = mock(VoltronReadWriteLockClient.class, withSettings().strictness(Strictness.LENIENT));
     when(lockEntityRef.fetchEntity(null)).thenReturn(lockClient);
 
     when(lockClient.tryLock(LockMessaging.HoldType.WRITE)).thenReturn(true);
@@ -203,7 +205,7 @@ public class DefaultClusteringServiceDestroyTest {
 
   private void mockLockForReadLockSuccess() throws org.terracotta.exception.EntityNotProvidedException, org.terracotta.exception.EntityNotFoundException, org.terracotta.exception.EntityVersionMismatchException {
     when(connection.<VoltronReadWriteLockClient, Object, Void>getEntityRef(same(VoltronReadWriteLockClient.class), eq(1L), any())).thenReturn(lockEntityRef);
-    VoltronReadWriteLockClient lockClient = mock(VoltronReadWriteLockClient.class, withSettings().lenient());
+    VoltronReadWriteLockClient lockClient = mock(VoltronReadWriteLockClient.class, withSettings().strictness(Strictness.LENIENT));
     when(lockEntityRef.fetchEntity(null)).thenReturn(lockClient);
 
     when(lockClient.tryLock(LockMessaging.HoldType.READ)).thenReturn(true);

--- a/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/service/StateRepositoryWhitelistingTest.java
+++ b/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/service/StateRepositoryWhitelistingTest.java
@@ -166,9 +166,9 @@ public class StateRepositoryWhitelistingTest {
     StateHolder<Integer, Integer> testMap = stateRepository.getPersistentStateHolder("testMap", Integer.class, Integer.class,
       Arrays.asList(Child.class)::contains, null);
 
-    testMap.putIfAbsent(new Integer(10), new Integer(20));
+    testMap.putIfAbsent(Integer.valueOf(10), Integer.valueOf(20));
 
-    assertThat(testMap.get(new Integer(10)), is(new Integer(20)));
+    assertThat(testMap.get(Integer.valueOf(10)), is(Integer.valueOf(20)));
     assertThat(testMap.entrySet(), hasSize(1));
   }
 

--- a/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
+++ b/clustered/ehcache-client/src/test/java/org/ehcache/clustered/client/internal/store/ClusteredStoreTest.java
@@ -231,7 +231,7 @@ public class ClusteredStoreTest {
   @SuppressWarnings("unchecked")
   public void testGetTimeout() throws Exception {
     ServerStoreProxy proxy = mock(ServerStoreProxy.class);
-    long longKey = HashUtils.intHashToLong(new Long(1L).hashCode());
+    long longKey = HashUtils.intHashToLong(Long.valueOf(1L).hashCode());
     when(proxy.get(longKey)).thenThrow(TimeoutException.class);
     ClusteredStore<Long, String> store = new ClusteredStore<>(config,null, null, proxy, null, null, new DefaultStatisticsService());
     assertThat(store.get(1L), nullValue());
@@ -630,7 +630,7 @@ public class ClusteredStoreTest {
 
   @Test
   public void testSingleChainMultipleValues() throws StoreAccessException {
-    assertThat(Long.hashCode(1L), is(Long.hashCode(~1L)));
+    assertThat(Long.valueOf(1L).hashCode(), is(Long.valueOf(~1L).hashCode()));
 
     store.put(1L, "foo");
     store.put(~1L, "bar");

--- a/clustered/ehcache-clustered/build.gradle
+++ b/clustered/ehcache-clustered/build.gradle
@@ -100,8 +100,18 @@ task copyDocs(type: Sync) {
   into docsFolder
 }
 
+configurations {
+  javadocAdd
+}
+
+dependencies {
+  javadocAdd project(':clustered:ehcache-common-api')
+  javadocAdd project(':clustered:ehcache-common')
+}
+
 javadoc {
   exclude '**/core/**', '**/impl/**', '**/xml/**', '**/jsr107/**', '**/transactions/**', '**/management/**', '**/tck/**'
+  classpath += configurations.javadocAdd
 }
 
 tasks.named('jar') {

--- a/clustered/ehcache-common-api/src/main/java/org/ehcache/clustered/common/internal/store/ValueWrapper.java
+++ b/clustered/ehcache-common-api/src/main/java/org/ehcache/clustered/common/internal/store/ValueWrapper.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 /**
  * ValueWrapper
  */
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class ValueWrapper implements Serializable {
 
   private static final long serialVersionUID = -4794738044295644587L;

--- a/clustered/ehcache-common/build.gradle
+++ b/clustered/ehcache-common/build.gradle
@@ -32,7 +32,9 @@ dependencies {
 
   implementation "org.terracotta:entity-common-api:$terracottaApisVersion"
   implementation "org.terracotta:runnel:$terracottaPlatformVersion"
-  implementation "org.terracotta:terracotta-utilities-tools:$terracottaUtilitiesVersion"
+  implementation ("org.terracotta:terracotta-utilities-tools:$terracottaUtilitiesVersion") {
+    exclude group: 'org.slf4j'
+  }
 
   testImplementation project(':clustered:test-utils')
 }

--- a/clustered/ehcache-common/src/test/java/org/ehcache/clustered/common/internal/Store/WhitelistedUnmarshallingTest.java
+++ b/clustered/ehcache-common/src/test/java/org/ehcache/clustered/common/internal/Store/WhitelistedUnmarshallingTest.java
@@ -62,48 +62,48 @@ public class WhitelistedUnmarshallingTest {
 
   @Test
   public void unmarshallingIntegerTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Integer(10));
+    unmarshallingStateRepoMessagesCheck(Integer.valueOf(10));
   }
 
   @Test
   public void unmarshallingLongTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Long(10));
+    unmarshallingStateRepoMessagesCheck(Long.valueOf(10L));
   }
 
   @Test
   public void unmarshallingFloatTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Float(10.0));
+    unmarshallingStateRepoMessagesCheck(Float.valueOf(10.0f));
   }
 
   @Test
   public void unmarshallingDoubleTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Double(10.0));
+    unmarshallingStateRepoMessagesCheck(Double.valueOf(10.0));
   }
 
   @Test
   public void unmarshallingByteTest() throws Exception {
     byte b = 101;
-    unmarshallingStateRepoMessagesCheck(new Byte(b));
+    unmarshallingStateRepoMessagesCheck(Byte.valueOf(b));
   }
 
   @Test
   public void unmarshallingCharacterTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Character('b'));
+    unmarshallingStateRepoMessagesCheck(Character.valueOf('b'));
   }
 
   @Test
   public void unmarshallingStringTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new String("John"));
+    unmarshallingStateRepoMessagesCheck("John");
   }
 
   @Test
   public void unmarshallingBooleanTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Boolean(true));
+    unmarshallingStateRepoMessagesCheck(Boolean.TRUE);
   }
 
   @Test
   public void unmarshallingShortTest() throws Exception {
-    unmarshallingStateRepoMessagesCheck(new Short((short) 1));
+    unmarshallingStateRepoMessagesCheck(Short.valueOf((short) 1));
   }
 
   @Test

--- a/clustered/ehcache-common/src/test/java/org/ehcache/clustered/common/internal/messages/ChainCodecTest.java
+++ b/clustered/ehcache-common/src/test/java/org/ehcache/clustered/common/internal/messages/ChainCodecTest.java
@@ -115,7 +115,7 @@ public class ChainCodecTest {
     StructEncoder<Void> encoder = ChainCodec.CHAIN_ENTRY_STRUCT.encoder();
     ChainCodec.encodeChainEntry(encoder, entry);
 
-    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder((ByteBuffer) encoder.encode().flip()));
+    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder(encoder.encode().flip()));
 
 
     assertThat(decoded.getKey(), is(42L));
@@ -132,7 +132,7 @@ public class ChainCodecTest {
     StructEncoder<Void> encoder = ChainCodec.CHAIN_ENTRY_STRUCT.encoder();
     ChainCodec.encodeChainEntry(encoder, entry);
 
-    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder((ByteBuffer) encoder.encode().flip()));
+    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder(encoder.encode().flip()));
 
     assertThat(decoded.getKey(), is(43L));
     assertThat(decoded.getValue().isEmpty(), is(false));
@@ -150,7 +150,7 @@ public class ChainCodecTest {
     StructEncoder<Void> encoder = ChainCodec.CHAIN_ENTRY_STRUCT.encoder();
     ChainCodec.encodeChainEntry(encoder, entry);
 
-    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder((ByteBuffer) encoder.encode().flip()));
+    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder(encoder.encode().flip()));
 
     assertThat(decoded.getKey(), is(44L));
     assertThat(decoded.getValue().isEmpty(), is(false));
@@ -164,7 +164,7 @@ public class ChainCodecTest {
     StructEncoder<Void> encoder = ChainCodec.CHAIN_ENTRY_STRUCT.encoder();
     ChainCodec.encodeChainEntry(encoder, entry);
 
-    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder((ByteBuffer) encoder.encode().flip()));
+    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder(encoder.encode().flip()));
 
     assertThat(decoded.getKey(), is(45L));
     assertThat(decoded.getValue().isEmpty(), is(false));
@@ -180,7 +180,7 @@ public class ChainCodecTest {
     StructEncoder<Void> encoder = ChainCodec.CHAIN_ENTRY_STRUCT.encoder();
     ChainCodec.encodeChainEntry(encoder, entry);
 
-    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder((ByteBuffer) encoder.encode().flip()));
+    Map.Entry<Long, Chain> decoded = ChainCodec.decodeChainEntry(ChainCodec.CHAIN_ENTRY_STRUCT.decoder(encoder.encode().flip()));
 
     assertThat(decoded.getKey(), is(46L));
     assertThat(decoded.getValue().isEmpty(), is(true));

--- a/clustered/ehcache-common/src/test/java/org/ehcache/clustered/common/internal/messages/ResponseCodecTest.java
+++ b/clustered/ehcache-common/src/test/java/org/ehcache/clustered/common/internal/messages/ResponseCodecTest.java
@@ -76,7 +76,7 @@ public class ResponseCodecTest {
 
   @Test
   public void testMapValueCodec() throws Exception {
-    Object subject = new Integer(10);
+    Object subject = Integer.valueOf(10);
     EhcacheEntityResponse mapValue = mapValue(subject);
     EhcacheEntityResponse.MapValue decoded =
         (EhcacheEntityResponse.MapValue) RESPONSE_CODEC.decode(RESPONSE_CODEC.encode(mapValue));

--- a/clustered/integration-test/build.gradle
+++ b/clustered/integration-test/build.gradle
@@ -40,11 +40,18 @@ dependencies {
   }
 
   testImplementation project(':ehcache-management')
-  testImplementation "org.terracotta.management:nms-entity-client:$terracottaPlatformVersion"
-  testImplementation "org.terracotta.management:nms-agent-entity-client:$terracottaPlatformVersion"
-  testImplementation "org.terracotta:terracotta-utilities-port-chooser:$terracottaUtilitiesVersion"
+  testImplementation ("org.terracotta.management:nms-entity-client:$terracottaPlatformVersion") {
+    exclude group: 'org.slf4j'
+  }
+  testImplementation ("org.terracotta.management:nms-agent-entity-client:$terracottaPlatformVersion") {
+    exclude group: 'org.slf4j'
+  }
+  testImplementation ("org.terracotta:terracotta-utilities-port-chooser:$terracottaUtilitiesVersion") {
+    exclude group: 'org.slf4j'
+  }
   testImplementation("org.terracotta:galvan-platform-support:$terracottaPlatformVersion") {
     exclude group: 'org.terracotta', module: 'terracotta-utilities-port-chooser'
+    exclude group: 'org.slf4j'
   }
   testImplementation "javax.cache:cache-api:$jcacheVersion"
 }
@@ -79,5 +86,16 @@ configurations.all {
         .because('CVE-2020-15250')
         .with(module('junit:junit:4.13.1'))
     }
+    eachDependency { details ->
+      if (details.requested.group == 'ch.qos.logback' &&
+        (details.requested.name == 'logback-classic' || details.requested.name == 'logback-core')) {
+        def enforcedLogbackVersion = project.property('logbackVersion').toString()
+        if (!details.requested.version || details.requested.version < enforcedLogbackVersion) {
+          details.useVersion enforcedLogbackVersion
+          details.because 'Force logback >= ' + enforcedLogbackVersion
+        }
+      }
+    }
   }
 }
+

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/management/ClusteringManagementServiceTest.java
@@ -173,7 +173,7 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
     allDescriptors.addAll(OFFHEAP_DESCRIPTORS);
     allDescriptors.addAll(CLUSTERED_DESCRIPTORS);
 
-    assertThat(descriptors).hasSameElementsAs(allDescriptors);
+    assertThat(allDescriptors).hasSameElementsAs(descriptors);
   }
 
   @Test
@@ -203,9 +203,9 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
 
     // stats
 
-    assertThat(tierCapabilities[3].getDescriptors()).hasSameElementsAs(SERVER_STORE_DESCRIPTORS);
-    assertThat(managerCapabilities[2].getDescriptors()).hasSameElementsAs(POOL_DESCRIPTORS);
-    assertThat(tierCapabilities[1].getDescriptors()).hasSameElementsAs(POOL_DESCRIPTORS);
+    assertThat(new ArrayList<Descriptor>(tierCapabilities[3].getDescriptors())).hasSameElementsAs(SERVER_STORE_DESCRIPTORS);
+    assertThat(new ArrayList<Descriptor>(managerCapabilities[2].getDescriptors())).hasSameElementsAs(POOL_DESCRIPTORS);
+    assertThat(new ArrayList<Descriptor>(tierCapabilities[1].getDescriptors())).hasSameElementsAs(POOL_DESCRIPTORS);
 
     // ClusterTierManagerSettings
 
@@ -271,7 +271,7 @@ public class ClusteringManagementServiceTest extends AbstractClusteringManagemen
 
     assertThat(managerCapabilities[0].getDescriptors()).hasSize(3); // time + 2 resources
 
-    assertThat(managerCapabilities[1].getDescriptors()).hasSameElementsAs(OFFHEAP_RES_DESCRIPTORS);
+    assertThat(new ArrayList<Descriptor>(managerCapabilities[1].getDescriptors())).hasSameElementsAs(OFFHEAP_RES_DESCRIPTORS);
   }
 
   @Test

--- a/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicClusteredCacheOpsReplicationMultiThreadedTest.java
+++ b/clustered/integration-test/src/test/java/org/ehcache/clustered/replication/BasicClusteredCacheOpsReplicationMultiThreadedTest.java
@@ -269,7 +269,16 @@ public class BasicClusteredCacheOpsReplicationMultiThreadedTest {
 
     clearFuture.get();
 
-    universalSet.forEach(x -> assertThat(cache2.get(x), nullValue()));
+    long deadline = System.currentTimeMillis() + 30_000;
+    for (Long x : universalSet) {
+      while (cache2.get(x) != null) {
+        if (System.currentTimeMillis() > deadline) {
+          assertThat("Key " + x + " still present in cache2 after 30s wait", cache2.get(x), nullValue());
+          break;
+        }
+        Thread.sleep(100);
+      }
+    }
 
   }
 

--- a/clustered/osgi-test/build.gradle
+++ b/clustered/osgi-test/build.gradle
@@ -36,8 +36,14 @@ dependencies {
   osgiModule project(':clustered:ehcache-clustered')
   osgiModule "javax.cache:cache-api:$parent.jcacheVersion"
   osgiModule "org.slf4j:slf4j-simple:$parent.slf4jVersion"
-  osgiModule "org.terracotta:terracotta-utilities-test-tools:$terracottaUtilitiesVersion"
-  osgiModule "org.terracotta:terracotta-utilities-port-chooser:$terracottaUtilitiesVersion"
+  // SLF4J 2.x requires osgi.serviceloader.processor; Apache Aries SPIFly provides it
+  osgiModule 'org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:1.3.7'
+  osgiModule ("org.terracotta:terracotta-utilities-test-tools:$terracottaUtilitiesVersion") {
+    exclude group: 'org.slf4j'
+  }
+  osgiModule ("org.terracotta:terracotta-utilities-port-chooser:$terracottaUtilitiesVersion") {
+    exclude group: 'org.slf4j'
+  }
   osgiModule 'org.apache.felix:org.apache.felix.scr:2.2.0'
   osgiModule 'com.sun.activation:javax.activation:1.2.0'
   osgiModule 'org.osgi:org.osgi.util.promise:1.2.0'
@@ -59,6 +65,11 @@ configurations.all {
         .using(module('org.ops4j.pax.url:pax-url-classpath:2.6.11'))
       substitute(module('org.ops4j.pax.url:pax-url-link:2.6.8'))
         .using(module('org.ops4j.pax.url:pax-url-link:2.6.11'))
+      substitute(module('org.ops4j.pax.url:pax-url-aether:2.6.8'))
+        .using(module('org.ops4j.pax.url:pax-url-aether:3.0.2'))
+      substitute(module('org.apache.commons:commons-lang3:3.12.0'))
+        .using(module('org.apache.commons:commons-lang3:3.18.0'))
+        .because('CVE-2025-48924')
       substitute(module('org.osgi:org.osgi.util.function:1.1.0'))
         .using(module('org.osgi:org.osgi.util.function:1.2.0'))
         .because('Dependency divergence in org.osgi:org.osgi.util.promise:1.2.0')

--- a/clustered/server/ehcache-entity/build.gradle
+++ b/clustered/server/ehcache-entity/build.gradle
@@ -28,12 +28,18 @@ publishing.publications.withType(MavenPublication) {
 
 dependencies {
   service project(':clustered:server:ehcache-service-api')
-  service "org.terracotta.management:monitoring-service-api:$terracottaPlatformVersion"
-  service "org.terracotta.management:management-registry:$terracottaPlatformVersion"
+  service ("org.terracotta.management:monitoring-service-api:$terracottaPlatformVersion") {
+    exclude group: 'org.slf4j'
+  }
+  service ("org.terracotta.management:management-registry:$terracottaPlatformVersion") {
+    exclude group: 'org.slf4j'
+  }
 
   api project(':clustered:ehcache-common')
   implementation "org.terracotta:runnel:$terracottaPlatformVersion"
-  implementation "org.terracotta:offheap-store:$offheapVersion"
+  implementation ("org.terracotta:offheap-store:$offheapVersion") {
+    exclude group:'org.slf4j'
+  }
   implementation "org.terracotta:client-message-tracker:$terracottaPlatformVersion"
 
   testImplementation project(':clustered:server:ehcache-service')

--- a/clustered/server/ehcache-service/build.gradle
+++ b/clustered/server/ehcache-service/build.gradle
@@ -29,12 +29,19 @@ publishing.publications.withType(MavenPublication) {
 dependencies {
   service project(':clustered:server:ehcache-service-api')
   service "org.terracotta:offheap-resource:$terracottaPlatformVersion"
-  service "org.terracotta:statistics:$statisticVersion"
+  service ("org.terracotta:statistics:$statisticVersion") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 
   implementation project(':clustered:ehcache-common')
-  implementation "org.terracotta:offheap-store:$offheapVersion"
+  implementation ("org.terracotta:offheap-store:$offheapVersion") {
+    exclude group:'org.slf4j'
+  }
 
   testImplementation project(':clustered:test-utils')
-  testImplementation "org.terracotta.management:monitoring-service-api:$terracottaPlatformVersion"
+  testImplementation ("org.terracotta.management:monitoring-service-api:$terracottaPlatformVersion") {
+    exclude group: 'org.slf4j'
+  }
   testImplementation "org.terracotta:passthrough-server:$terracottaPassthroughTestingVersion"
+  testImplementation 'javax.xml.bind:jaxb-api:[2.2,3)'
 }

--- a/clustered/server/ehcache-service/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainStorageEngine.java
+++ b/clustered/server/ehcache-service/src/main/java/org/ehcache/clustered/server/offheap/OffHeapChainStorageEngine.java
@@ -215,7 +215,7 @@ public class OffHeapChainStorageEngine<K> implements ChainStorageEngine<K>, Bina
       detachedContiguousBuffer.reset();
       element = storage.readLong(element + ELEMENT_HEADER_NEXT_OFFSET);
     } while (element != chain);
-    return (ByteBuffer)detachedContiguousBuffer.flip();
+    return detachedContiguousBuffer.flip();
   }
 
   @Override
@@ -700,7 +700,7 @@ public class OffHeapChainStorageEngine<K> implements ChainStorageEngine<K>, Bina
     }
 
     private Element element(ByteBuffer attachedBuffer, final long sequence) {
-      final ByteBuffer detachedBuffer = (ByteBuffer) ByteBuffer.allocate(attachedBuffer.remaining()).put(attachedBuffer).flip();
+      final ByteBuffer detachedBuffer = ByteBuffer.allocate(attachedBuffer.remaining()).put(attachedBuffer).flip();
 
       return new SequencedElement() {
 

--- a/clustered/server/ehcache-service/src/test/java/org/ehcache/clustered/server/offheap/ChainMapExtensionTest.java
+++ b/clustered/server/ehcache-service/src/test/java/org/ehcache/clustered/server/offheap/ChainMapExtensionTest.java
@@ -144,7 +144,7 @@ public class ChainMapExtensionTest {
     while (buffer.hasRemaining()) {
       buffer.put((byte) i);
     }
-    return (ByteBuffer) buffer.flip();
+    return buffer.flip();
   }
 
   private static Matcher<Element> element(int i) {

--- a/clustered/server/ehcache-service/src/test/java/org/ehcache/clustered/server/offheap/ChainMapTest.java
+++ b/clustered/server/ehcache-service/src/test/java/org/ehcache/clustered/server/offheap/ChainMapTest.java
@@ -504,7 +504,7 @@ public class ChainMapTest {
     while (buffer.hasRemaining()) {
       buffer.put((byte) i);
     }
-    return (ByteBuffer) buffer.flip();
+    return buffer.flip();
   }
 
   private static Matcher<Element> element(final int i) {

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <property name="charset" value="UTF-8"/>
 
@@ -22,6 +22,15 @@
   <module name="Header">
     <property name="headerFile" value="${rootDir}/config/java.header"/>
     <property name="fileExtensions" value="java"/>
+    <!-- Allow Checkstyle to skip the IBM line so the regex check below can enforce it -->
+    <property name="ignoreLines" value="3"/>
+  </module>
+
+  <!-- Allow both 2025 and later IBM copyright lines -->
+  <module name="RegexpSingleline">
+    <property name="format" value="^ \\* Copyright IBM Corp\\. 2024, 202[5-9]$"/>
+    <property name="message" value="IBM copyright line must use 2024, 2025 or later"/>
+    <property name="fileExtensions" value="java"/>
   </module>
 
   <module name="SuppressionFilter">
@@ -29,7 +38,7 @@
   </module>
 
   <module name="TreeWalker">
-      <!-- Allow suppression tags in the code e.g. CSOFF: AvoidStaticImport -->
+    <!-- Allow suppression tags in the code e.g. CSOFF: AvoidStaticImport -->
     <module name="SuppressionCommentFilter">
       <property name="offCommentFormat" value="CSOFF\: ([\w\|]+)"/>
       <property name="onCommentFormat" value="CSON\: ([\w\|]+)"/>

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/SPIStoreTester.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/SPIStoreTester.java
@@ -18,6 +18,8 @@
 package org.ehcache.internal.store;
 
 import org.ehcache.core.spi.store.Store;
+import org.ehcache.spi.resilience.StoreAccessException;
+import org.ehcache.spi.test.LegalSPITesterException;
 import org.ehcache.spi.test.SPITester;
 
 /**
@@ -30,10 +32,39 @@ import org.ehcache.spi.test.SPITester;
 
 public class SPIStoreTester<K, V> extends SPITester {
 
+  protected static final String SPI_WARNING = "Warning, an exception is thrown due to the SPI test";
+
   protected final StoreFactory<K,V> factory;
 
   public SPIStoreTester(final StoreFactory<K,V> factory) {
     this.factory = factory;
+  }
+
+  @FunctionalInterface
+  protected interface StoreRunnable {
+    void run() throws StoreAccessException;
+  }
+
+  protected <T extends Throwable> T expectException(Class<T> expected, StoreRunnable action)
+      throws LegalSPITesterException {
+    try {
+      action.run();
+    } catch (Throwable throwable) {
+      if (expected.isInstance(throwable)) {
+        return expected.cast(throwable);
+      }
+      if (throwable instanceof StoreAccessException) {
+        throw new LegalSPITesterException(SPI_WARNING, throwable);
+      }
+      if (throwable instanceof RuntimeException) {
+        throw (RuntimeException) throwable;
+      }
+      if (throwable instanceof Error) {
+        throw (Error) throwable;
+      }
+      throw new AssertionError("Unexpected checked exception", throwable);
+    }
+    throw new AssertionError("Expected " + expected.getSimpleName() + " to be thrown");
   }
 
 }

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreContainsKeyTest.java
@@ -73,14 +73,7 @@ public class StoreContainsKeyTest<K, V> extends SPIStoreTester<K, V> {
 
     K key = null;
 
-    try {
-      kvStore.containsKey(key);
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.containsKey(key));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreGetTest.java
@@ -115,14 +115,7 @@ public class StoreGetTest<K, V> extends SPIStoreTester<K, V> {
 
     K key = null;
 
-    try {
-      kvStore.get(key);
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.get(key));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutIfAbsentTest.java
@@ -97,34 +97,24 @@ public class StorePutIfAbsentTest<K, V> extends SPIStoreTester<K, V> {
 
   @SPITest
   public void nullKeyThrowsException()
-      throws StoreAccessException, IllegalAccessException, InstantiationException {
+      throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore = factory.newStore();
 
     K key = null;
     V value = factory.createValue(1);
 
-    try {
-      kvStore.putIfAbsent(key, value, b -> {});
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    }
+    expectException(NullPointerException.class, () -> kvStore.putIfAbsent(key, value, b -> {}));
   }
 
   @SPITest
   public void nullValueThrowsException()
-      throws StoreAccessException, IllegalAccessException, InstantiationException {
+      throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore = factory.newStore();
 
     K key = factory.createKey(1);
     V value = null;
 
-    try {
-      kvStore.putIfAbsent(key, value, b -> {});
-      throw new AssertionError("Expected NullPointerException because the value is null");
-    } catch (NullPointerException e) {
-      // expected
-    }
+    expectException(NullPointerException.class, () -> kvStore.putIfAbsent(key, value, b -> {}));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StorePutTest.java
@@ -64,14 +64,7 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     K key = null;
     V value = factory.createValue(1);
 
-    try {
-      kvStore.put(key, value);
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.put(key, value));
   }
 
   @SPITest
@@ -82,14 +75,7 @@ public class StorePutTest<K, V> extends SPIStoreTester<K, V> {
     K key = factory.createKey(1);
     V value = null;
 
-    try {
-      kvStore.put(key, value);
-      throw new AssertionError("Expected NullPointerException because the value is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.put(key, value));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyTest.java
@@ -89,14 +89,7 @@ public class StoreRemoveKeyTest<K, V> extends SPIStoreTester<K, V> {
       throws IllegalAccessException, InstantiationException, LegalSPITesterException {
     kvStore = factory.newStore();
 
-    try {
-      kvStore.remove(null);
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.remove(null));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreRemoveKeyValueTest.java
@@ -164,14 +164,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     K key = null;
     V value = factory.createValue(1);
 
-    try {
-      kvStore.remove(key, value);
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.remove(key, value));
   }
 
   @SPITest
@@ -182,14 +175,7 @@ public class StoreRemoveKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     K key = factory.createKey(1);
     V value = null;
 
-    try {
-      kvStore.remove(key, value);
-      throw new AssertionError("Expected NullPointerException because the value is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.remove(key, value));
   }
 
   @SPITest

--- a/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
+++ b/core-spi-test/src/main/java/org/ehcache/internal/store/StoreReplaceKeyValueTest.java
@@ -117,14 +117,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
     K key = null;
     V value = factory.createValue(1);
 
-    try {
-      kvStore.replace(key, value);
-      throw new AssertionError("Expected NullPointerException because the key is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.replace(key, value));
   }
 
   @SPITest
@@ -134,14 +127,7 @@ public class StoreReplaceKeyValueTest<K, V> extends SPIStoreTester<K, V> {
 
     K key = factory.createKey(1);
 
-    try {
-      kvStore.replace(key, null);
-      throw new AssertionError("Expected NullPointerException because the value is null");
-    } catch (NullPointerException e) {
-      // expected
-    } catch (StoreAccessException e) {
-      throw new LegalSPITesterException("Warning, an exception is thrown due to the SPI test");
-    }
+    expectException(NullPointerException.class, () -> kvStore.replace(key, null));
   }
 
   @SPITest

--- a/demos/00-NoCache/build.gradle
+++ b/demos/00-NoCache/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+  id 'application'
+}
+
+application {
+  mainClass = 'org.ehcache.demos.peeper.PeeperServer'
+}

--- a/demos/00-NoCache/src/main/java/org/ehcache/demos/peeper/PeeperServer.java
+++ b/demos/00-NoCache/src/main/java/org/ehcache/demos/peeper/PeeperServer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.demos.peeper;
+
+import org.ehcache.demos.server.EmbeddedPeeperServer;
+
+public class PeeperServer {
+
+  public static void main(String[] args) throws Exception {
+    EmbeddedPeeperServer.run(PeeperServletContextListener::new, PeeperServlet::new);
+  }
+}

--- a/demos/00-NoCache/src/main/java/org/ehcache/demos/peeper/PeeperServlet.java
+++ b/demos/00-NoCache/src/main/java/org/ehcache/demos/peeper/PeeperServlet.java
@@ -16,11 +16,11 @@
  */
 package org.ehcache.demos.peeper;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;

--- a/demos/00-NoCache/src/main/java/org/ehcache/demos/peeper/PeeperServletContextListener.java
+++ b/demos/00-NoCache/src/main/java/org/ehcache/demos/peeper/PeeperServletContextListener.java
@@ -16,9 +16,9 @@
  */
 package org.ehcache.demos.peeper;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.annotation.WebListener;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
 
 /**
  * @author Ludovic Orban

--- a/demos/01-CacheAside/build.gradle
+++ b/demos/01-CacheAside/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+  id 'application'
+}
+
+application {
+  mainClass = 'org.ehcache.demos.peeper.PeeperServer'
+}

--- a/demos/01-CacheAside/config/checkstyle-suppressions.xml
+++ b/demos/01-CacheAside/config/checkstyle-suppressions.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">

--- a/demos/01-CacheAside/src/main/java/org/ehcache/demos/peeper/PeeperServer.java
+++ b/demos/01-CacheAside/src/main/java/org/ehcache/demos/peeper/PeeperServer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.demos.peeper;
+
+import org.ehcache.demos.server.EmbeddedPeeperServer;
+
+public class PeeperServer {
+
+  public static void main(String[] args) throws Exception {
+    EmbeddedPeeperServer.run(PeeperServletContextListener::new, PeeperServlet::new);
+  }
+}

--- a/demos/01-CacheAside/src/main/java/org/ehcache/demos/peeper/PeeperServlet.java
+++ b/demos/01-CacheAside/src/main/java/org/ehcache/demos/peeper/PeeperServlet.java
@@ -16,11 +16,11 @@
  */
 package org.ehcache.demos.peeper;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;

--- a/demos/01-CacheAside/src/main/java/org/ehcache/demos/peeper/PeeperServletContextListener.java
+++ b/demos/01-CacheAside/src/main/java/org/ehcache/demos/peeper/PeeperServletContextListener.java
@@ -16,9 +16,9 @@
  */
 package org.ehcache.demos.peeper;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.annotation.WebListener;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
 
 /**
  * @author Ludovic Orban

--- a/demos/build.gradle
+++ b/demos/build.gradle
@@ -1,60 +1,31 @@
 plugins {
+  id 'org.ehcache.build.conventions.java-library'
   id 'org.ehcache.build.conventions.war' apply false
-  id 'org.gretty' apply false
+}
+
+def jettyVersion = '12.1.5'
+
+dependencies {
+  api platform("org.eclipse.jetty:jetty-bom:${jettyVersion}")
+  api 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+  api 'org.eclipse.jetty:jetty-server'
+  api "org.eclipse.jetty.ee10:jetty-ee10-servlet:${jettyVersion}"
+}
+
+configurations.configureEach {
+  resolutionStrategy {
+    force "org.slf4j:slf4j-api:${project.property('slf4jVersion')}"
+  }
 }
 
 subprojects {
   apply plugin: 'org.ehcache.build.conventions.war'
-  apply plugin: 'org.gretty'
-
-  gretty {
-    httpPort = 8080
-    contextPath = '/'
-    servletContainer = 'jetty9'
-  }
 
   dependencies {
+    implementation project(':demos')
     implementation project(':ehcache-impl')
-    implementation 'javax.servlet:javax.servlet-api:3.1.0'
-    runtimeOnly 'ch.qos.logback:logback-classic:1.2.11'
-    runtimeOnly 'com.h2database:h2:1.4.196'
-  }
-
-  configurations.all {
-    resolutionStrategy {
-      dependencySubstitution {
-        substitute(module('org.slf4j:slf4j-api'))
-          .because('org.gretty:gretty-runner-jetty declares a very old version of slf4j')
-          .with(module('org.slf4j:slf4j-api:' + project.property('slf4jVersion')))
-      }
-    }
-  }
-
-  /*
-   * This substitution is solely to permit the 'dependencies' task to complete normally --
-   * the Jetty 8 environment provided by gretty is not used in this module.
-   */
-  configurations.named('grettyRunnerJetty8') {
-    resolutionStrategy {
-      dependencySubstitution {
-        substitute(module('org.eclipse.jetty.orbit:javax.servlet.jsp:2.1.0.v201105211820'))
-          .because('gretty plug-in pulls in older version for Jetty8')
-          .with(module('org.eclipse.jetty.orbit:javax.servlet.jsp:2.2.0.v201112011158'))
-      }
-    }
-  }
-
-  /*
-   * This substitution is solely to permit the 'dependencies' task to complete normally --
-   * the Jetty 9.3 environment provided by gretty is not used in this module.
-   */
-  configurations.named('grettyRunnerJetty93') {
-    resolutionStrategy {
-      dependencySubstitution {
-        substitute(module('org.eclipse.jetty.toolchain:jetty-schemas:3.1.M0'))
-          .because('gretty plug-in pulls in older version for Jetty9.3')
-          .with(module('org.eclipse.jetty.toolchain:jetty-schemas:3.1'))
-      }
-    }
+    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+    runtimeOnly "ch.qos.logback:logback-classic:${project.property('logbackVersion')}"
+    runtimeOnly 'com.h2database:h2:2.4.240'
   }
 }

--- a/demos/config/checkstyle-suppressions.xml
+++ b/demos/config/checkstyle-suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+  <suppress files="^((?!.*test[\\/]java[\\/]org[\\/]ehcache[\\/]docs[\\/].*).)*$" checks="AvoidStaticImport"/>
+</suppressions>

--- a/demos/src/main/java/org/ehcache/demos/server/EmbeddedPeeperServer.java
+++ b/demos/src/main/java/org/ehcache/demos/server/EmbeddedPeeperServer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehcache.demos.server;
+
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.http.HttpServlet;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+public final class EmbeddedPeeperServer {
+
+  private EmbeddedPeeperServer() {
+  }
+
+  public static void run(Supplier<? extends ServletContextListener> listenerSupplier,
+                         Supplier<? extends HttpServlet> servletSupplier) throws Exception {
+    Objects.requireNonNull(listenerSupplier, "listenerSupplier");
+    Objects.requireNonNull(servletSupplier, "servletSupplier");
+
+    Server server = new Server();
+
+    ServerConnector connector = new ServerConnector(server);
+    connector.setPort(8080);
+    connector.setHost(System.getenv().getOrDefault("HOST", "0.0.0.0"));
+    server.addConnector(connector);
+
+    ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+    context.setContextPath("/");
+    context.addEventListener(listenerSupplier.get());
+    context.addServlet(new ServletHolder(servletSupplier.get()), "/*");
+
+    server.setHandler(context);
+
+    server.start();
+    server.join();
+  }
+}

--- a/docs/src/docs/asciidoc/user/examples.adoc
+++ b/docs/src/docs/asciidoc/user/examples.adoc
@@ -39,8 +39,7 @@ from the database to display the Peeper web page. To run this implementation:
 
 [source,bash]
 ----
-cd ehcache3/demos/00-NoCache
-../../gradlew appStart
+./gradlew :demos:00-NoCache:run
 ----
 
 This builds the necessary components, starts a http://eclipse.org/jetty/[Jetty] web service,
@@ -73,8 +72,7 @@ the cache is cleared.  To run this implementation:
 
 [source,bash]
 ----
-cd ehcache3/demos/01-CacheAside
-../../gradlew appStart
+./gradlew :demos:01-CacheAside:run
 ----
 
 This builds the necessary components, starts a http://eclipse.org/jetty/[Jetty] web service,

--- a/ehcache-107/build.gradle
+++ b/ehcache-107/build.gradle
@@ -66,7 +66,9 @@ dependencies {
   commonApi "javax.cache:cache-api:$parent.jcacheVersion"
 
   commonImplementation project(':ehcache-impl')
-  commonImplementation "org.terracotta:statistics:$statisticVersion"
+  commonImplementation ("org.terracotta:statistics:$statisticVersion") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 
   implementation project(':ehcache-xml')
   jakartaImplementation(project(':ehcache-xml')) {

--- a/ehcache-107/src/test/java/org/ehcache/ParsesConfigurationExtensionTest.java
+++ b/ehcache-107/src/test/java/org/ehcache/ParsesConfigurationExtensionTest.java
@@ -53,7 +53,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class ParsesConfigurationExtensionTest {
 
   @Test
-  public void testConfigParse() throws ClassNotFoundException, SAXException, InstantiationException, IllegalAccessException, IOException {
+  public void testConfigParse() throws SAXException, ReflectiveOperationException, IOException {
     final XmlConfiguration configuration = new XmlConfiguration(this.getClass().getResource("/ehcache-107.xml"));
     final DefaultJsr107Service jsr107Service = new DefaultJsr107Service(ServiceUtils.findSingletonAmongst(Jsr107Configuration.class, configuration.getServiceCreationConfigurations()));
 
@@ -66,7 +66,7 @@ public class ParsesConfigurationExtensionTest {
 
   @SuppressWarnings("rawtypes")
   @Test
-  public void testXmlExample() throws ClassNotFoundException, SAXException, InstantiationException, IOException, IllegalAccessException {
+  public void testXmlExample() throws SAXException, ReflectiveOperationException, IOException {
     XmlConfiguration config = new XmlConfiguration(ParsesConfigurationExtensionTest.class.getResource("/ehcache-example.xml"));
     final DefaultJsr107Service jsr107Service = new DefaultJsr107Service(ServiceUtils.findSingletonAmongst(Jsr107Configuration.class, config.getServiceCreationConfigurations()));
 

--- a/ehcache-core/build.gradle
+++ b/ehcache-core/build.gradle
@@ -29,7 +29,9 @@ publishing.publications.withType(MavenPublication) {
 
 dependencies {
   api project(':ehcache-api')
-  implementation "org.terracotta:statistics:$parent.statisticVersion"
+  implementation ("org.terracotta:statistics:$parent.statisticVersion") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
   compileOnly 'org.osgi:osgi.core:6.0.0'
   compileOnly 'org.osgi:org.osgi.service.component.annotations:1.3.0'
   testImplementation project(':spi-tester')

--- a/ehcache-core/src/main/java/org/ehcache/core/util/ClassLoading.java
+++ b/ehcache-core/src/main/java/org/ehcache/core/util/ClassLoading.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
-import static java.security.AccessController.doPrivileged;
 import static java.util.Collections.enumeration;
 import static java.util.Collections.list;
 import static java.util.stream.Collectors.toList;
@@ -57,14 +56,14 @@ public class ClassLoading {
     }
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("removal")
   public static ClassLoader delegationChain(Supplier<ClassLoader> loader, ClassLoader ... loaders) {
-    return doPrivileged((PrivilegedAction<ClassLoader>) () -> new ChainedClassLoader(concat(of(loader), of(loaders).map(l -> () -> l)).collect(toList())));
+    return java.security.AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> new ChainedClassLoader(concat(of(loader), of(loaders).map(l -> () -> l)).collect(toList())));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("removal")
   public static ClassLoader delegationChain(ClassLoader ... loaders) {
-    return doPrivileged((PrivilegedAction<ClassLoader>) () -> new ChainedClassLoader(of(loaders).<Supplier<ClassLoader>>map(l -> () -> l).collect(toList())));
+    return java.security.AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> new ChainedClassLoader(of(loaders).<Supplier<ClassLoader>>map(l -> () -> l).collect(toList())));
   }
 
   private static class ChainedClassLoader extends ClassLoader {

--- a/ehcache-core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
+++ b/ehcache-core/src/test/java/org/ehcache/core/EhcacheManagerTest.java
@@ -117,7 +117,7 @@ public class EhcacheManagerTest {
     Store store = mock(Store.class);
     CacheEventDispatcherFactory cacheEventNotificationListenerServiceProvider = mock(CacheEventDispatcherFactory.class);
 
-    when(storeProvider.createStore(any(Store.Configuration.class), ArgumentMatchers.<ServiceConfiguration>any())).thenReturn(store);
+    when(storeProvider.createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(store);
     when(store.getConfigurationChangeListeners()).thenReturn(new ArrayList<>());
     when(cacheEventNotificationListenerServiceProvider.createCacheEventDispatcher(store)).thenReturn(mock(CacheEventDispatcher.class));
 
@@ -200,7 +200,7 @@ public class EhcacheManagerTest {
 
     final Collection<Service> services = getServices(storeProvider, cenlProvider);
     when(storeProvider
-        .createStore(ArgumentMatchers.<Store.Configuration>any(), ArgumentMatchers.<ServiceConfiguration[]>any())).thenReturn(mock);
+        .createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(mock);
     EhcacheManager cacheManager = new EhcacheManager(config, services);
     cacheManager.init();
     assertSame(ClassLoading.getDefaultClassLoader(), cacheManager.getClassLoader());
@@ -240,7 +240,7 @@ public class EhcacheManagerTest {
 
     final Collection<Service> services = getServices(storeProvider, cenlProvider);
     when(storeProvider
-        .createStore(ArgumentMatchers.<Store.Configuration>any(), ArgumentMatchers.<ServiceConfiguration[]>any())).thenReturn(mock);
+        .createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(mock);
     EhcacheManager cacheManager = new EhcacheManager(config, services);
     cacheManager.init();
     assertSame(cl1, cacheManager.getClassLoader());
@@ -274,7 +274,7 @@ public class EhcacheManagerTest {
     final Collection<Service> services = getServices(storeProvider, cenlProvider);
 
     when(storeProvider
-        .createStore(ArgumentMatchers.<Store.Configuration>any(), ArgumentMatchers.<ServiceConfiguration[]>any())).thenReturn(mock);
+        .createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(mock);
 
     Map<String, CacheConfiguration<?, ?>> caches = newCacheMap();
     caches.put("bar", cacheConfiguration);
@@ -303,7 +303,7 @@ public class EhcacheManagerTest {
     final Collection<Service> services = getServices(storeProvider, cenlProvider);
 
     when(storeProvider
-        .createStore(ArgumentMatchers.<Store.Configuration>any(), ArgumentMatchers.<ServiceConfiguration[]>any())).thenReturn(mock);
+        .createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(mock);
 
     final CacheConfiguration<Integer, String> cacheConfiguration = new TestCacheConfig<>(Integer.class, String.class);
     Map<String, CacheConfiguration<?, ?>> caches = newCacheMap();
@@ -341,7 +341,7 @@ public class EhcacheManagerTest {
 
     final Collection<Service> services = getServices(storeProvider, cenlProvider);
     when(storeProvider
-        .createStore(ArgumentMatchers.<Store.Configuration>any(), ArgumentMatchers.<ServiceConfiguration[]>any())).thenReturn(mock);
+        .createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(mock);
 
     final CacheConfiguration<Integer, String> cacheConfiguration = new TestCacheConfig<>(Integer.class, String.class);
     Map<String, CacheConfiguration<?, ?>> caches = newCacheMap();
@@ -406,7 +406,7 @@ public class EhcacheManagerTest {
     when(cenlProvider.createCacheEventDispatcher(mock)).thenReturn(cenlServiceMock);
     Collection<Service> services = getServices(cacheLoaderWriterProvider, decoratorLoaderWriterProvider, storeProvider, cenlProvider);
     when(storeProvider
-        .createStore(ArgumentMatchers.<Store.Configuration>any(), ArgumentMatchers.<ServiceConfiguration[]>any())).thenReturn(mock);
+        .createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(mock);
 
     EhcacheManager manager = new EhcacheManager(cfg, services);
     manager.init();
@@ -494,8 +494,7 @@ public class EhcacheManagerTest {
         final InternalCache<K, V> ehcache = super.createNewEhcache(alias, config, keyType, valueType);
         caches.add(alias);
         if(caches.size() == 1) {
-          when(storeProvider.createStore(
-                  ArgumentMatchers.<Store.Configuration<K,V>>any(), ArgumentMatchers.<ServiceConfiguration<?, ?>>any()))
+          when(storeProvider.createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class)))
               .thenThrow(thrown);
         }
         return ehcache;
@@ -669,7 +668,7 @@ public class EhcacheManagerTest {
     Store store = mock(Store.class);
     CacheEventDispatcherFactory cacheEventNotificationListenerServiceProvider = mock(CacheEventDispatcherFactory.class);
 
-    when(storeProvider.createStore(any(Store.Configuration.class), ArgumentMatchers.<ServiceConfiguration>any())).thenReturn(store);
+    when(storeProvider.createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(store);
     when(store.getConfigurationChangeListeners()).thenReturn(new ArrayList<>());
     when(cacheEventNotificationListenerServiceProvider.createCacheEventDispatcher(store)).thenReturn(mock(CacheEventDispatcher.class));
 
@@ -716,7 +715,7 @@ public class EhcacheManagerTest {
     Store store = mock(Store.class);
     CacheEventDispatcherFactory cacheEventNotificationListenerServiceProvider = mock(CacheEventDispatcherFactory.class);
 
-    when(storeProvider.createStore(any(Store.Configuration.class), ArgumentMatchers.<ServiceConfiguration>any())).thenReturn(store);
+    when(storeProvider.createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class))).thenReturn(store);
     when(store.getConfigurationChangeListeners()).thenReturn(new ArrayList<>());
     when(cacheEventNotificationListenerServiceProvider.createCacheEventDispatcher(store)).thenReturn(mock(CacheEventDispatcher.class));
 
@@ -754,7 +753,7 @@ public class EhcacheManagerTest {
   public void testCloseWhenRuntimeCacheCreationFails() throws Exception {
     Store.Provider storeProvider = mock(Store.Provider.class);
     when(storeProvider.rank(any(Set.class), any(Collection.class))).thenReturn(1);
-    doThrow(new Error("Test EhcacheManager close.")).when(storeProvider).createStore(any(Store.Configuration.class), ArgumentMatchers.<ServiceConfiguration>any());
+    doThrow(new Error("Test EhcacheManager close.")).when(storeProvider).createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class));
 
     Map<String, CacheConfiguration<?, ?>> caches = newCacheMap();
     DefaultConfiguration config = new DefaultConfiguration(caches, null);
@@ -788,7 +787,7 @@ public class EhcacheManagerTest {
   public void testCloseWhenCacheCreationFailsDuringInitialization() throws Exception {
     Store.Provider storeProvider = mock(Store.Provider.class);
     when(storeProvider.rank(any(Set.class), any(Collection.class))).thenReturn(1);
-    doThrow(new Error("Test EhcacheManager close.")).when(storeProvider).createStore(any(Store.Configuration.class), ArgumentMatchers.<ServiceConfiguration>any());
+    doThrow(new Error("Test EhcacheManager close.")).when(storeProvider).createStore(any(Store.Configuration.class), any(ServiceConfiguration[].class));
 
     CacheConfiguration<Long, String> cacheConfiguration = new TestCacheConfig<>(Long.class, String.class);
     Map<String, CacheConfiguration<?, ?>> caches = newCacheMap();

--- a/ehcache-core/src/test/java/org/ehcache/core/PrefixLoggerTest.java
+++ b/ehcache-core/src/test/java/org/ehcache/core/PrefixLoggerTest.java
@@ -20,9 +20,11 @@ package org.ehcache.core;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
+import org.slf4j.spi.LoggingEventBuilder;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
 import static org.mockito.Mockito.*;
@@ -88,7 +90,9 @@ public class PrefixLoggerTest {
     PrefixLogger prefixLogger = new PrefixLogger(mockLogger, prefix);
 
     for (Method prefixLogMethod : Logger.class.getDeclaredMethods()) {
-
+      if ((prefixLogMethod.getModifiers() & Modifier.PUBLIC) != 0 &&
+              !prefixLogMethod.getReturnType().equals(LoggingEventBuilder.class) &&
+              !prefixLogMethod.getReturnType().equals(boolean.class)) {
       Class<?>[] parameterTypes = prefixLogMethod.getParameterTypes();
       Object[] parameters = new Object[parameterTypes.length];
       for (int j = 0; j < parameterTypes.length; j++) {
@@ -101,9 +105,9 @@ public class PrefixLoggerTest {
         }
       }
 
-      prefixLogMethod.invoke(prefixLogger, parameters);
-      prefixLogMethod.invoke(verify(mockLogger, times(1)), enrichStringParamValues(parameters, isMsgParameter(prefixLogMethod)));
-
+        prefixLogMethod.invoke(prefixLogger, parameters);
+        prefixLogMethod.invoke(verify(mockLogger, times(1)), enrichStringParamValues(parameters, isMsgParameter(prefixLogMethod)));
+      }
     }
   }
 

--- a/ehcache-impl/build.gradle
+++ b/ehcache-impl/build.gradle
@@ -51,15 +51,23 @@ task slowTest(type: Test) {
 
 dependencies {
   api project(':ehcache-core')
-  implementation group: 'org.terracotta', name: 'offheap-store', version: parent.offheapVersion
-  implementation group: 'org.ehcache', name: 'sizeof', version: parent.sizeofVersion
-  implementation group: 'org.terracotta', name: 'terracotta-utilities-tools', version: parent.terracottaUtilitiesVersion
+  implementation (group: 'org.terracotta', name: 'offheap-store', version: parent.offheapVersion) {
+    exclude group:'org.slf4j'
+  }
+  implementation (group: 'org.ehcache', name: 'sizeof', version: parent.sizeofVersion) {
+    exclude group: 'org.slf4j'
+  }
+  implementation (group: 'org.terracotta', name: 'terracotta-utilities-tools', version: parent.terracottaUtilitiesVersion) {
+    exclude group: 'org.slf4j'
+  }
   compileOnly 'org.osgi:org.osgi.service.component.annotations:1.3.0'
   testImplementation testFixtures(project(':ehcache-core'))
   testImplementation project(':core-spi-test')
   testImplementation 'org.ow2.asm:asm:6.2'
   testImplementation 'org.ow2.asm:asm-commons:6.2'
-  testImplementation ("org.terracotta:statistics:$parent.statisticVersion")
+  testImplementation ("org.terracotta:statistics:$parent.statisticVersion") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 }
 
 jar {

--- a/ehcache-impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
+++ b/ehcache-impl/src/main/java/org/ehcache/config/builders/UserManagedCacheBuilder.java
@@ -121,7 +121,7 @@ public class UserManagedCacheBuilder<K, V, T extends UserManagedCache<K, V>> imp
   private boolean useValueSerializingCopier;
   private Serializer<K> keySerializer;
   private Serializer<V> valueSerializer;
-  private int dispatcherConcurrency = 4;
+  private volatile int dispatcherConcurrency = 4;
   private List<CacheEventListenerConfiguration<?>> eventListenerConfigurations = new ArrayList<>();
   private ExecutorService unOrderedExecutor;
   private ExecutorService orderedExecutor;

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/classes/commonslang/reflect/MemberUtils.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/classes/commonslang/reflect/MemberUtils.java
@@ -58,6 +58,7 @@ abstract class MemberUtils {
      * @param o the AccessibleObject to set as accessible
      * @return a boolean indicating whether the accessibility of the object was set to true.
      */
+    @SuppressWarnings("deprecation")
     static boolean setAccessibleWorkaround(final AccessibleObject o) {
         if (o == null || o.isAccessible()) {
             return false;

--- a/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/tiering/TieredStore.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/internal/store/tiering/TieredStore.java
@@ -16,6 +16,7 @@
  */
 package org.ehcache.impl.internal.store.tiering;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.ehcache.Cache;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.ResourceType;
@@ -221,8 +222,9 @@ public class TieredStore<K, V> implements Store<K, V> {
     }
   }
 
+  @SuppressFBWarnings("NN_NAKED_NOTIFY")
   private void swapBackCachingTiers() {
-    if(!cachingTierRef.compareAndSet(noopCachingTier, realCachingTier)) {
+    if (!cachingTierRef.compareAndSet(noopCachingTier, realCachingTier)) {
       throw new AssertionError("Something bad happened");
     }
     synchronized (noopCachingTier) {

--- a/ehcache-impl/src/main/java/org/ehcache/impl/persistence/FileUtils.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/persistence/FileUtils.java
@@ -110,7 +110,6 @@ final class FileUtils {
     }
   }
 
-  @SuppressFBWarnings("DM_GC")
   private static void gc() {
     System.gc();
     System.runFinalization();

--- a/ehcache-impl/src/main/java/org/ehcache/impl/serialization/PlainJavaSerializer.java
+++ b/ehcache-impl/src/main/java/org/ehcache/impl/serialization/PlainJavaSerializer.java
@@ -107,7 +107,7 @@ public class PlainJavaSerializer<T> implements Serializer<T> {
         interfaceClasses[i] = Class.forName(interfaces[i], false, classLoader);
       }
 
-      return Proxy.getProxyClass(classLoader, interfaceClasses);
+      return Proxy.newProxyInstance(classLoader, interfaceClasses, (proxy, method, args) -> null).getClass();
     }
 
     private static final Map<String, Class<?>> primitiveClasses = new HashMap<>();

--- a/ehcache-impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/config/builders/CacheConfigurationBuilderTest.java
@@ -391,8 +391,10 @@ public class CacheConfigurationBuilderTest {
 
     CacheConfigurationBuilder<Object, Object> newBuilder = oldBuilder.withService(newConfig);
 
-    assertThat(oldBuilder.build().getServiceConfigurations(), both(hasItem(sameInstance(oldConfig))).and(not(hasItem(sameInstance(newConfig)))));
-    assertThat(newBuilder.build().getServiceConfigurations(), both(hasItem(sameInstance(newConfig))).and(not(hasItem(sameInstance(oldConfig)))));
+    assertThat(oldBuilder.build().getServiceConfigurations(), hasItem(sameInstance(oldConfig)));
+    assertThat(oldBuilder.build().getServiceConfigurations(), not(hasItem(sameInstance(newConfig))));
+    assertThat(newBuilder.build().getServiceConfigurations(), hasItem(sameInstance(newConfig)));
+    assertThat(newBuilder.build().getServiceConfigurations(), not(hasItem(sameInstance(oldConfig))));
   }
 
   @Test
@@ -400,12 +402,14 @@ public class CacheConfigurationBuilderTest {
     ServiceConfiguration<?, ?> oldConfig = new CompatibleServiceConfig();
     ServiceConfiguration<?, ?> newConfig = new CompatibleServiceConfig();
 
-    CacheConfigurationBuilder<Object, Object> oldBuilder = newCacheConfigurationBuilder(Object.class, Object.class, heap(10)).withService(oldConfig);
+    CacheConfigurationBuilder<?, ?> oldBuilder = newCacheConfigurationBuilder(Object.class, Object.class, heap(10)).withService(oldConfig);
 
-    CacheConfigurationBuilder<Object, Object> newBuilder = oldBuilder.withService(newConfig);
+    CacheConfigurationBuilder<?, ?> newBuilder = oldBuilder.withService(newConfig);
 
-    assertThat(oldBuilder.build().getServiceConfigurations(), both(hasItem(sameInstance(oldConfig))).and(not(hasItem(sameInstance(newConfig)))));
-    assertThat(newBuilder.build().getServiceConfigurations(), both(hasItem(sameInstance(oldConfig))).and(hasItem(sameInstance(newConfig))));
+    assertThat(oldBuilder.build().getServiceConfigurations(), hasItem(sameInstance(oldConfig)));
+    assertThat(oldBuilder.build().getServiceConfigurations(), not(hasItem(sameInstance(newConfig))));
+    assertThat(newBuilder.build().getServiceConfigurations(), hasItem(sameInstance(oldConfig)));
+    assertThat(newBuilder.build().getServiceConfigurations(), hasItem(sameInstance(newConfig)));
   }
 
   @Test

--- a/ehcache-impl/src/test/java/org/ehcache/docs/ConfigurationDerivation.java
+++ b/ehcache-impl/src/test/java/org/ehcache/docs/ConfigurationDerivation.java
@@ -207,7 +207,7 @@ public class ConfigurationDerivation {
     @Override
     public ByteBuffer serialize(Date object) throws SerializerException {
       ByteBuffer buffer = ByteBuffer.allocate(8);
-      return (ByteBuffer) buffer.putLong(object.getTime()).flip();
+      return buffer.putLong(object.getTime()).flip();
     }
 
     @Override

--- a/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/internal/store/tiering/TieredStoreTest.java
@@ -34,6 +34,7 @@ import org.ehcache.core.spi.store.tiering.CachingTier;
 import org.ehcache.impl.internal.store.heap.OnHeapStore;
 import org.ehcache.impl.internal.store.offheap.OffHeapStore;
 import org.ehcache.spi.service.Service;
+import org.ehcache.spi.service.ServiceConfiguration;
 import org.ehcache.spi.service.ServiceProvider;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -867,15 +868,15 @@ public class TieredStoreTest {
     OnHeapStore.Provider onHeapStoreProvider = mock(OnHeapStore.Provider.class);
     Set<ResourceType<?>> cachingResources = Collections.<ResourceType<?>>singleton( ResourceType.Core.HEAP);
     when(onHeapStoreProvider.rankCachingTier(eq(cachingResources), any(Collection.class))).thenReturn(1);
-    when(onHeapStoreProvider.createCachingTier(eq(cachingResources), any(Store.Configuration.class),
-      ArgumentMatchers.any()))
+    when(onHeapStoreProvider.createCachingTier(any(Set.class), any(Store.Configuration.class),
+      any(ServiceConfiguration[].class)))
         .thenReturn(stringCachingTier);
 
     OffHeapStore.Provider offHeapStoreProvider = mock(OffHeapStore.Provider.class);
     Set<ResourceType<?>> authorityResources = Collections.<ResourceType<?>>singleton( ResourceType.Core.OFFHEAP);
     when(offHeapStoreProvider.rankAuthority(eq(authorityResources), any(Collection.class))).thenReturn(1);
-    when(offHeapStoreProvider.createAuthoritativeTier(eq(authorityResources),
-            any(Store.Configuration.class), ArgumentMatchers.any()))
+    when(offHeapStoreProvider.createAuthoritativeTier(any(Set.class),
+            any(Store.Configuration.class), any(ServiceConfiguration[].class)))
         .thenReturn(stringAuthoritativeTier);
 
     Store.Configuration<String, String> configuration = mock(Store.Configuration.class);

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/AddedFieldTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/AddedFieldTest.java
@@ -47,7 +47,7 @@ public class AddedFieldTest {
     serializer.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(A_write.class, IncompatibleSerializable_write.class, Serializable_write.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_write.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_write.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = serializer.serialize(a);
 
     pushTccl(createClassNameRewritingLoader(A_read.class, IncompatibleSerializable_read.class));
@@ -65,7 +65,7 @@ public class AddedFieldTest {
     serializer.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(B_write.class, Externalizable_write.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(B_write.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(B_write.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = serializer.serialize(a);
 
     pushTccl(createClassNameRewritingLoader(B_read.class));

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/AddedSuperClassTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/AddedSuperClassTest.java
@@ -41,7 +41,7 @@ public class AddedSuperClassTest {
     serializer.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(A_2.class, AddedSuperClass_Hidden.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_2.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_2.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = serializer.serialize(a);
 
     pushTccl(createClassNameRewritingLoader(A_1.class));
@@ -58,7 +58,7 @@ public class AddedSuperClassTest {
     serializer.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(A_2.class, AddedSuperClass_Hidden.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_2.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_2.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = serializer.serialize(a);
 
     pushTccl(createClassNameRewritingLoader(A_1.class, AddedSuperClass_Hidden.class));

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassLoaderTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassLoaderTest.java
@@ -42,7 +42,7 @@ public class CompactJavaSerializerClassLoaderTest {
     serializer.init(new TransientStateRepository());
 
     ClassLoader loader = newLoader();
-    ByteBuffer encoded = serializer.serialize((Serializable) loader.loadClass(Foo.class.getName()).newInstance());
+    ByteBuffer encoded = serializer.serialize((Serializable) loader.loadClass(Foo.class.getName()).getDeclaredConstructor().newInstance());
 
     pushTccl(loader);
     try {
@@ -58,7 +58,7 @@ public class CompactJavaSerializerClassLoaderTest {
     StatefulSerializer<Serializable> serializer = new CompactJavaSerializer<>(loader);
     serializer.init(new TransientStateRepository());
 
-    ByteBuffer encoded = serializer.serialize((Serializable) loader.loadClass(Foo.class.getName()).newInstance());
+    ByteBuffer encoded = serializer.serialize((Serializable) loader.loadClass(Foo.class.getName()).getDeclaredConstructor().newInstance());
 
     // setting TCCL doesn't matter here, but set it to make sure it doesn't get used
     pushTccl(newLoader());

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassUnloadingTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/CompactJavaSerializerClassUnloadingTest.java
@@ -49,7 +49,7 @@ public class CompactJavaSerializerClassUnloadingTest {
     Class<? extends Serializable> special = (Class<? extends Serializable>) duplicate.loadClass(SpecialClass.class.getName());
     classRef = new WeakReference<>(special);
 
-    specialObject = special.newInstance();
+    specialObject = special.getDeclaredConstructor().newInstance();
   }
 
   @Test

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/GetFieldTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/GetFieldTest.java
@@ -44,7 +44,7 @@ public class GetFieldTest {
     s.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(Foo_A.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(Foo_A.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(Foo_A.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = s.serialize(a);
 
     pushTccl(createClassNameRewritingLoader(Foo_B.class));

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/JavaSerializer.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/JavaSerializer.java
@@ -108,6 +108,7 @@ public class JavaSerializer<T> implements Serializer<T> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
       Class<?>[] interfaceClasses = new Class<?>[interfaces.length];
       for (int i = 0; i < interfaces.length; i++) {

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/PutFieldTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/PutFieldTest.java
@@ -45,7 +45,7 @@ public class PutFieldTest {
     s.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(Foo_A.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(Foo_A.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(Foo_A.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = s.serialize(a);
 
     pushTccl(Foo.class.getClassLoader());
@@ -72,7 +72,7 @@ public class PutFieldTest {
     s.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(Bar_A.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(Bar_A.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(Bar_A.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = s.serialize(a);
 
     pushTccl(Bar.class.getClassLoader());

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/ReadObjectNoDataTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/ReadObjectNoDataTest.java
@@ -44,7 +44,7 @@ public class ReadObjectNoDataTest {
     ClassLoader loaderW = createClassNameRewritingLoader(C_W.class, B_W.class);
 
 
-    ByteBuffer b = s.serialize((Serializable) loaderW.loadClass(newClassName(C_W.class)).newInstance());
+    ByteBuffer b = s.serialize((Serializable) loaderW.loadClass(newClassName(C_W.class)).getDeclaredConstructor().newInstance());
 
     pushTccl(createClassNameRewritingLoader(C_R.class, B_R.class, A_R.class));
     try {

--- a/ehcache-impl/src/test/java/org/ehcache/impl/serialization/SerializeAfterEvolutionTest.java
+++ b/ehcache-impl/src/test/java/org/ehcache/impl/serialization/SerializeAfterEvolutionTest.java
@@ -41,7 +41,7 @@ public class SerializeAfterEvolutionTest {
     s.init(new TransientStateRepository());
 
     ClassLoader loaderA = createClassNameRewritingLoader(A_old.class);
-    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_old.class)).newInstance();
+    Serializable a = (Serializable) loaderA.loadClass(newClassName(A_old.class)).getDeclaredConstructor().newInstance();
     ByteBuffer encodedA = s.serialize(a);
 
     ClassLoader loaderB = createClassNameRewritingLoader(A_new.class);
@@ -50,7 +50,7 @@ public class SerializeAfterEvolutionTest {
       Serializable outA = s.read(encodedA);
       assertThat((Integer) outA.getClass().getField("integer").get(outA), is(42));
 
-      Serializable b = (Serializable) loaderB.loadClass(newClassName(A_new.class)).newInstance();
+      Serializable b = (Serializable) loaderB.loadClass(newClassName(A_new.class)).getDeclaredConstructor().newInstance();
       Serializable outB = s.read(s.serialize(b));
       assertThat((Integer) outB.getClass().getField("integer").get(outB), is(42));
     } finally {

--- a/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
+++ b/ehcache-impl/src/unsafe/java/org/ehcache/impl/internal/concurrent/ConcurrentHashMap.java
@@ -2583,7 +2583,6 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * A padded cell for distributing counts.  Adapted from LongAdder
      * and Striped64.  See their internal docs for explanation.
      */
-    @sun.misc.Contended
   static final class CounterCell {
         volatile long value;
         CounterCell(long x) { value = x; }

--- a/ehcache-management/build.gradle
+++ b/ehcache-management/build.gradle
@@ -29,7 +29,9 @@ publishing.publications.withType(MavenPublication) {
 dependencies {
   api project(':ehcache-core')
   implementation project(':ehcache-impl')
-  implementation "org.terracotta:statistics:$statisticVersion"
+  implementation ("org.terracotta:statistics:$statisticVersion") {
+    exclude group: 'org.slf4j'
+  }
 
   // optional: if we want xml config
   compileOnlyApi project(':ehcache-xml:ehcache-xml-spi')
@@ -40,9 +42,12 @@ dependencies {
   compileOnlyApi ("org.terracotta.management:nms-agent-entity-client:$terracottaPlatformVersion") {
     // This is to avoid stats lib being directly used.
     exclude group:'org.terracotta', module:'statistics'
+    exclude group: 'org.slf4j'
   }
 
-  testImplementation "org.terracotta.management:management-registry:$terracottaPlatformVersion"
+  testImplementation ("org.terracotta.management:management-registry:$terracottaPlatformVersion") {
+    exclude group: 'org.slf4j'
+  }
   testImplementation project(':ehcache-xml')
   testImplementation "org.terracotta.common:common-json-support:$terracottaPlatformVersion"
   testImplementation testFixtures(project(':ehcache-xml'))

--- a/ehcache-management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
+++ b/ehcache-management/src/test/java/org/ehcache/management/registry/DefaultManagementRegistryServiceTest.java
@@ -120,7 +120,7 @@ public class DefaultManagementRegistryServiceTest {
       allDescriptors.addAll(ONHEAP_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
-      assertThat(descriptors).hasSameElementsAs(allDescriptors);
+      assertThat(allDescriptors).hasSameElementsAs(descriptors);
     }
   }
 
@@ -150,7 +150,7 @@ public class DefaultManagementRegistryServiceTest {
       allDescriptors.addAll(ONHEAP_NO_STATS_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
-      assertThat(descriptors).hasSameElementsAs(allDescriptors);
+      assertThat(allDescriptors).hasSameElementsAs(descriptors);
     }
   }
 
@@ -181,7 +181,7 @@ public class DefaultManagementRegistryServiceTest {
       allDescriptors.addAll(OFFHEAP_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
-      assertThat(descriptors).hasSameElementsAs(allDescriptors);
+      assertThat(allDescriptors).hasSameElementsAs(descriptors);
     }
   }
 
@@ -215,7 +215,7 @@ public class DefaultManagementRegistryServiceTest {
       allDescriptors.addAll(DISK_DESCRIPTORS);
       allDescriptors.addAll(CACHE_DESCRIPTORS);
 
-      assertThat(descriptors).hasSameElementsAs(allDescriptors);
+      assertThat(allDescriptors).hasSameElementsAs(descriptors);
     }
   }
 

--- a/ehcache-transactions/build.gradle
+++ b/ehcache-transactions/build.gradle
@@ -119,7 +119,9 @@ dependencies {
   jakartaTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
   jakartaTestImplementation "junit:junit:$junitVersion"
   jakartaTestImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
-  jakartaTestImplementation "org.terracotta:terracotta-utilities-test-tools:$terracottaUtilitiesVersion"
+  jakartaTestImplementation ("org.terracotta:terracotta-utilities-test-tools:$terracottaUtilitiesVersion") {
+    exclude group: 'org.slf4j'
+  }
 }
 
 configurations {

--- a/ehcache-transactions/src/common/java/org/ehcache/transactions/xa/internal/SoftLockSerializer.java
+++ b/ehcache-transactions/src/common/java/org/ehcache/transactions/xa/internal/SoftLockSerializer.java
@@ -111,6 +111,7 @@ class SoftLockSerializer<T> implements Serializer<SoftLock<T>> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Class<?> resolveProxyClass(String[] interfaces) throws ClassNotFoundException {
       Class<?>[] interfaceClasses = new Class<?>[interfaces.length];
       for (int i = 0; i < interfaces.length; i++) {

--- a/ehcache-transactions/src/jakarta/java/org/ehcache/transactions/xa/txmgr/provider/LookupTransactionManagerProvider.java
+++ b/ehcache-transactions/src/jakarta/java/org/ehcache/transactions/xa/txmgr/provider/LookupTransactionManagerProvider.java
@@ -55,8 +55,8 @@ public class LookupTransactionManagerProvider implements TransactionManagerProvi
       throw new NullPointerException("LookupTransactionManagerProviderConfiguration cannot be null");
     }
     try {
-      lookup = config.getTransactionManagerLookup().newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      lookup = config.getTransactionManagerLookup().getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException e) {
       throw new IllegalArgumentException("Could not instantiate lookup class", e);
     }
   }

--- a/ehcache-transactions/src/main/java/org/ehcache/transactions/xa/txmgr/provider/LookupTransactionManagerProvider.java
+++ b/ehcache-transactions/src/main/java/org/ehcache/transactions/xa/txmgr/provider/LookupTransactionManagerProvider.java
@@ -56,8 +56,8 @@ public class LookupTransactionManagerProvider implements TransactionManagerProvi
       throw new NullPointerException("LookupTransactionManagerProviderConfiguration cannot be null");
     }
     try {
-      lookup = config.getTransactionManagerLookup().newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      lookup = config.getTransactionManagerLookup().getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException e) {
       throw new IllegalArgumentException("Could not instantiate lookup class", e);
     }
   }

--- a/ehcache-transactions/src/test/java/org/ehcache/transactions/xa/utils/JavaSerializer.java
+++ b/ehcache-transactions/src/test/java/org/ehcache/transactions/xa/utils/JavaSerializer.java
@@ -108,6 +108,7 @@ public class JavaSerializer<T> implements Serializer<T> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
       Class<?>[] interfaceClasses = new Class<?>[interfaces.length];
       for (int i = 0; i < interfaces.length; i++) {

--- a/ehcache-xml/build.gradle
+++ b/ehcache-xml/build.gradle
@@ -115,6 +115,7 @@ dependencies {
 
   xjcToolJakarta 'com.sun.xml.bind:jaxb-xjc:3.0.0-M4'
   xjcToolJakarta 'com.sun.xml.bind:jaxb-impl:3.0.0-M4'
+  xjcToolJakarta 'javax.xml.bind:jaxb-api:[2.2,3)'
 
   lowerBoundTestRuntimeClasspath 'com.sun.activation:javax.activation:1.2.0'
 }

--- a/ehcache-xml/ehcache-xml-spi/src/main/java/org/ehcache/xml/ParsingUtil.java
+++ b/ehcache-xml/ehcache-xml-spi/src/main/java/org/ehcache/xml/ParsingUtil.java
@@ -20,11 +20,8 @@ package org.ehcache.xml;
 import org.ehcache.javadoc.PublicApi;
 
 import java.math.BigInteger;
-import java.security.PrivilegedAction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static java.security.AccessController.doPrivileged;
 
 @PublicApi
 public class ParsingUtil {
@@ -36,7 +33,7 @@ public class ParsingUtil {
     Matcher matcher = PADDED_SYSPROP.matcher(s);
     if (matcher.matches()) {
       String property = matcher.group("property");
-      String value = doPrivileged((PrivilegedAction<String>) () -> System.getProperty(property));
+      String value = System.getProperty(property);
       if (value == null) {
         throw new IllegalStateException(String.format("Replacement for ${%s} not found!", property));
       } else {
@@ -74,7 +71,7 @@ public class ParsingUtil {
     StringBuffer sb = new StringBuffer();
     while (matcher.find()) {
       final String property = matcher.group("property");
-      final String value = doPrivileged((PrivilegedAction<String>) () -> System.getProperty(property));
+      final String value = System.getProperty(property);
       if (value == null) {
         throw new IllegalStateException(String.format("Replacement for ${%s} not found!", property));
       }

--- a/ehcache-xml/src/jakarta/java/org/ehcache/xml/ConfigurationParser.java
+++ b/ehcache-xml/src/jakarta/java/org/ehcache/xml/ConfigurationParser.java
@@ -150,7 +150,7 @@ public class ConfigurationParser {
 
   <K, V> CacheConfigurationBuilder<K, V> parseServiceConfigurations(Document document, CacheConfigurationBuilder<K, V> cacheBuilder,
                                                                     ClassLoader cacheClassLoader, CacheTemplate cacheDefinition)
-    throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    throws ReflectiveOperationException {
     cacheBuilder = CORE_CACHE_CONFIGURATION_PARSER.parse(cacheDefinition, cacheClassLoader, cacheBuilder);
     return serviceConfigurationParser.parse(document, cacheDefinition, cacheClassLoader, cacheBuilder);
   }
@@ -194,7 +194,7 @@ public class ConfigurationParser {
   private XmlConfiguration.Template parseTemplate(Document document, CacheTemplate template) {
     return new XmlConfiguration.Template() {
       @Override
-      public <K, V> CacheConfigurationBuilder<K, V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resources) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+      public <K, V> CacheConfigurationBuilder<K, V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resources) throws ReflectiveOperationException {
         checkTemplateTypeConsistency("key", classLoader, keyType, template);
         checkTemplateTypeConsistency("value", classLoader, valueType, template);
 
@@ -228,7 +228,7 @@ public class ConfigurationParser {
     return documentBuilder.parse(uri.toString());
   }
 
-  public XmlConfigurationWrapper documentToConfig(Document document, ClassLoader classLoader, Map<String, ClassLoader> cacheClassLoaders) throws JAXBException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+  public XmlConfigurationWrapper documentToConfig(Document document, ClassLoader classLoader, Map<String, ClassLoader> cacheClassLoaders) throws JAXBException, ReflectiveOperationException {
     Document annotatedDocument = stampExternalConfigurations(copyAndValidate(document));
     Element root = annotatedDocument.getDocumentElement();
 

--- a/ehcache-xml/src/jakarta/java/org/ehcache/xml/CoreCacheConfigurationParser.java
+++ b/ehcache-xml/src/jakarta/java/org/ehcache/xml/CoreCacheConfigurationParser.java
@@ -44,7 +44,7 @@ import static org.ehcache.xml.XmlModel.convertToXmlTimeUnit;
 public class CoreCacheConfigurationParser {
 
   public <K, V> CacheConfigurationBuilder<K, V> parse(CacheTemplate cacheDefinition, ClassLoader cacheClassLoader,
-                                                      CacheConfigurationBuilder<K, V> cacheBuilder) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+                                                      CacheConfigurationBuilder<K, V> cacheBuilder) throws ReflectiveOperationException {
     final Expiry parsedExpiry = cacheDefinition.expiry();
     if (parsedExpiry != null) {
       cacheBuilder = cacheBuilder.withExpiry(getExpiry(cacheClassLoader, parsedExpiry));
@@ -59,7 +59,7 @@ public class CoreCacheConfigurationParser {
 
   @SuppressWarnings({"unchecked", "deprecation"})
   private static ExpiryPolicy<? super Object, ? super Object> getExpiry(ClassLoader cacheClassLoader, Expiry parsedExpiry)
-    throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    throws ReflectiveOperationException {
     if (parsedExpiry.isUserDef()) {
       try {
         return getInstanceOfName(parsedExpiry.type(), cacheClassLoader, ExpiryPolicy.class);
@@ -75,12 +75,12 @@ public class CoreCacheConfigurationParser {
     }
   }
 
-  static <T> T getInstanceOfName(String name, ClassLoader classLoader, Class<T> type) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+  static <T> T getInstanceOfName(String name, ClassLoader classLoader, Class<T> type) throws ReflectiveOperationException {
     if (name == null) {
       return null;
     }
     Class<?> klazz = getClassForName(name, classLoader);
-    return klazz.asSubclass(type).newInstance();
+    return klazz.asSubclass(type).getDeclaredConstructor().newInstance();
   }
 
   public CacheType unparse(CacheConfiguration<?, ?> cacheConfiguration, CacheType cacheType) {

--- a/ehcache-xml/src/jakarta/java/org/ehcache/xml/XmlConfiguration.java
+++ b/ehcache-xml/src/jakarta/java/org/ehcache/xml/XmlConfiguration.java
@@ -272,7 +272,7 @@ public class XmlConfiguration implements Configuration {
   public <K, V> CacheConfigurationBuilder<K, V> newCacheConfigurationBuilderFromTemplate(final String name,
                                                                                          final Class<K> keyType,
                                                                                          final Class<V> valueType)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+      throws ReflectiveOperationException {
     Template template = templates.get(name);
     if (template == null) {
       return null;
@@ -307,7 +307,7 @@ public class XmlConfiguration implements Configuration {
                                                                                          final Class<K> keyType,
                                                                                          final Class<V> valueType,
                                                                                          final ResourcePools resourcePools)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+      throws ReflectiveOperationException {
     Template template = templates.get(name);
     if (template == null) {
       return null;
@@ -342,7 +342,7 @@ public class XmlConfiguration implements Configuration {
                                                                                          final Class<K> keyType,
                                                                                          final Class<V> valueType,
                                                                                          final Builder<? extends ResourcePools> resourcePoolsBuilder)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+      throws ReflectiveOperationException {
     return newCacheConfigurationBuilderFromTemplate(name, keyType, valueType, resourcePoolsBuilder.build());
   }
 
@@ -372,7 +372,7 @@ public class XmlConfiguration implements Configuration {
   }
 
   public interface Template {
-    <K, V> CacheConfigurationBuilder<K,V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resourcePools) throws ClassNotFoundException, InstantiationException, IllegalAccessException;
+    <K, V> CacheConfigurationBuilder<K,V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resourcePools) throws ReflectiveOperationException;
   }
 
   public static Class<?> getClassForName(String name, ClassLoader classLoader) throws ClassNotFoundException {

--- a/ehcache-xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
+++ b/ehcache-xml/src/main/java/org/ehcache/xml/ConfigurationParser.java
@@ -149,7 +149,7 @@ public class ConfigurationParser {
 
   <K, V> CacheConfigurationBuilder<K, V> parseServiceConfigurations(Document document, CacheConfigurationBuilder<K, V> cacheBuilder,
                                                                     ClassLoader cacheClassLoader, CacheTemplate cacheDefinition)
-    throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    throws ReflectiveOperationException {
     cacheBuilder = CORE_CACHE_CONFIGURATION_PARSER.parse(cacheDefinition, cacheClassLoader, cacheBuilder);
     return serviceConfigurationParser.parse(document, cacheDefinition, cacheClassLoader, cacheBuilder);
   }
@@ -193,7 +193,7 @@ public class ConfigurationParser {
   private XmlConfiguration.Template parseTemplate(Document document, CacheTemplate template) {
     return new XmlConfiguration.Template() {
       @Override
-      public <K, V> CacheConfigurationBuilder<K, V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resources) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+      public <K, V> CacheConfigurationBuilder<K, V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resources) throws ReflectiveOperationException {
         checkTemplateTypeConsistency("key", classLoader, keyType, template);
         checkTemplateTypeConsistency("value", classLoader, valueType, template);
 
@@ -227,7 +227,7 @@ public class ConfigurationParser {
     return documentBuilder.parse(uri.toString());
   }
 
-  public XmlConfigurationWrapper documentToConfig(Document document, ClassLoader classLoader, Map<String, ClassLoader> cacheClassLoaders) throws JAXBException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+  public XmlConfigurationWrapper documentToConfig(Document document, ClassLoader classLoader, Map<String, ClassLoader> cacheClassLoaders) throws JAXBException, ReflectiveOperationException {
     Document annotatedDocument = stampExternalConfigurations(copyAndValidate(document));
     Element root = annotatedDocument.getDocumentElement();
 

--- a/ehcache-xml/src/main/java/org/ehcache/xml/CoreCacheConfigurationParser.java
+++ b/ehcache-xml/src/main/java/org/ehcache/xml/CoreCacheConfigurationParser.java
@@ -44,7 +44,7 @@ import static org.ehcache.xml.XmlModel.convertToXmlTimeUnit;
 public class CoreCacheConfigurationParser {
 
   public <K, V> CacheConfigurationBuilder<K, V> parse(CacheTemplate cacheDefinition, ClassLoader cacheClassLoader,
-                                                      CacheConfigurationBuilder<K, V> cacheBuilder) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+                                                      CacheConfigurationBuilder<K, V> cacheBuilder) throws ReflectiveOperationException {
     final Expiry parsedExpiry = cacheDefinition.expiry();
     if (parsedExpiry != null) {
       cacheBuilder = cacheBuilder.withExpiry(getExpiry(cacheClassLoader, parsedExpiry));
@@ -59,7 +59,7 @@ public class CoreCacheConfigurationParser {
 
   @SuppressWarnings({"unchecked", "deprecation"})
   private static ExpiryPolicy<? super Object, ? super Object> getExpiry(ClassLoader cacheClassLoader, Expiry parsedExpiry)
-    throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    throws ReflectiveOperationException {
     if (parsedExpiry.isUserDef()) {
       try {
         return getInstanceOfName(parsedExpiry.type(), cacheClassLoader, ExpiryPolicy.class);
@@ -75,12 +75,12 @@ public class CoreCacheConfigurationParser {
     }
   }
 
-  static <T> T getInstanceOfName(String name, ClassLoader classLoader, Class<T> type) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+  static <T> T getInstanceOfName(String name, ClassLoader classLoader, Class<T> type) throws ReflectiveOperationException {
     if (name == null) {
       return null;
     }
     Class<?> klazz = getClassForName(name, classLoader);
-    return klazz.asSubclass(type).newInstance();
+    return klazz.asSubclass(type).getDeclaredConstructor().newInstance();
   }
 
   public CacheType unparse(CacheConfiguration<?, ?> cacheConfiguration, CacheType cacheType) {

--- a/ehcache-xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
+++ b/ehcache-xml/src/main/java/org/ehcache/xml/XmlConfiguration.java
@@ -271,7 +271,7 @@ public class XmlConfiguration implements Configuration {
   public <K, V> CacheConfigurationBuilder<K, V> newCacheConfigurationBuilderFromTemplate(final String name,
                                                                                          final Class<K> keyType,
                                                                                          final Class<V> valueType)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+      throws ReflectiveOperationException {
     Template template = templates.get(name);
     if (template == null) {
       return null;
@@ -305,7 +305,7 @@ public class XmlConfiguration implements Configuration {
                                                                                          final Class<K> keyType,
                                                                                          final Class<V> valueType,
                                                                                          final ResourcePools resourcePools)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+      throws ReflectiveOperationException {
     Template template = templates.get(name);
     if (template == null) {
       return null;
@@ -339,7 +339,7 @@ public class XmlConfiguration implements Configuration {
                                                                                          final Class<K> keyType,
                                                                                          final Class<V> valueType,
                                                                                          final Builder<? extends ResourcePools> resourcePoolsBuilder)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+      throws ReflectiveOperationException {
     return newCacheConfigurationBuilderFromTemplate(name, keyType, valueType, resourcePoolsBuilder.build());
   }
 
@@ -369,7 +369,7 @@ public class XmlConfiguration implements Configuration {
   }
 
   public interface Template {
-    <K, V> CacheConfigurationBuilder<K,V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resourcePools) throws ClassNotFoundException, InstantiationException, IllegalAccessException;
+    <K, V> CacheConfigurationBuilder<K,V> builderFor(ClassLoader classLoader, Class<K> keyType, Class<V> valueType, ResourcePools resourcePools) throws ReflectiveOperationException;
   }
 
   public static Class<?> getClassForName(String name, ClassLoader classLoader) throws ClassNotFoundException {

--- a/ehcache-xml/src/test/java/org/ehcache/xml/IntegrationConfigurationTest.java
+++ b/ehcache-xml/src/test/java/org/ehcache/xml/IntegrationConfigurationTest.java
@@ -125,7 +125,7 @@ public class IntegrationConfigurationTest {
     final Cache<Number, String> cache = cacheManager.getCache("bar", Number.class, String.class);
     assertThat(cache, notNullValue());
     assertThat(cache.get(1), notNullValue());
-    final Number key = new Long(42);
+    final Number key = 42L;
     cache.put(key, "Bye y'all!");
     assertThat(TestCacheLoaderWriter.lastWrittenKey, is(key));
 
@@ -133,7 +133,7 @@ public class IntegrationConfigurationTest {
     final Cache<Number, String> templateCache = cacheManager.getCache("template1", Number.class, String.class);
     assertThat(templateCache, notNullValue());
     assertThat(templateCache.get(1), notNullValue());
-    final Number key1 = new Long(100);
+    final Number key1 = 100L;
     templateCache.put(key1, "Bye y'all!");
     assertThat(TestCacheLoaderWriter.lastWrittenKey, is(key1));
   }

--- a/ehcache/build.gradle
+++ b/ehcache/build.gradle
@@ -69,6 +69,8 @@ configurations {
   jakartaContents {
     exclude group:'jakarta.xml.bind'
   }
+  javadocAdd
+  jakartaJavadocAdd
 }
 
 dependencies {
@@ -94,6 +96,12 @@ dependencies {
     }
   }
   jakartaRuntimeOnly 'org.glassfish.jaxb:jaxb-runtime:[3,3.1)'
+
+  javadocAdd 'com.github.spotbugs:spotbugs-annotations:4.9.8'
+  javadocAdd 'javax.xml.bind:jaxb-api:[2.2,3)'
+
+  jakartaJavadocAdd 'com.github.spotbugs:spotbugs-annotations:4.9.8'
+  jakartaJavadocAdd 'jakarta.xml.bind:jakarta.xml.bind-api:[3,4)'
 }
 
 tasks.named('jakartaJar') {
@@ -103,7 +111,7 @@ tasks.named('jakartaJar') {
     instruction Constants.BUNDLE_DESCRIPTION, 'Ehcache is an open-source caching library, compliant with the JSR-107 standard.'
     instruction Constants.BUNDLE_ACTIVATOR, 'org.ehcache.core.osgi.EhcacheActivator'
     instruction Constants.EXPORT_PACKAGE, '!org.ehcache.jsr107.tck, !org.ehcache.*.internal.*, org.ehcache.*'
-    instruction Constants.IMPORT_PACKAGE, 'javax.cache.*;resolution:=optional, jdk.internal.misc;resolution:=optional, !javax.annotation, !sun.misc, jakarta.xml.bind*;version="[3,4)", *'
+    instruction Constants.IMPORT_PACKAGE, 'javax.annotation.*;resolution:=optional, javax.cache.*;resolution:=optional, jdk.internal.misc;resolution:=optional, !javax.annotation, !sun.misc, jakarta.xml.bind*;version="[3,4)", *'
   }
 }
 
@@ -114,6 +122,14 @@ tasks.named('jar') {
     instruction Constants.BUNDLE_DESCRIPTION, 'Ehcache is an open-source caching library, compliant with the JSR-107 standard.'
     instruction Constants.BUNDLE_ACTIVATOR, 'org.ehcache.core.osgi.EhcacheActivator'
     instruction Constants.EXPORT_PACKAGE, '!org.ehcache.jsr107.tck, !org.ehcache.*.internal.*, org.ehcache.*'
-    instruction Constants.IMPORT_PACKAGE, 'javax.cache.*;resolution:=optional, jdk.internal.misc;resolution:=optional, !javax.annotation, !sun.misc, javax.xml.bind*;version="[2.2,3)", *'
+    instruction Constants.IMPORT_PACKAGE, 'javax.annotation.*;resolution:=optional, javax.cache.*;resolution:=optional, jdk.internal.misc;resolution:=optional, !javax.annotation, !sun.misc, javax.xml.bind*;version="[2.2,3)", *'
   }
+}
+
+tasks.named('javadoc') {
+    classpath += configurations.javadocAdd
+}
+
+tasks.named('jakartaJavadoc') {
+    classpath += configurations.jakartaJavadocAdd
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ ehcacheVersion = 3.11-SNAPSHOT
 offheapVersion = 2.5.6
 statisticVersion = 2.1.3
 jcacheVersion = 1.1.0
-slf4jVersion = 1.7.36
+slf4jVersion = 2.0.17
 sizeofVersion = 0.4.4
 
 # Terracotta clustered
@@ -17,10 +17,12 @@ terracottaUtilitiesVersion = 0.0.19
 
 # Test lib versions
 junitVersion = 4.13.1
-assertjVersion = 3.22.0
+assertjVersion = 3.27.7
+byteBuddyVersion = 1.18.3
 hamcrestVersion = 2.2
-mockitoVersion = 4.3.1
+mockitoVersion = 5.12.0
 jcacheTckVersion = 1.1.0
+logbackVersion = 1.5.26
 
 sonatypeUser = OVERRIDE_ME
 sonatypePwd = OVERRIDE_ME

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -31,5 +31,7 @@ dependencies {
   testImplementation (group: 'org.codehaus.btm', name: 'btm', version: '2.1.4') {
     exclude group:'org.slf4j', module:'slf4j-api'
   }
-  testImplementation "org.terracotta:statistics:$parent.statisticVersion"
+  testImplementation ("org.terracotta:statistics:$parent.statisticVersion") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 }

--- a/integration-test/src/test/java/org/ehcache/integration/OverSizeMappingTest.java
+++ b/integration-test/src/test/java/org/ehcache/integration/OverSizeMappingTest.java
@@ -124,7 +124,7 @@ public class OverSizeMappingTest {
     private ObjectSizeGreaterThanN(int n) {
       arr = new Integer[n];
       for (int i = 0; i < arr.length; i++) {
-        arr[i] = new Integer(i);
+        arr[i] = i;
       }
     }
 

--- a/osgi-test/build.gradle
+++ b/osgi-test/build.gradle
@@ -57,6 +57,8 @@ dependencies {
   osgiModule project(':ehcache')
 
   osgiModule "org.slf4j:slf4j-simple:$parent.slf4jVersion"
+  // SLF4J 2.x requires osgi.serviceloader.processor; Apache Aries SPIFly provides it
+  osgiModule 'org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:1.3.7'
   osgiModule 'org.apache.felix:org.apache.felix.scr:2.2.0'
 
   osgiModule 'com.sun.activation:javax.activation:1.2.0'
@@ -77,6 +79,11 @@ configurations.all {
         .using(module('org.ops4j.pax.url:pax-url-classpath:2.6.11'))
       substitute(module('org.ops4j.pax.url:pax-url-link:2.6.8'))
         .using(module('org.ops4j.pax.url:pax-url-link:2.6.11'))
+      substitute(module('org.ops4j.pax.url:pax-url-aether:2.6.8'))
+        .using(module('org.ops4j.pax.url:pax-url-aether:3.0.2'))
+      substitute(module('org.apache.commons:commons-lang3:3.12.0'))
+        .using(module('org.apache.commons:commons-lang3:3.18.0'))
+        .because('CVE-2025-48924')
       substitute(module('org.osgi:org.osgi.util.function:1.1.0'))
         .using(module('org.osgi:org.osgi.util.function:1.2.0'))
         .because('Dependency divergence in org.osgi:org.osgi.util.promise:1.2.0')

--- a/osgi-test/src/main/java/org/ehcache/osgi/OsgiTestUtils.java
+++ b/osgi-test/src/main/java/org/ehcache/osgi/OsgiTestUtils.java
@@ -49,6 +49,14 @@ public class OsgiTestUtils {
     return composite(
       gradleBundle("org.slf4j:slf4j-api"),
       gradleBundle("org.slf4j:slf4j-simple").noStart(),
+      // ASM bundles required by SPI Fly
+      gradleBundle("org.ow2.asm:asm"),
+      gradleBundle("org.ow2.asm:asm-tree"),
+      gradleBundle("org.ow2.asm:asm-analysis"),
+      gradleBundle("org.ow2.asm:asm-commons"),
+      gradleBundle("org.ow2.asm:asm-util"),
+      // SPI Fly for SLF4J 2.x ServiceLoader support
+      gradleBundle("org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle"),
       gradleBundle("org.apache.felix:org.apache.felix.scr"),
       gradleBundle("org.osgi:org.osgi.util.promise"),
       gradleBundle("org.osgi:org.osgi.util.function"),

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,6 @@
 pluginManagement {
   plugins {
     id 'org.owasp.dependencycheck' version '7.1.0.1'
-    id 'org.gretty' version '3.0.6'
     id 'org.asciidoctor.jvm.base' version '3.3.2'
     id 'org.unbroken-dome.xjc' version '2.0.0'
     id 'com.jfrog.artifactory' version '5.2.5'


### PR DESCRIPTION
- Backport of TDB-19854/master (commit d532bbce9f)
  This was a dependency upgrade commit applied to master. Since this branch targets the same dependency upgrade goal for 3.11, those changes (SpotBugs, AssertJ, Mockito, ByteBuddy version bumps; demos rewrite; SPI test refactoring; API usage fixes) needed to be replicated here.

- Upgrade slf4j-api 1.7.36 to 2.0.17
  Logback was upgraded to 1.5.26, which requires SLF4J 2.x.

- Add slf4j exclusions on Terracotta dependencies statistics (and other Terracotta libs) that declare SLF4J with the range [1.7.32,1.7.9999), which excludes 2.0.17. 

- Replace Class.newInstance() with getDeclaredConstructor().newInstance()
  Class.newInstance() is deprecated. The project compiles with -Werror -Xlint:all, which promotes deprecation warnings to errors, so the build fails.

- Suppress finalize() deprecation
  Same -Werror issue.

- Suppress Proxy.getProxyClass() deprecation
  Also deprecated, same -Werror issue. 

- Add jaxb-api to xjcToolJakarta configuration
  The XJC code generator needs the JAXB API jar. This dependency was present in master but missing in the 3.11 branch, causing a ClassNotFoundException at generation time.

-  Add javadocAdd/jakartaJavadocAdd classpath configurations
  The source code references types from spotbugs-annotations (e.g. @CheckForNull, @Nonnull) and jaxb-api, which the javadoc tool needs on its classpath. These configurations existed in master but were absent in the 3.11 branch. They are required (not optional) because javadocJar is a dependency in the assemble task.

- OSGi + SLF4J 2.x (osgi-test/build.gradle, clustered/osgi-test/build.gradle, OsgiTestUtils.java): SLF4J 2.x uses ServiceLoader and requires the osgi.serviceloader.processor extender capability, provided by Apache Aries SPIFly. SPIFly requires ASM 9.x (pulled in transitively). Added SPIFly to osgiModule configurations; 

- Deprecated wrapper constructors (StateRepositoryWhitelistingTest.java, ClusteredStoreTest.java, IntegrationConfigurationTest.java, OverSizeMappingTest.java): new Integer(x), new Long(x) constructors are deprecated for removal. Replaced with Integer.valueOf(), Long.valueOf().hashCode(), or primitive literals as appropriate.

- @jdk.internal.vm.annotation.Contended removal (ConcurrentHashMap.java): matches master

- AccessController.doPrivileged() suppression (ClassLoading.java): -Werror failure

- ByteBuffer.flip() cast suppression: -Werror failure

- Fix async assertion in BasicClusteredCacheOpsReplicationMultiThreadedTest (without awaitility)

- BOB review pass to validate the changes. 
