### PR TITLE
Update platform => 5.11.10

### DIFF
--- a/build-logic/src/main/java/org/ehcache/build/conventions/CheckstyleConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/CheckstyleConvention.java
@@ -23,8 +23,11 @@ public class CheckstyleConvention implements Plugin<Project> {
     project.getConfigurations().named("checkstyle", config -> {
       config.getResolutionStrategy().dependencySubstitution(subs -> {
         subs.substitute(subs.module("org.codehaus.plexus:plexus-utils:3.1.1"))
-          .using(subs.module("org.codehaus.plexus:plexus-utils:3.3.0"))
-          .because("Checkstyle 10.18.1 pulls mismatched plexus-utils versions");
+          .using(subs.module("org.codehaus.plexus:plexus-utils:3.6.1"))
+          .because("CVE-2025-67030");
+        subs.substitute(subs.module("org.codehaus.plexus:plexus-utils:3.3.0"))
+          .using(subs.module("org.codehaus.plexus:plexus-utils:3.6.1"))
+          .because("CVE-2025-67030");
         subs.substitute(subs.module("org.apache.commons:commons-lang3:3.7"))
           .using(subs.module("org.apache.commons:commons-lang3:3.8.1"))
           .because("Checkstyle transitives mix commons-lang3 versions");

--- a/build-logic/src/main/java/org/ehcache/build/conventions/SpotbugsConvention.java
+++ b/build-logic/src/main/java/org/ehcache/build/conventions/SpotbugsConvention.java
@@ -50,7 +50,7 @@ public class SpotbugsConvention implements Plugin<Project> {
           .using(subs.module("org.apache.commons:commons-lang3:3.19.0"))
           .because("Spotbugs 4.9.8 has dependency divergences");
         subs.substitute(subs.module("org.apache.logging.log4j:log4j-core:2.25.2"))
-          .using(subs.module("org.apache.logging.log4j:log4j-core:2.25.3"))
+          .using(subs.module("org.apache.logging.log4j:log4j-core:2.25.4"))
           .because("Security vulnerability fix");
       });
     });

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ slf4jVersion = 2.0.17
 sizeofVersion = 0.4.4
 
 # Terracotta clustered
-terracottaPlatformVersion = 5.11.9
+terracottaPlatformVersion = 5.11.10
 terracottaCoreVersion = 5.12.22
 terracottaUtilitiesVersion = 0.0.19
 


### PR DESCRIPTION
Changes:
- [TDB-20032: Fix Lock ad Unlock commands](https://github.com/Terracotta-OSS/terracotta-platform/commit/f6c59f6ff405086648224aae7fe3336bb3141b1d)
- [TDB-20178: Skip restart when node collection is empty](https://github.com/Terracotta-OSS/terracotta-platform/commit/34d545b2f7ce0e730b04550617a6e75047462e5f)
- [TDB-19069, TDB-20103: Add relay and replica support](https://github.com/Terracotta-OSS/terracotta-platform/commit/90f65513838fd28d697f0f3693c59b0061bda9ac)

Also:
- Updated log4j (CVE-2026-34480, CVE-2026-34478, CVE-2026-34477)
- Update plexus-utils to 3.6.1 (CVE-2025-67030)